### PR TITLE
 JavaScriptCore upgrade for Android

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -105,7 +105,7 @@ android {
 
     defaultConfig {
         applicationId "com.ledgerlivemobile"
-        minSdkVersion 18
+        minSdkVersion 21
         targetSdkVersion 27
         renderscriptTargetApi 20
         renderscriptSupportModeEnabled true
@@ -171,6 +171,16 @@ android {
     packagingOptions {
         doNotStrip '*/mips/*.so'
         doNotStrip '*/mips64/*.so'
+    }
+}
+
+configurations.all {
+    resolutionStrategy {
+        eachDependency { DependencyResolveDetails details ->
+            if (details.requested.name == 'android-jsc') {
+                details.useTarget group: details.requested.group, name: 'android-jsc-intl', version: 'r224109'
+            }
+        }
     }
 }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,10 @@ allprojects {
             url "https://maven.google.com"
         }
         maven { url "https://jitpack.io" }
+            maven {
+            // Local Maven repo containing AARs with JSC library built for Android
+            url "$rootDir/../node_modules/jsc-android/dist"
+       }
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "hoist-non-react-statics": "3.0.1",
     "i18next": "11.5.0",
     "invariant": "2.2.4",
+    "jsc-android": "^224109.1.0",
     "lodash": "4.17.10",
     "moment": "2.22.2",
     "numeral": "2.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4081,6 +4081,10 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+jsc-android@^224109.1.0:
+  version "224109.1.0"
+  resolved "https://registry.yarnpkg.com/jsc-android/-/jsc-android-224109.1.0.tgz#9749ec92f1e284b3c09befe7c47cc6e60b1f0cdf"
+
 jsdom@^11.5.1:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"


### PR DESCRIPTION
Use [npm/jsc-android](https://www.npmjs.com/package/jsc-android) which is up to date, in place of the 4 year old build of JSC bundled with React Native.
I did a quick test on our app, and it seems to give a nice performance boost.