### PR TITLE
Implement a fallback when no crypto icons

### DIFF
--- a/src/components/CurrencyIcon.js
+++ b/src/components/CurrencyIcon.js
@@ -1,9 +1,10 @@
 // @flow
 
 import React, { PureComponent } from "react";
-import { View } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { getCryptoCurrencyIcon } from "@ledgerhq/live-common/lib/reactNative";
 import type { Currency } from "@ledgerhq/live-common/lib/types";
+import LText from "../components/LText";
 
 type Props = {
   currency: Currency,
@@ -15,11 +16,21 @@ export default class CurrencyIcon extends PureComponent<Props> {
     const { size, currency } = this.props;
     const IconComponent = getCryptoCurrencyIcon(currency);
     if (!IconComponent) {
-      console.warn(
-        `No icon for currency ${currency.name} (coinType ${currency.coinType})`,
+      return (
+        <View style={[styles.altRoot, { width: size, height: size }]}>
+          <LText style={{ fontSize: Math.floor(size / 3) }}>
+            {currency.ticker}
+          </LText>
+        </View>
       );
-      return <View style={{ width: size, height: size }} />;
     }
     return <IconComponent size={size} color={currency.color} />;
   }
 }
+
+const styles = StyleSheet.create({
+  altRoot: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});


### PR DESCRIPTION
we can improve the fallback but we probably need one because in future when ERC20 will be there, we won't have icons for all.

<img width="353" alt="capture d ecran 2018-08-31 a 11 56 30" src="https://user-images.githubusercontent.com/211411/44906398-11d6ac00-ad15-11e8-9ebc-aa43cfccd91f.png">
