### PR TITLE
Fix staging and release builds on Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -162,6 +162,15 @@ android {
     dexOptions {
         jumboMode true
     }
+
+    // - NDK v17+ dropped support for MIPS
+    // - The latest Gradle version compatible with RN isn't aware of that
+    // - This prevents it to try to load inexisting libs
+    // cf https://github.com/android-ndk/ndk/issues/700
+    packagingOptions {
+        doNotStrip '*/mips/*.so'
+        doNotStrip '*/mips64/*.so'
+    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,10 +3,9 @@
 buildscript {
     repositories {
         jcenter()
-        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.5-all.zip


### PR DESCRIPTION
Fixed by rolling back Gradle and its Android plugin to the highest version compatible with React Native, and prevent them to try to use a dropped architecture toolchain.

- Android Studio uses the latest NDK version (with no way to force a lower version from the build config files)
- The latest NDK version dropped MIPS support
- Only the latest Gradle Android plugin take that into account
- React Native isn't compatible with the latest Gradle Android plugin
- or even the latest Gradle version

cf android-ndk/ndk#700