### PR TITLE
Portfolio animated top bar & Graph improvements

### DIFF
--- a/src/components/Delta.js
+++ b/src/components/Delta.js
@@ -18,6 +18,7 @@ type Props = {
   to: BigNumber,
   percent?: boolean,
   unit?: Unit,
+  style?: mixed,
 };
 
 const arrowUp = <IconArrowUp size={12} color={colors.success} />;
@@ -25,9 +26,13 @@ const arrowDown = <IconArrowDown size={12} color={colors.alert} />;
 
 export default class Delta extends PureComponent<Props> {
   render() {
-    const { from, to, percent, unit } = this.props;
+    const { from, to, percent, unit, style } = this.props;
 
-    let delta = percent
+    if (percent && from.isEqualTo(0)) {
+      return null;
+    }
+
+    const delta = percent
       ? to
           .minus(from)
           .dividedBy(from)
@@ -35,10 +40,11 @@ export default class Delta extends PureComponent<Props> {
       : to.minus(from);
 
     if (delta.isNaN()) {
-      delta = BigNumber(0);
+      return null;
     }
+
     return (
-      <View style={styles.root}>
+      <View style={[styles.root, style]}>
         {delta.isGreaterThanOrEqualTo(0) ? arrowUp : arrowDown}
         <View style={styles.content}>
           <LText tertiary style={styles.text}>

--- a/src/components/FormatDate.js
+++ b/src/components/FormatDate.js
@@ -1,0 +1,16 @@
+// @flow
+
+import { PureComponent } from "react";
+import moment from "moment";
+
+type Props = {
+  date: Date,
+  format: string,
+};
+
+export default class FormatDate extends PureComponent<Props> {
+  render() {
+    const { date, format } = this.props;
+    return moment(date).format(format);
+  }
+}

--- a/src/components/provideSummary.js
+++ b/src/components/provideSummary.js
@@ -1,0 +1,114 @@
+// @flow
+
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import { getBalanceHistorySum } from "@ledgerhq/live-common/lib/helpers/account";
+import { BigNumber } from "bignumber.js";
+
+import type { Currency, Account } from "@ledgerhq/live-common/lib/types";
+
+import { accountsSelector } from "../reducers/accounts";
+import {
+  exchangeSettingsForAccountSelector,
+  counterValueCurrencySelector,
+  counterValueExchangeSelector,
+  intermediaryCurrency,
+  selectedTimeRangeSelector,
+  timeRangeDaysByKey,
+} from "../reducers/settings";
+
+import CounterValues from "../countervalues";
+
+import type { Item } from "../components/Graph";
+
+export type Summary = {
+  accounts: Account[],
+  isAvailable: boolean,
+  balanceHistory: Item[],
+  balanceStart: BigNumber,
+  balanceEnd: BigNumber,
+  selectedTimeRange: string,
+  setSelectedTimeRange: string => void,
+  counterValueCurrency: Currency,
+};
+
+type Props = {
+  summary: Summary,
+  hash: string,
+};
+
+const mapStateToProps = state => {
+  const accounts = accountsSelector(state);
+  const counterValueCurrency = counterValueCurrencySelector(state);
+  const counterValueExchange = counterValueExchangeSelector(state);
+  const selectedTimeRange = selectedTimeRangeSelector(state);
+  const daysCount = timeRangeDaysByKey[selectedTimeRange];
+  let isAvailable = true;
+
+  // create array of original values, used to reconciliate
+  // with counter values after calculation
+  const originalValues = [];
+
+  const balanceHistory = getBalanceHistorySum(
+    accounts,
+    daysCount || 30,
+    (account, value, date) => {
+      // keep track of original value
+      originalValues.push(value);
+      const fromExchange = exchangeSettingsForAccountSelector(state, {
+        account,
+      });
+
+      const cv = CounterValues.calculateWithIntermediarySelector(state, {
+        value,
+        date,
+        from: account.currency,
+        fromExchange,
+        intermediary: intermediaryCurrency,
+        toExchange: counterValueExchange,
+        to: counterValueCurrency,
+      });
+      if (!cv) {
+        isAvailable = false;
+        return BigNumber(0);
+      }
+      return cv;
+    },
+  ).map((item, i) => ({
+    // reconciliate balance history with original values
+    ...item,
+    originalValue: originalValues[i] || BigNumber(0),
+  }));
+
+  const balanceEnd = balanceHistory[balanceHistory.length - 1].value;
+
+  const summary = {
+    accounts,
+    isAvailable,
+    balanceHistory,
+    balanceStart: balanceHistory[0].value,
+    balanceEnd,
+    selectedTimeRange,
+    counterValueCurrency,
+  };
+
+  return {
+    summary,
+    hash: `${accounts.length > 0 ? accounts[0].id : ""}_${
+      balanceHistory.length
+    }_${balanceEnd.toString()}_${isAvailable.toString()}`,
+  };
+};
+
+export default (WrappedComponent: any) => {
+  class Inner extends Component<Props> {
+    shouldComponentUpdate(nextProps: Props) {
+      return nextProps.hash !== this.props.hash;
+    }
+    render() {
+      return <WrappedComponent {...this.props} />;
+    }
+  }
+
+  return connect(mapStateToProps)(Inner);
+};

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -4,6 +4,9 @@
     "apply": "Apply",
     "delete": "Delete"
   },
+  "portfolio": {
+    "totalBalance": "Total balance"
+  },
   "time": {
     "day": "Day",
     "week": "Week",

--- a/src/screens/Portfolio/AnimatedTopBar.js
+++ b/src/screens/Portfolio/AnimatedTopBar.js
@@ -1,0 +1,83 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { StyleSheet, Animated } from "react-native";
+import { translate } from "react-i18next";
+
+import type AnimatedValue from "react-native/Libraries/Animated/src/nodes/AnimatedValue";
+
+import colors from "../../colors";
+import type { T } from "../../types/common";
+
+import LText from "../../components/LText";
+import Space from "../../components/Space";
+import CurrencyUnitValue from "../../components/CurrencyUnitValue";
+
+import type { Summary } from "../../components/provideSummary";
+
+class AnimatedTopBar extends PureComponent<{
+  scrollY: AnimatedValue,
+  summary: Summary,
+  t: T,
+}> {
+  render() {
+    const { scrollY, summary, t } = this.props;
+
+    const opacity = scrollY.interpolate({
+      inputRange: [0, 100],
+      outputRange: [0, 1],
+      extrapolate: "clamp",
+    });
+
+    const translateY = scrollY.interpolate({
+      inputRange: [0, 120],
+      outputRange: [60, 0],
+      extrapolate: "clamp",
+    });
+
+    return (
+      <Animated.View style={[styles.root, { opacity }]}>
+        <Animated.View style={[styles.inner, { transform: [{ translateY }] }]}>
+          <LText secondary style={styles.labelText}>
+            {t("common:portfolio.totalBalance")}
+          </LText>
+          <Space h={5} />
+          <LText tertiary style={styles.balanceText}>
+            <CurrencyUnitValue
+              unit={summary.counterValueCurrency.units[0]}
+              value={summary.balanceEnd}
+            />
+          </LText>
+        </Animated.View>
+      </Animated.View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  root: {
+    elevation: 20,
+    position: "absolute",
+    backgroundColor: "white",
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 60,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  inner: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  labelText: {
+    fontSize: 12,
+    color: colors.grey,
+  },
+  balanceText: {
+    fontSize: 16,
+    color: colors.darkBlue,
+  },
+});
+
+export default translate()(AnimatedTopBar);

--- a/src/screens/Portfolio/PortfolioGraphCard.js
+++ b/src/screens/Portfolio/PortfolioGraphCard.js
@@ -16,7 +16,7 @@ import colors from "../../colors";
 import { setSelectedTimeRange } from "../../actions/settings";
 
 import Delta from "../../components/Delta";
-import Space from "../../components/Space";
+import FormatDate from "../../components/FormatDate";
 import Graph from "../../components/Graph";
 import Pills from "../../components/Pills";
 import Card from "../../components/Card";
@@ -66,7 +66,8 @@ class PortfolioGraphCard extends PureComponent<Props, State> {
       <Card style={styles.root}>
         <PortfolioGraphCardHeader
           from={balanceStart}
-          to={hoveredItem ? hoveredItem.value : balanceEnd}
+          to={balanceEnd}
+          hoveredItem={hoveredItem}
           unit={counterValueCurrency.units[0]}
         />
         <Graph
@@ -95,20 +96,31 @@ class PortfolioGraphCardHeader extends PureComponent<{
   from: BigNumber,
   to: BigNumber,
   unit: Unit,
+  hoveredItem: ?Item,
 }> {
   render() {
-    const { unit, from, to } = this.props;
+    const { unit, from, to, hoveredItem } = this.props;
     return (
       <Fragment>
         <View style={styles.balanceTextContainer}>
           <LText style={styles.balanceText}>
-            <CurrencyUnitValue unit={unit} value={to} />
+            <CurrencyUnitValue
+              unit={unit}
+              value={hoveredItem ? hoveredItem.value : to}
+            />
           </LText>
         </View>
         <View style={styles.subtitleContainer}>
-          <Delta percent from={from} to={to} />
-          <Space w={20} />
-          <Delta from={from} to={to} unit={unit} />
+          {hoveredItem ? (
+            <LText>
+              <FormatDate date={hoveredItem.date} format="LL" />
+            </LText>
+          ) : (
+            <Fragment>
+              <Delta percent from={from} to={to} style={styles.deltaPercent} />
+              <Delta from={from} to={to} unit={unit} />
+            </Fragment>
+          )}
         </View>
       </Fragment>
     );
@@ -136,6 +148,9 @@ const styles = StyleSheet.create({
   pillsContainer: {
     marginTop: 10,
     alignItems: "center",
+  },
+  deltaPercent: {
+    marginRight: 20,
   },
 });
 


### PR DESCRIPTION
Two features in this commit:

- add scroll-based-animated top bar in Portfolio screen. It displays total balance.
- when touching the graph, the date is shown on the card header

![scroll](https://user-images.githubusercontent.com/315259/45037878-51c4c880-b060-11e8-956f-9874d55596ba.gif)
![click](https://user-images.githubusercontent.com/315259/45037877-51c4c880-b060-11e8-957c-91b35901ba28.gif)
