### PR TITLE
Graph ability to draw based on value instead of countervalue

### DIFF
--- a/src/components/GraphCard.js
+++ b/src/components/GraphCard.js
@@ -35,6 +35,7 @@ type Props = {
   setSelectedTimeRange: string => void,
   onPanResponderStart: () => *,
   onPanResponderRelease: () => *,
+  useCounterValue?: boolean,
   renderTitle?: ({ counterValueUnit: Unit, item: Item }) => React$Node,
 };
 
@@ -57,7 +58,13 @@ class GraphCard extends PureComponent<Props, State> {
   };
 
   render() {
-    const { summary, t, onPanResponderStart, renderTitle } = this.props;
+    const {
+      summary,
+      t,
+      onPanResponderStart,
+      renderTitle,
+      useCounterValue,
+    } = this.props;
 
     const {
       accounts,
@@ -97,6 +104,7 @@ class GraphCard extends PureComponent<Props, State> {
           onItemHover={this.onItemHover}
           onPanResponderStart={onPanResponderStart}
           onPanResponderRelease={this.onPanResponderRelease}
+          useCounterValue={useCounterValue}
         />
         <View style={styles.pillsContainer}>
           <Pills

--- a/src/screens/Portfolio/index.js
+++ b/src/screens/Portfolio/index.js
@@ -165,6 +165,7 @@ const GraphCardContainer = ({
     <Greetings nbAccounts={summary.accounts.length} />
     <GraphCard
       summary={summary}
+      useCounterValue
       onPanResponderStart={onPanResponderStart}
       onPanResponderRelease={onPanResponderRelease}
     />


### PR DESCRIPTION
![screenshot_20180906-105955__01](https://user-images.githubusercontent.com/315259/45147292-e7796880-b1c4-11e8-8295-00471a7a5913.jpg)

Following discussions about the usefulness of the actual graph (e.g https://github.com/LedgerHQ/ledger-live-desktop/issues/1478), the `Graph` component can now renders either countervalues or directly values. I've changed the curve to be square-based, because it makes no sense to interpolate here, and enabled it on account screen (Portfolio screen mixes all crypto, so not doable).

IMO (also asked multiple times on desktop), Portfolio **should not display line graph** but a **pie chart** showing % of holding of each asset based on cv. Again, mixing up market prices + transaction history makes no sense.