### PR TITLE
update bottom modals for design and make more generic for future

### DIFF
--- a/src/components/GenericButton.js
+++ b/src/components/GenericButton.js
@@ -97,6 +97,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     paddingHorizontal: 10,
+    borderRadius: 4,
   },
   containerDisabled: {
     opacity: 0.5,

--- a/src/components/ModalBottomAction.js
+++ b/src/components/ModalBottomAction.js
@@ -2,15 +2,16 @@
 import React, { Component } from "react";
 import { View, StyleSheet } from "react-native";
 import LText from "../components/LText";
+import colors from "../colors";
 
 export default class ModalBottomAction extends Component<{
   icon: *,
   title: *,
   description: *,
-  button: *,
+  footer: *,
 }> {
   render() {
-    const { icon, title, description, button } = this.props;
+    const { icon, title, description, footer } = this.props;
     return (
       <View>
         <View style={styles.root}>
@@ -22,8 +23,8 @@ export default class ModalBottomAction extends Component<{
               </LText>
             )}
             <LText style={styles.description}>{description}</LText>
+            <View style={styles.footer}>{footer}</View>
           </View>
-          <View style={styles.button}>{button}</View>
         </View>
       </View>
     );
@@ -32,30 +33,29 @@ export default class ModalBottomAction extends Component<{
 
 const styles = StyleSheet.create({
   root: {
-    padding: 10,
     borderBottomWidth: 1,
     borderColor: "#eee",
     alignItems: "center",
   },
   icon: {
-    marginTop: 15,
+    margin: 24,
   },
   body: {
     flexDirection: "column",
+    marginHorizontal: 16,
   },
   title: {
-    marginTop: 15,
+    marginTop: 16,
     textAlign: "center",
     fontSize: 14,
   },
   description: {
     fontSize: 14,
     textAlign: "center",
-    margin: 15,
+    marginBottom: 24,
+    color: colors.grey,
   },
-  button: {
-    margin: 25,
-    flexDirection: "row",
-    flexGrow: 1,
+  footer: {
+    paddingBottom: 16,
   },
 });

--- a/src/images/icons/Trash.js
+++ b/src/images/icons/Trash.js
@@ -1,0 +1,19 @@
+// @flow
+import React from "react";
+import Svg, { Path } from "react-native-svg";
+
+type Props = {
+  size: number,
+  color: string,
+};
+
+export default function Trash({ size, color }: Props) {
+  return (
+    <Svg viewBox="0 0 16 16" width={size} height={size}>
+      <Path
+        fill={color}
+        d="M2 4.832a.75.75 0 1 1 0-1.5h11.917a.75.75 0 0 1 0 1.5H2zm9.843-.75h1.5v9.037c0 1.131-.933 2.04-2.074 2.04h-6.62c-1.142 0-2.075-.909-2.075-2.04V4.082h1.5v9.037c0 .294.253.54.574.54h6.62c.322 0 .575-.246.575-.54V4.082zm-5.783 0h-1.5V2.79c0-1.131.933-2.04 2.074-2.04h2.648c1.142 0 2.074.91 2.074 2.041v1.29h-1.5v-1.29c0-.294-.252-.541-.574-.541H6.634c-.321 0-.574.247-.574.541v1.29zm-.176 3.227a.75.75 0 0 1 1.5 0v3.873a.75.75 0 0 1-1.5 0V7.31zm2.648 0a.75.75 0 0 1 1.5 0v3.873a.75.75 0 0 1-1.5 0V7.31z"
+      />
+    </Svg>
+  );
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1,4 +1,7 @@
 {
+  "common": {
+    "cancel": "Cancel"
+  },
   "settings": {
     "display": {
       "title": "General",
@@ -38,7 +41,7 @@
       "clearCacheDesc": "Clearing the Ledger Live cache forces network resynchronization. Your settings and accounts are not affected. The private keys to access your crypto assets in the blockchain remain secure on your Ledger device and on your Recovery sheet.",
       "clearCacheModal": "Are you sure?",
       "clearCacheModalDesc": "Clearing the Ledger Live cache forces network resynchronization. Your settings and accounts are not affected. The private keys to access your crypto assets in the blockchain remain secure on your Ledger device and on your Recovery sheet.",
-      "clearCacheButton": "Clear Cache",
+      "clearCacheButton": "Clear",
       "exportLogs": "Export logs",
       "exportLogsDesc": "Exporting Ledger Live logs may be necessary for troubleshooting purposes.",
       "hardReset": "Reset Ledger Live",

--- a/src/screens/Settings/Help/ClearCacheRow.js
+++ b/src/screens/Settings/Help/ClearCacheRow.js
@@ -12,6 +12,7 @@ import Menu from "../../../components/Menu";
 import Warning from "../../../images/icons/Warning";
 import ModalBottomAction from "../../../components/ModalBottomAction";
 import BlueButton from "../../../components/BlueButton";
+import GreyButton from "../../../components/GreyButton";
 
 const mapStateToProps = createStructuredSelector({});
 
@@ -55,20 +56,32 @@ class ClearCacheRow extends PureComponent<Props, State> {
           <Modal transparent onRequestClose={this.onRequestClose}>
             <Menu onRequestClose={this.onRequestClose}>
               <ModalBottomAction
-                title={t("common:settings.help.clearCacheModal")}
+                title={null}
                 icon={
                   <View style={styles.imageContainer}>
-                    <Warning size={16} color={colors.live} />
+                    <Warning size={24} color={colors.live} />
                   </View>
                 }
                 description={t("common:settings.help.clearCacheModalDesc")}
-                button={
-                  <BlueButton
-                    title={t("common:settings.help.clearCacheButton")}
-                    onPress={this.onClearCache}
-                    containerStyle={styles.buttonContainer}
-                    titleStyle={styles.buttonTitle}
-                  />
+                footer={
+                  <View style={styles.footerContainer}>
+                    <GreyButton
+                      title={t("common:common.cancel")}
+                      onPress={this.onRequestClose}
+                      containerStyle={styles.buttonContainer}
+                      titleStyle={styles.buttonTitle}
+                    />
+
+                    <BlueButton
+                      title={t("common:settings.help.clearCacheButton")}
+                      onPress={this.onClearCache}
+                      containerStyle={[
+                        styles.buttonContainer,
+                        styles.clearCacheBg,
+                      ]}
+                      titleStyle={[styles.buttonTitle, styles.clearCacheTitle]}
+                    />
+                  </View>
                 }
               />
             </Menu>
@@ -93,15 +106,22 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  buttonContainer: {
-    margin: 10,
-    backgroundColor: colors.live,
+
+  footerContainer: {
     flexDirection: "row",
-    flexGrow: 1,
-    borderRadius: 4,
+    justifyContent: "space-around",
+  },
+  buttonContainer: {
+    height: 48,
+    width: 136,
+  },
+  clearCacheBg: {
+    backgroundColor: colors.live,
   },
   buttonTitle: {
+    fontSize: 16,
+  },
+  clearCacheTitle: {
     color: colors.white,
-    fontSize: 14,
   },
 });

--- a/src/screens/Settings/Help/HardResetRow.js
+++ b/src/screens/Settings/Help/HardResetRow.js
@@ -10,9 +10,10 @@ import { withReboot } from "../../../context/Reboot";
 import SettingsRow from "../../../components/SettingsRow";
 import type { T } from "../../../types/common";
 import Menu from "../../../components/Menu";
-import Warning from "../../../images/icons/Warning";
+import Trash from "../../../images/icons/Trash";
 import ModalBottomAction from "../../../components/ModalBottomAction";
-import RedButton from "../../../components/GenericButton";
+import RedButton from "../../../components/RedButton";
+import GreyButton from "../../../components/GreyButton";
 
 const mapStateToProps = createStructuredSelector({});
 
@@ -56,20 +57,31 @@ class HardResetRow extends PureComponent<Props, State> {
           <Modal transparent onRequestClose={this.onRequestClose}>
             <Menu onRequestClose={this.onRequestClose}>
               <ModalBottomAction
-                title={t("common:settings.help.hardResetModal")}
+                title={null}
                 icon={
                   <View style={styles.imageContainer}>
-                    <Warning size={16} color={colors.alert} />
+                    <Trash size={24} color={colors.alert} />
                   </View>
                 }
                 description={t("common:settings.help.hardResetModalDesc")}
-                button={
-                  <RedButton
-                    title={t("common:settings.help.hardResetModalButton")}
-                    onPress={this.onHardReset}
-                    containerStyle={styles.buttonContainer}
-                    titleStyle={styles.buttonTitle}
-                  />
+                footer={
+                  <View style={styles.footerContainer}>
+                    <GreyButton
+                      title={t("common:common.cancel")}
+                      onPress={this.onRequestClose}
+                      containerStyle={styles.buttonContainer}
+                      titleStyle={styles.buttonTitle}
+                    />
+                    <RedButton
+                      title={t("common:settings.help.hardResetModalButton")}
+                      onPress={this.onHardReset}
+                      containerStyle={[
+                        styles.buttonContainer,
+                        styles.resetButtonBg,
+                      ]}
+                      titleStyle={[styles.buttonTitle, styles.resetButtonTitle]}
+                    />
+                  </View>
                 }
               />
             </Menu>
@@ -94,15 +106,21 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  buttonContainer: {
-    margin: 10,
-    backgroundColor: colors.alert,
+  footerContainer: {
     flexDirection: "row",
-    flexGrow: 1,
-    borderRadius: 4,
+    justifyContent: "space-around",
+  },
+  buttonContainer: {
+    height: 48,
+    width: 136,
+  },
+  resetButtonBg: {
+    backgroundColor: colors.alert,
   },
   buttonTitle: {
+    fontSize: 16,
+  },
+  resetButtonTitle: {
     color: colors.white,
-    fontSize: 14,
   },
 });


### PR DESCRIPTION
To accommodate designs bottom modal drawer was updated (now used just in hard reset and clear cache). it was also generalized to be able to update it if needed easier in the future if needed.

Tested on iPhone X, on simulators: iPhone SE and iPhone 6+ and on the android simulator

Hard reset           |  Clear cache
:-------------------------:|:-------------------------:
![img_2774](https://user-images.githubusercontent.com/10082039/44044042-aa6de716-9f24-11e8-877a-45c0f521484c.PNG) | ![img_2775](https://user-images.githubusercontent.com/10082039/44044038-a6f3a2b0-9f24-11e8-8721-716e677c481e.PNG)


