### PR TITLE
currency settings re-design

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -92,7 +92,8 @@
       "rateProvider": "Rate Provider ({{currencyTicker}}-> BTC)",
       "rateProviderDesc": "Lorem ipsum dolor sit amet, ectetur adipiscing elit. Donec congue urn",
       "confirmationNb": "Number of confirmations",
-      "confirmationNbDesc": "Lorem ipsum dolor sit amet, ectetur adipiscing elit. Donec congue urn"
+      "confirmationNbDesc": "Lorem ipsum dolor sit amet, ectetur adipiscing elit. Donec congue urn",
+      "currencySettingsTitle": "{{currencyName}} Settings"
     },
     "about": {
       "title": "About",

--- a/src/navigators.js
+++ b/src/navigators.js
@@ -20,7 +20,8 @@ import RateProviderSettings from "./screens/Settings/General/RateProviderSetting
 import GeneralSettings from "./screens/Settings/General";
 import AboutSettings from "./screens/Settings/About";
 import HelpSettings from "./screens/Settings/Help";
-import CurrenciesSettings from "./screens/Settings/Currencies";
+import CurrenciesSettings from "./screens/Settings/Currencies/";
+import CurrencySettings from "./screens/Settings/Currencies/CurrencySettings";
 import Manager from "./screens/Manager";
 import ReceiveFundsMain from "./screens/ReceiveFunds";
 import SendFundsMain from "./screens/SendFunds";
@@ -72,6 +73,7 @@ const SettingsStack = createStackNavigator(
     // $FlowFixMe
     HelpSettings,
     CurrenciesSettings,
+    CurrencySettings,
   },
   // $FlowFixMe
   StackNavigatorConfig,

--- a/src/screens/Settings/Currencies/index.js
+++ b/src/screens/Settings/Currencies/index.js
@@ -1,41 +1,107 @@
 /* @flow */
-import React, { PureComponent } from "react";
+import React, { PureComponent, Fragment } from "react";
 import { connect } from "react-redux";
-import { ScrollView } from "react-native";
+import { View } from "react-native";
+import { translate } from "react-i18next";
+import { compose } from "redux";
 import { createStructuredSelector } from "reselect";
-import type { CryptoCurrency } from "@ledgerhq/live-common/lib/types";
 import type { NavigationScreenProp } from "react-navigation";
-import CurrencySettingsSection from "./CurrencySettingsSection";
+import type { CryptoCurrency } from "@ledgerhq/live-common/lib/types";
+import type { T } from "../../../types/common";
 import { currenciesSelector } from "../../../reducers/accounts";
+import SettingsRow from "../../../components/SettingsRow";
+import CurrencyIcon from "../../../components/CurrencyIcon";
+import CurrencySettings from "./CurrencySettings";
+import LText from "../../../components/LText";
 
 type Props = {
   navigation: NavigationScreenProp<*>,
   currencies: CryptoCurrency[],
+  t: T,
 };
 
 const mapStateToProps = createStructuredSelector({
   currencies: currenciesSelector,
 });
 
-class CurrenciesSettings extends PureComponent<Props, *> {
-  static navigationOptions = {
-    title: "Currencies",
-  };
+class CurrenciesSettings extends PureComponent<Props> {
+  static navigationOptions = ({ navigation }) => ({
+    title: `${navigation.state.params.title}`,
+  });
 
   render() {
-    const { navigation, currencies } = this.props;
+    const { navigation, currencies, t } = this.props;
+    if (!currencies.length) return null;
     return (
-      <ScrollView contentContainerStyle={{ paddingBottom: 60 }}>
-        {currencies.map(currency => (
-          <CurrencySettingsSection
-            key={currency.coinType}
-            currency={currency}
+      <Fragment>
+        {currencies.length < 2 ? (
+          <RenderCurrencySettings
+            currency={currencies[0]}
             navigation={navigation}
+            t={t}
           />
-        ))}
-      </ScrollView>
+        ) : (
+          <RenderCurrencyList currencies={currencies} navigation={navigation} />
+        )}
+      </Fragment>
     );
   }
 }
 
-export default connect(mapStateToProps)(CurrenciesSettings);
+export default compose(
+  connect(mapStateToProps),
+  translate(),
+)(CurrenciesSettings);
+
+class RenderCurrencyList extends PureComponent<{
+  navigation: NavigationScreenProp<*>,
+  currencies: CryptoCurrency[],
+}> {
+  render() {
+    const { currencies, navigation } = this.props;
+    return (
+      <View>
+        {currencies.map(currency => (
+          <SettingsRow
+            title={currency.ticker}
+            iconLeft={<CurrencyIcon size={20} currency={currency} />}
+            key={currency.id}
+            desc={null}
+            arrowRight
+            onPress={() =>
+              navigation.navigate("CurrencySettings", {
+                currencyId: currency.id,
+              })
+            }
+          />
+        ))}
+      </View>
+    );
+  }
+}
+class RenderCurrencySettings extends PureComponent<{
+  currency: CryptoCurrency,
+  navigation: NavigationScreenProp<*>,
+  t: T,
+}> {
+  // TODO: add Coin Icon to the title
+  componentDidMount() {
+    const { navigation, t, currency } = this.props;
+    navigation.setParams({
+      title: (
+        <LText>
+          <CurrencyIcon size={20} currency={currency} />
+          {t("common:settings.currencies.currencySettingsTitle", {
+            currencyName: currency.name,
+          })}
+        </LText>
+      ),
+    });
+  }
+  render() {
+    const { currency, navigation } = this.props;
+    return (
+      <CurrencySettings currencyId={currency.id} navigation={navigation} />
+    );
+  }
+}

--- a/src/screens/Settings/index.js
+++ b/src/screens/Settings/index.js
@@ -40,7 +40,9 @@ class Settings extends Component<{
         title: t("common:settings.currencies.title"),
         desc: t("common:settings.currencies.desc"),
         onClick: () => {
-          navigation.navigate("CurrenciesSettings", {});
+          navigation.navigate("CurrenciesSettings", {
+            title: t("common:settings.currencies.title"),
+          });
         },
       },
       {


### PR DESCRIPTION
Currency Settings according to the new design 

1) When we have more than 1 currency - we have now intermediary screen with a list of currencies, each clickable with navigation to another string with settings (conf number and exchange if applicable)
2) if we have just 1 coin it goes straight to the Settings page without rendering the list first

TODO: add icon in the dynamic title and maybe place current value of slider in a different place
<div>
<img src="https://user-images.githubusercontent.com/10082039/45045203-8fcae800-b072-11e8-88f5-b276376d1091.PNG" width="200" />
<img src="https://user-images.githubusercontent.com/10082039/45045206-9194ab80-b072-11e8-9d72-b5947e1ce3f3.PNG" width="200" />
</div>