### PR TITLE
Update main tab bar style

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-native-touch-id": "4.0.1",
     "react-native-vector-icons": "^5.0.0",
     "react-navigation": "2.9.3",
+    "react-navigation-tabs": "^0.6.0",
     "react-redux": "5.0.7",
     "redux": "4.0.0",
     "redux-actions": "2.6.1",

--- a/src/navigators.js
+++ b/src/navigators.js
@@ -1,10 +1,8 @@
 // @flow
 import React from "react";
 import { StyleSheet } from "react-native";
-import {
-  createBottomTabNavigator,
-  createStackNavigator,
-} from "react-navigation";
+import { createStackNavigator } from "react-navigation";
+import { createBottomTabNavigator, BottomTabBar } from "react-navigation-tabs";
 import colors from "./colors";
 import SettingsIcon from "./images/icons/Settings";
 import ManagerIcon from "./images/icons/Manager";
@@ -47,6 +45,11 @@ const styles = StyleSheet.create({
     backgroundColor: "white",
     borderBottomWidth: 0,
     elevation: 0,
+  },
+  bottomTabBar: {
+    height: 48,
+    borderTopColor: colors.lightFog,
+    backgroundColor: colors.white,
   },
 });
 
@@ -113,14 +116,23 @@ AccountsStack.navigationOptions = {
   ),
 };
 
-const Main = createBottomTabNavigator({
-  Portfolio,
-  Accounts: AccountsStack,
-  // $FlowFixMe
-  Transfer,
-  Manager: ManagerStack,
-  Settings: SettingsStack,
-});
+const CustomTabBar = props => (
+  <BottomTabBar {...props} style={styles.bottomTabBar} />
+);
+
+const Main = createBottomTabNavigator(
+  {
+    Portfolio,
+    Accounts: AccountsStack,
+    // $FlowFixMe
+    Transfer,
+    Manager: ManagerStack,
+    Settings: SettingsStack,
+  },
+  {
+    tabBarComponent: CustomTabBar,
+  },
+);
 
 Main.navigationOptions = {
   header: null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5592,6 +5592,16 @@ react-navigation-tabs@0.5.1:
     react-native-safe-area-view "^0.7.0"
     react-native-tab-view "^1.0.0"
 
+react-navigation-tabs@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/react-navigation-tabs/-/react-navigation-tabs-0.6.0.tgz#2f526194f4360e56c2702e736887449acc2080dc"
+  dependencies:
+    hoist-non-react-statics "^2.5.0"
+    prop-types "^15.6.1"
+    react-lifecycles-compat "^3.0.4"
+    react-native-safe-area-view "^0.7.0"
+    react-native-tab-view "^1.0.0"
+
 react-navigation@2.9.3:
   version "2.9.3"
   resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-2.9.3.tgz#de97f7102df6b836af780bfa5bfa80747148da19"


### PR DESCRIPTION
![screenshot_20180906-155804](https://user-images.githubusercontent.com/315259/45162393-325ba600-b1ee-11e8-92c7-920387766193.jpg)

Couldn't find a way to style it like described in the docs (just using `style` prop in parameters), so I took the second docs example, using `react-navigation-tabs`. Works like a charm and we can customize what we want.