### PR TITLE
Use linear curve for portfolio graph

### DIFF
--- a/src/components/Graph/index.js
+++ b/src/components/Graph/index.js
@@ -122,9 +122,7 @@ export default class Graph extends PureComponent<Props, State> {
       ? d => this.y(d.value.toNumber())
       : d => this.y(d.originalValue.toNumber());
 
-    const curve = useCounterValue
-      ? shape.curveCatmullRom
-      : shape.curveStepBefore;
+    const curve = useCounterValue ? shape.curveLinear : shape.curveStepBefore;
 
     this.x = scale
       .scaleTime()


### PR DESCRIPTION
In some cases the `cuveCatmullRom` causes strange behaviour (e.g going under `0` because of curving). `curveBasis` is not perfect also, because the "dot" following the finger end up not in the line. Let's step back to `curveLinear` (ISO as desktop)

catmullRom | curveBasis | curveLinear
------------ | ------------- | ---------
![2018-09-14_474x332](https://user-images.githubusercontent.com/315259/45556270-1fbf1d80-b83b-11e8-9391-0ffb227702a0.png) | ![2018-09-14_465x334](https://user-images.githubusercontent.com/315259/45556268-1fbf1d80-b83b-11e8-9389-a0be3ca9eeab.png) | ![2018-09-14_460x334](https://user-images.githubusercontent.com/315259/45556267-1fbf1d80-b83b-11e8-8929-2ca60d3b7938.png)