### PR TITLE
Libcore integration for Android & iOS

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -211,6 +211,7 @@ dependencies {
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:27.1.1"
     compile "com.facebook.react:react-native:+"  // From node_modules
+    compile project(':react-native-ledger-core')
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
 
     <uses-sdk
         android:minSdkVersion="21"
-        android:targetSdkVersion="27" />
+        android:targetSdkVersion="27"
+        tools:overrideLibrary="com.ledger.reactnative" />
 
     <application
       android:name=".MainApplication"

--- a/android/app/src/main/java/com/ledgerlivemobile/MainApplication.java
+++ b/android/app/src/main/java/com/ledgerlivemobile/MainApplication.java
@@ -17,11 +17,21 @@ import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 import com.facebook.soloader.SoLoader;
+import com.ledger.reactnative.RCTCoreBindingPackage;
 
 import java.util.Arrays;
 import java.util.List;
 
 public class MainApplication extends Application implements ReactApplication {
+
+  static {
+    try {
+      System.loadLibrary("ledger-core");
+    } catch (UnsatisfiedLinkError e) {
+      System.err.println("ledger-core native library failed to load: " + e);
+      System.exit(1);
+    }
+  }
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
@@ -42,6 +52,7 @@ public class MainApplication extends Application implements ReactApplication {
               new BlurViewPackage(),
               new SvgPackage(),
               new ReactNativeConfigPackage(),
+              new RCTCoreBindingPackage(),
               new BlePackage()
       );
     }

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -28,4 +28,7 @@ project(':react-native-config').projectDir = new File(rootProject.projectDir, '.
 include ':react-native-ble-plx'
 project(':react-native-ble-plx').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-ble-plx/android')
 
+include ':react-native-ledger-core'
+project(':react-native-ledger-core').projectDir = new File(rootProject.projectDir, '../node_modules/@ledgerhq/react-native-ledger-core/android')
+
 include ':app'

--- a/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -51,6 +51,9 @@
 		A854DAD55ED1456696918FDF /* MuseoSans-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = CE7E1D553FBD49E0A85347D3 /* MuseoSans-Bold.otf */; };
 		AA971EB1796D4FD797316C3D /* OpenSans-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 44387CB2EE84464C83A75FD7 /* OpenSans-Regular.ttf */; };
 		ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */ = {isa = PBXBuildFile; fileRef = ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */; };
+		B9D85A51214907140007703A /* libRNLibLedgerCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B9D85A132149064F0007703A /* libRNLibLedgerCore.a */; };
+		B9D85A532149082F0007703A /* libledger-core.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B9D85A522149082F0007703A /* libledger-core.dylib */; };
+		B9D85A54214908400007703A /* libledger-core.dylib in Embed Libraries */ = {isa = PBXBuildFile; fileRef = B9D85A522149082F0007703A /* libledger-core.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		D5C1F1874ECE48F4AA5693AF /* MuseoSans-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = CEDB8CDC561E4D4BBA7A64CD /* MuseoSans-SemiBold.otf */; };
 		DEF1B1546B36491B9894A599 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 545FD04868AD450083DC4717 /* libz.tbd */; };
 		E346451EC3604977A20BAAB1 /* libRNBlur.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C5890E524DD4BA092CB8080 /* libRNBlur.a */; };
@@ -394,7 +397,35 @@
 			remoteGlobalIDString = 358F4ED71D1E81A9004DF814;
 			remoteInfo = RCTBlob;
 		};
+		B9D85A122149064F0007703A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B9D859E12149064E0007703A /* RNLibLedgerCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNLibLedgerCore;
+		};
+		B9D85A4F2149070B0007703A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = B9D859E12149064E0007703A /* RNLibLedgerCore.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = 58B511DA1A9E6C8500147676;
+			remoteInfo = RNLibLedgerCore;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		B9D85A4E2149068F0007703A /* Embed Libraries */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				B9D85A54214908400007703A /* libledger-core.dylib in Embed Libraries */,
+			);
+			name = "Embed Libraries";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		008BC7A712F04B01A070866A /* TouchID.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = TouchID.xcodeproj; path = "../node_modules/react-native-touch-id/TouchID.xcodeproj"; sourceTree = "<group>"; };
@@ -449,6 +480,8 @@
 		ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTBlob.xcodeproj; path = "../node_modules/react-native/Libraries/Blob/RCTBlob.xcodeproj"; sourceTree = "<group>"; };
 		AE0C18E225CD47BA91948A0E /* libSplashScreen.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libSplashScreen.a; sourceTree = "<group>"; };
 		AFD05AA846DD466ABCB867EB /* RNBlur.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNBlur.xcodeproj; path = "../node_modules/react-native-blur/ios/RNBlur.xcodeproj"; sourceTree = "<group>"; };
+		B9D859E12149064E0007703A /* RNLibLedgerCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNLibLedgerCore.xcodeproj; path = "../node_modules/@ledgerhq/react-native-ledger-core/ios/RNLibLedgerCore.xcodeproj"; sourceTree = "<group>"; };
+		B9D85A522149082F0007703A /* libledger-core.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libledger-core.dylib"; path = "../node_modules/@ledgerhq/react-native-ledger-core/ios/Libraries/x86/libledger-core.dylib"; sourceTree = "<group>"; };
 		C7C5BB743ED04E53A2323979 /* OpenSans-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-SemiBold.ttf"; path = "../assets/fonts/OpenSans-SemiBold.ttf"; sourceTree = "<group>"; };
 		CE7E1D553FBD49E0A85347D3 /* MuseoSans-Bold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "MuseoSans-Bold.otf"; path = "../assets/fonts/MuseoSans-Bold.otf"; sourceTree = "<group>"; };
 		CEDB8CDC561E4D4BBA7A64CD /* MuseoSans-SemiBold.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "MuseoSans-SemiBold.otf"; path = "../assets/fonts/MuseoSans-SemiBold.otf"; sourceTree = "<group>"; };
@@ -476,6 +509,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B9D85A51214907140007703A /* libRNLibLedgerCore.a in Frameworks */,
 				347AB25E20498A4E00BE6F60 /* libRNSentry.a in Frameworks */,
 				349F66892045ADD9002149B4 /* libRNCamera.a in Frameworks */,
 				ADBDB9381DFEBF1600ED6528 /* libRCTBlob.a in Frameworks */,
@@ -484,6 +518,7 @@
 				00C302E51ABCBA2D00DB3ED1 /* libRCTActionSheet.a in Frameworks */,
 				00C302E81ABCBA2D00DB3ED1 /* libRCTImage.a in Frameworks */,
 				133E29F31AD74F7200F7D852 /* libRCTLinking.a in Frameworks */,
+				B9D85A532149082F0007703A /* libledger-core.dylib in Frameworks */,
 				00C302E91ABCBA2D00DB3ED1 /* libRCTNetwork.a in Frameworks */,
 				139105C61AF99C1200B5F7CC /* libRCTSettings.a in Frameworks */,
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
@@ -739,6 +774,7 @@
 		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				B9D859E12149064E0007703A /* RNLibLedgerCore.xcodeproj */,
 				349F66542045ADCC002149B4 /* RNCamera.xcodeproj */,
 				5E91572D1DD0AC6500FF2AA8 /* RCTAnimation.xcodeproj */,
 				146833FF1AC3E56700842450 /* React.xcodeproj */,
@@ -822,6 +858,7 @@
 		90B115AE643A42D1BF8AA6F4 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				B9D85A522149082F0007703A /* libledger-core.dylib */,
 				545FD04868AD450083DC4717 /* libz.tbd */,
 			);
 			name = Frameworks;
@@ -832,6 +869,14 @@
 			children = (
 				ADBDB9271DFEBF0700ED6528 /* libRCTBlob.a */,
 				34457EBD2003A12500415724 /* libRCTBlob-tvOS.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B9D859E22149064E0007703A /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				B9D85A132149064F0007703A /* libRNLibLedgerCore.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -867,10 +912,12 @@
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
 				34457ED72003A43200415724 /* carthage copy-frameworks */,
 				C5DD91777D904DF2BEB7E83C /* Upload Debug Symbols to Sentry */,
+				B9D85A4E2149068F0007703A /* Embed Libraries */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				B9D85A502149070B0007703A /* PBXTargetDependency */,
 			);
 			name = ledgerlivemobile;
 			productName = "Hello World";
@@ -980,6 +1027,10 @@
 				{
 					ProductGroup = 349F66552045ADCC002149B4 /* Products */;
 					ProjectRef = 349F66542045ADCC002149B4 /* RNCamera.xcodeproj */;
+				},
+				{
+					ProductGroup = B9D859E22149064E0007703A /* Products */;
+					ProjectRef = B9D859E12149064E0007703A /* RNLibLedgerCore.xcodeproj */;
 				},
 				{
 					ProductGroup = 347AB1EC2049885900BE6F60 /* Products */;
@@ -1336,6 +1387,13 @@
 			remoteRef = ADBDB9261DFEBF0700ED6528 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		B9D85A132149064F0007703A /* libRNLibLedgerCore.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNLibLedgerCore.a;
+			remoteRef = B9D85A122149064F0007703A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
@@ -1452,6 +1510,11 @@
 			target = 13B07F861A680F5B00A75B9A /* ledgerlivemobile */;
 			targetProxy = 00E356F41AD99517003FC87E /* PBXContainerItemProxy */;
 		};
+		B9D85A502149070B0007703A /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RNLibLedgerCore;
+			targetProxy = B9D85A4F2149070B0007703A /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
@@ -1567,6 +1630,7 @@
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../node_modules/@ledgerhq/react-native-ledger-core/ios/**";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -1606,6 +1670,7 @@
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../node_modules/@ledgerhq/react-native-ledger-core/ios/**";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@ledgerhq/live-common": "^3.4.0",
     "@ledgerhq/react-native-hid": "4.21.0",
     "@ledgerhq/react-native-hw-transport-ble": "4.21.0",
-    "@ledgerhq/react-native-ledger-core": "^0.1.1",
+    "@ledgerhq/react-native-ledger-core": "^0.2.1",
     "@ledgerhq/react-native-passcode-auth": "2.0.0",
     "async": "^2.6.1",
     "bignumber.js": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@ledgerhq/live-common": "^3.4.0",
     "@ledgerhq/react-native-hid": "4.21.0",
     "@ledgerhq/react-native-hw-transport-ble": "4.21.0",
+    "@ledgerhq/react-native-ledger-core": "^0.1.1",
     "@ledgerhq/react-native-passcode-auth": "2.0.0",
     "async": "^2.6.1",
     "bignumber.js": "^7.2.1",

--- a/src/logic/getLibcore.js
+++ b/src/logic/getLibcore.js
@@ -1,0 +1,72 @@
+import { Platform, NativeModules } from "react-native";
+
+let core;
+let walletPoolInstance;
+let threadDispatcher;
+
+export default async () => {
+  if (core) {
+    return core;
+  }
+
+  if (Platform.OS === "android") {
+    core = {
+      getPoolInstance: () => walletPoolInstance,
+      getThreadDispatcher: () => threadDispatcher,
+      flush: async () => {
+        await core.coreHttpClient.flush();
+        await core.coreWebSocketClient.flush();
+        await core.corePathResolver.flush();
+        await core.coreLogPrinter.flush();
+        await core.coreRandomNumberGenerator.flush();
+        await core.coreDynamicObject.flush();
+        await core.coreDatabaseBackend.flush();
+      },
+
+      // forwarding native functions
+      coreAccount: NativeModules.CoreAccount,
+      coreDatabaseBackend: NativeModules.CoreDatabaseBackend,
+      coreDynamicObject: NativeModules.CoreDynamicObject,
+      coreEventBus: NativeModules.CoreEventBus,
+      coreEventReceiver: NativeModules.CoreEventReceiver,
+      coreExtendedKeyAccountCreationInfo:
+        NativeModules.CoreExtendedKeyAccountCreationInfo,
+      coreHttpClient: NativeModules.CoreHttpClient,
+      coreLogPrinter: NativeModules.CoreLogPrinter,
+      coreOperationQuery: NativeModules.CoreOperationQuery,
+      corePathResolver: NativeModules.CorePathResolver,
+      coreRandomNumberGenerator: NativeModules.CoreRandomNumberGenerator,
+      coreThreadDispatcher: NativeModules.CoreThreadDispatcher,
+      coreWallet: NativeModules.CoreWallet,
+      coreWalletPool: NativeModules.CoreWalletPool,
+      coreWebSocketClient: NativeModules.CoreWebSocketClient,
+    };
+  } else {
+    // TODO: ios here
+    throw new Error(`Unsupported platform: ${Platform.OS}`);
+  }
+
+  const httpClient = await core.coreHttpClient.newInstance();
+  const webSocket = await core.coreWebSocketClient.newInstance();
+  const pathResolver = await core.corePathResolver.newInstance();
+  const logPrinter = await core.coreLogPrinter.newInstance();
+  threadDispatcher = await core.coreThreadDispatcher.newInstance();
+  const rng = await core.coreRandomNumberGenerator.newInstance();
+  const backend = await core.coreDatabaseBackend.getSqlite3Backend();
+  const dynamicObject = await core.coreDynamicObject.newInstance();
+
+  walletPoolInstance = await core.coreWalletPool.newInstance(
+    "ledger_live_desktop",
+    "",
+    httpClient,
+    webSocket,
+    pathResolver,
+    logPrinter,
+    threadDispatcher,
+    rng,
+    backend,
+    dynamicObject,
+  );
+
+  return core;
+};

--- a/src/logic/libcore.js
+++ b/src/logic/libcore.js
@@ -1,0 +1,117 @@
+// @flow
+
+import getLibCore from "./getLibcore";
+
+async function getOrCreateWallet({
+  core,
+  walletName,
+  currencyId,
+}: {
+  core: *,
+  walletName: string,
+  currencyId: string,
+}) {
+  const poolInstance = core.getPoolInstance();
+  const currency = await core.coreWalletPool.getCurrency(
+    poolInstance,
+    currencyId,
+  );
+  let wallet;
+  try {
+    wallet = await core.coreWalletPool.getWallet(poolInstance, walletName);
+  } catch (err) {
+    const config = await core.coreDynamicObject.newInstance();
+    core.coreDynamicObject.putString(config, "KEYCHAIN_ENGINE", "BIP49_P2SH");
+    core.coreDynamicObject.putString(
+      config,
+      "KEYCHAIN_DERIVATION_SCHEME",
+      "49'/1'/<account>'/<node>/<address>",
+    );
+    wallet = await core.coreWalletPool.createWallet(
+      poolInstance,
+      walletName,
+      currency,
+      config,
+    );
+  }
+  return wallet;
+}
+
+export async function syncAccount({ core, account }: { core: *, account: * }) {
+  const eventReceiver = await core.coreEventReceiver.newInstance();
+  const eventBus = await core.coreAccount.synchronize(account);
+  const serialContext = await core.coreThreadDispatcher.getSerialExecutionContext(
+    core.getThreadDispatcher(),
+    "main",
+  );
+  await core.coreEventBus.subscribe(eventBus, serialContext, eventReceiver);
+}
+
+export async function getAccountFromXPUB({
+  xpub,
+  currencyId,
+}: {
+  xpub: string,
+  currencyId: string,
+}) {
+  let account;
+  const index = 0;
+  const core = await getLibCore();
+
+  // TODO: real wallet name
+  const walletName = `temporary-wallet-name-${Date.now()}`;
+
+  const wallet = await getOrCreateWallet({ core, walletName, currencyId });
+
+  // TODO: why do we do this now?
+  await core.flush();
+
+  try {
+    account = await core.coreWallet.getAccount(wallet, index);
+  } catch (err) {
+    const extendedInfos = await core.coreWallet.getExtendedKeyAccountCreationInfo(
+      wallet,
+      index,
+    );
+    const infosIndex = await core.coreExtendedKeyAccountCreationInfo.getIndex(
+      extendedInfos,
+    );
+    const extendedKeys = await core.coreExtendedKeyAccountCreationInfo.getExtendedKeys(
+      extendedInfos,
+    );
+    const owners = await core.coreExtendedKeyAccountCreationInfo.getOwners(
+      extendedInfos,
+    );
+    const derivations = await core.coreExtendedKeyAccountCreationInfo.getDerivations(
+      extendedInfos,
+    );
+
+    extendedKeys.push(xpub);
+
+    const newExtendedKeys = await core.coreExtendedKeyAccountCreationInfo.init(
+      infosIndex,
+      owners,
+      derivations,
+      extendedKeys,
+    );
+
+    account = await core.coreWallet.newAccountWithExtendedKeyInfo(
+      wallet,
+      newExtendedKeys,
+    );
+  }
+
+  await syncAccount({ core, account });
+
+  const query = await core.coreAccount.queryOperations(account);
+  const completedQuery = await core.coreOperationQuery.complete(query);
+  const operations = await core.coreOperationQuery.execute(completedQuery);
+
+  await core.flush();
+
+  // TODO: build an Account
+  return {
+    account,
+    operations,
+  };
+}

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -15,4 +15,31 @@ if (__DEV__ && process.env.NODE_ENV !== "test") {
       console.warn(e);
     }
   }, 100);
+
+  // FIXME: we can safely remove that when the problem is fixed
+  //        on libcore side: actually if a callback based function
+  //        fails on libcore, the error callback is called twice
+  //
+  //        wrapping the calls in timeout doesnt help avoiding the
+  //        redbox, so we just want to ignore this like that for now :)
+  //
+  setupDirtyHackToHandleLibcoreDoubleCallback();
+}
+
+function setupDirtyHackToHandleLibcoreDoubleCallback() {
+  const ErrorUtils = require("ErrorUtils"); // eslint-disable-line import/no-unresolved
+  ErrorUtils.setGlobalHandler((e, isFatal) => {
+    try {
+      if (
+        e.message.match(
+          /only one callback may be registered to a function in a native module/,
+        )
+      ) {
+        return;
+      }
+      require("ExceptionsManager").handleException(e, isFatal); // eslint-disable-line import/no-unresolved
+    } catch (ee) {
+      console.log("Failed to print error: ", ee.message);
+    }
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,6 +561,12 @@
     "@ledgerhq/hw-transport" "^4.21.0"
     invariant "^2.2.4"
 
+"@ledgerhq/react-native-ledger-core@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-0.1.1.tgz#2c60fd20404bcdc665363d2833b87bfe68d5508f"
+  dependencies:
+    react-native "0.55.4"
+
 "@ledgerhq/react-native-passcode-auth@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-passcode-auth/-/react-native-passcode-auth-2.0.0.tgz#18f8fcc64d72b410300de203c2ddf8b4ae2a7fc3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,9 +561,9 @@
     "@ledgerhq/hw-transport" "^4.21.0"
     invariant "^2.2.4"
 
-"@ledgerhq/react-native-ledger-core@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-0.1.1.tgz#2c60fd20404bcdc665363d2833b87bfe68d5508f"
+"@ledgerhq/react-native-ledger-core@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-0.2.1.tgz#5aee97609f5e6f9ef65e58b412004ce95c9aa154"
   dependencies:
     react-native "0.55.4"
 


### PR DESCRIPTION
- new dependency on `lib-ledger-core-react-native-bindings`
- load the dynamic library at runtime
- get the `core` cross-platform singleton from `logic/getLibcore.js`, which init the wallet pool instance and a bunch of implementations (http handler, logger..) and exposes our native methods
- add a basic bitcoin account sync from xpub POC in `helpers/libcore.js`
- add a little hack to prevent (showing) error from double promise callback call on libcore side (see `src/polyfill.js`)

I have only tested it on Android, the iOS native methods still needs to be mapped in `logic/getLibcore.js`, if I remember the generated names are different so @KhalilBellakrid  we'll need you to point us the direction where to search :)

Anyway, the whole thing should work out of the box with only a `yarn install`.