### PR TITLE
reject camera fallback

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -170,6 +170,7 @@ configurations.all {
 }
 
 dependencies {
+    compile project(':react-native-open-settings')
     compile project(':react-native-config')
     compile project(':react-native-svg')
     compile project(':@ledgerhq_react-native-hid')

--- a/android/app/src/main/java/com/ledgerlivemobile/MainApplication.java
+++ b/android/app/src/main/java/com/ledgerlivemobile/MainApplication.java
@@ -3,6 +3,7 @@ package com.ledgerlivemobile;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.opensettings.OpenSettingsPackage;
 import com.lugg.ReactNativeConfig.ReactNativeConfigPackage;
 import com.horcrux.svg.SvgPackage;
 import com.ledgerwallet.hid.ReactHIDPackage;
@@ -32,6 +33,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new OpenSettingsPackage(),
             new ReactNativeConfigPackage(),
             new SvgPackage(),
             new ReactHIDPackage(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'ledgerlivemobile'
+include ':react-native-open-settings'
+project(':react-native-open-settings').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-open-settings/android')
 include ':react-native-config'
 project(':react-native-config').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-config/android')
 include ':react-native-svg'

--- a/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		66BAE44DC0E24A36AE0245DE /* MaterialIcons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C1DA370D18E2494FA56F0D1D /* MaterialIcons.ttf */; };
 		7803605C741B4AC289D51F0D /* FontAwesome5_Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 6DC818670C904605A8FBA62A /* FontAwesome5_Regular.ttf */; };
 		7E87C9D031974B438C0F01F2 /* FontAwesome5_Solid.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7D2EA4CD0AC843B4A69D57A5 /* FontAwesome5_Solid.ttf */; };
+		7EDEA35621D64751B73F49C7 /* libReact Native Open Settings.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 88F6163E74364066BC1A5713 /* libReact Native Open Settings.a */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
 		86DD631BC8AA4C13A80FBD6D /* MuseoSans-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 3263CCC7104E4B86AC2ADDB4 /* MuseoSans-Regular.otf */; };
 		8883689AB6244426A9E1C1C0 /* Entypo.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 603D0C57D1C8456C82B34496 /* Entypo.ttf */; };
@@ -119,6 +120,13 @@
 			proxyType = 2;
 			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
 			remoteInfo = React;
+		};
+		24A1F4F7214FE1220093BEC2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A49125B8906C40DFB2011F37 /* React Native Open Settings.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 190C8BAA1BEAADCC00CD505E;
+			remoteInfo = "React Native Open Settings";
 		};
 		3425212D2085014A00F0782B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -452,6 +460,7 @@
 		7D2EA4CD0AC843B4A69D57A5 /* FontAwesome5_Solid.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Solid.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Solid.ttf"; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 		8427C9F7A477440AB9F329D6 /* Ionicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Ionicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Ionicons.ttf"; sourceTree = "<group>"; };
+		88F6163E74364066BC1A5713 /* libReact Native Open Settings.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = "libReact Native Open Settings.a"; sourceTree = "<group>"; };
 		8FAD0BFA211D977700531995 /* Octicons.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Octicons.ttf; sourceTree = "<group>"; };
 		8FAD0BFB211D977700531995 /* Feather.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Feather.ttf; sourceTree = "<group>"; };
 		8FAD0BFC211D977700531995 /* Entypo.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = Entypo.ttf; sourceTree = "<group>"; };
@@ -469,6 +478,7 @@
 		934B4698578340ED8F9A61E1 /* libRNSVG.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNSVG.a; sourceTree = "<group>"; };
 		9A58AC9A5DA149AC83518141 /* SimpleLineIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = SimpleLineIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/SimpleLineIcons.ttf"; sourceTree = "<group>"; };
 		9AE4011B27774E1EAFC940E3 /* libReactNativeConfig.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libReactNativeConfig.a; sourceTree = "<group>"; };
+		A49125B8906C40DFB2011F37 /* React Native Open Settings.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = "React Native Open Settings.xcodeproj"; path = "../node_modules/react-native-open-settings/React Native Open Settings.xcodeproj"; sourceTree = "<group>"; };
 		AAD9939A2894455FB2EC4881 /* FontAwesome5_Brands.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Brands.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Brands.ttf"; sourceTree = "<group>"; };
 		ADBDB91F1DFEBF0600ED6528 /* RCTBlob.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTBlob.xcodeproj; path = "../node_modules/react-native/Libraries/Blob/RCTBlob.xcodeproj"; sourceTree = "<group>"; };
 		AE0C18E225CD47BA91948A0E /* libSplashScreen.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libSplashScreen.a; sourceTree = "<group>"; };
@@ -524,6 +534,7 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				DEF1B1546B36491B9894A599 /* libz.tbd in Frameworks */,
+				7EDEA35621D64751B73F49C7 /* libReact Native Open Settings.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -630,6 +641,14 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
+		24A1F4F4214FE1220093BEC2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				24A1F4F8214FE1220093BEC2 /* libReact Native Open Settings.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		3425212A2085014A00F0782B /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -660,6 +679,7 @@
 				FEE547B54ACD4EF5AD24A94E /* libPasscodeAuth.a */,
 				E17D41657FAD4BEDBE62C1B2 /* libTouchID.a */,
 				3A45C4CF346C4C9594B2EC36 /* libRNVectorIcons.a */,
+				88F6163E74364066BC1A5713 /* libReact Native Open Settings.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -783,6 +803,7 @@
 				008BC7A712F04B01A070866A /* TouchID.xcodeproj */,
 				EE89361C161C48FB98136880 /* PasscodeAuth.xcodeproj */,
 				4AD2AECC687D45E9BBCCED05 /* RNVectorIcons.xcodeproj */,
+				A49125B8906C40DFB2011F37 /* React Native Open Settings.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1006,6 +1027,10 @@
 					ProjectRef = 139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */;
 				},
 				{
+					ProductGroup = 24A1F4F4214FE1220093BEC2 /* Products */;
+					ProjectRef = A49125B8906C40DFB2011F37 /* React Native Open Settings.xcodeproj */;
+				},
+				{
 					ProductGroup = 146834001AC3E56700842450 /* Products */;
 					ProjectRef = 146833FF1AC3E56700842450 /* React.xcodeproj */;
 				},
@@ -1087,6 +1112,13 @@
 			fileType = archive.ar;
 			path = libReact.a;
 			remoteRef = 146834031AC3E56700842450 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		24A1F4F8214FE1220093BEC2 /* libReact Native Open Settings.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libReact Native Open Settings.a";
+			remoteRef = 24A1F4F7214FE1220093BEC2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		3425212E2085014A00F0782B /* libSplashScreen.a */ = {
@@ -1527,11 +1559,15 @@
 					"$(SRCROOT)/../node_modules/react-native-touch-id",
 					"$(SRCROOT)/../node_modules/@ledgerhq/react-native-passcode-auth",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-open-settings",
 				);
 				INFOPLIST_FILE = ledgerlivemobileTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -1562,11 +1598,15 @@
 					"$(SRCROOT)/../node_modules/react-native-touch-id",
 					"$(SRCROOT)/../node_modules/@ledgerhq/react-native-passcode-auth",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-open-settings",
 				);
 				INFOPLIST_FILE = ledgerlivemobileTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -1601,6 +1641,7 @@
 					"$(SRCROOT)/../node_modules/react-native-touch-id",
 					"$(SRCROOT)/../node_modules/@ledgerhq/react-native-passcode-auth",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-open-settings",
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
@@ -1641,6 +1682,7 @@
 					"$(SRCROOT)/../node_modules/react-native-touch-id",
 					"$(SRCROOT)/../node_modules/@ledgerhq/react-native-passcode-auth",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
+					"$(SRCROOT)/../node_modules/react-native-open-settings",
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "ledgerlivemobile",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "react-native-open-settings": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-native-open-settings/-/react-native-open-settings-1.0.1.tgz",
+      "integrity": "sha1-HArj0l/T/W3pS21TgzPUckXMWgw="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-native-config": "0.11.5",
     "react-native-locale": "0.0.19",
     "react-native-modal": "^6.5.0",
+    "react-native-open-settings": "^1.0.1",
     "react-native-progress": "^3.5.0",
     "react-native-qrcode-svg": "5.1.0",
     "react-native-sentry": "0.39.0",

--- a/src/icons/FallbackCamera.js
+++ b/src/icons/FallbackCamera.js
@@ -1,0 +1,62 @@
+// @flow
+import React from "react";
+import Svg, { G, Path, Rect } from "react-native-svg";
+
+export default function LiveLogo() {
+  return (
+    <Svg width="159" height="91">
+      <G fill="none" fillRule="evenodd">
+        <Path
+          d="M.5 67.5h158V4A3.5 3.5 0 0 0 155 .5H4A3.5 3.5 0 0 0 .5 4v63.5z"
+          stroke="#D8D8D8"
+          fill="#FFF"
+        />
+        <G transform="translate(0 67)">
+          <Path
+            d="M.5.5V20A3.5 3.5 0 0 0 4 23.5h75.5V.5H.5z"
+            stroke="#D8D8D8"
+            fill="#FFF"
+          />
+          <Rect
+            fill="#E8E8E8"
+            fillRule="nonzero"
+            opacity=".6"
+            x="27.368"
+            y="11"
+            width="25.263"
+            height="2"
+            rx="1"
+          />
+        </G>
+        <G transform="translate(79 67)">
+          <Path
+            d="M.5.5v23H76a3.5 3.5 0 0 0 3.5-3.5V.5H.5z"
+            stroke="#D8D8D8"
+            fill="#FFF"
+          />
+          <Rect
+            fill="#C2C2C2"
+            fillRule="nonzero"
+            opacity=".6"
+            x="23.158"
+            y="11"
+            width="33.684"
+            height="2"
+            rx="1"
+          />
+        </G>
+        <G transform="translate(16 20)" fill="#6490F1">
+          <Rect opacity=".2" width="28" height="28" rx="14" />
+          <Path
+            d="M20.303 9c1.118 0 2.03.892 2.03 2v7.333c0 1.108-.912 2-2.03 2H8.03c-1.118 0-2.03-.892-2.03-2V11c0-1.108.912-2 2.03-2h2.375l1.165-1.709A.667.667 0 0 1 12.121 7h4.091c.22 0 .427.109.55.291L17.929 9h2.375zm-8.995 1.042a.667.667 0 0 1-.55.291H8.03c-.388 0-.697.302-.697.667v7.333c0 .365.31.667.697.667h12.273c.388 0 .697-.302.697-.667V11c0-.365-.309-.667-.697-.667h-2.727a.667.667 0 0 1-.551-.29l-1.165-1.71h-3.386l-1.166 1.71zm2.859 7.625c-1.871 0-3.394-1.49-3.394-3.334S12.296 11 14.167 11c1.87 0 3.394 1.489 3.394 3.333 0 1.845-1.523 3.334-3.394 3.334zm0-1.334c1.141 0 2.06-.898 2.06-2 0-1.1-.919-2-2.06-2-1.142 0-2.06.9-2.06 2 0 1.102.918 2 2.06 2z"
+            fillRule="nonzero"
+          />
+        </G>
+        <G transform="translate(60 28)" fillRule="nonzero">
+          <Rect fill="#999" width="80" height="2" rx="1" />
+          <Rect fill="#D8D8D8" y="10" width="56" height="2" rx="1" />
+        </G>
+      </G>
+    </Svg>
+  );
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -135,6 +135,14 @@
         "alreadyImported": "Already imported",
         "noAccounts": "Nothing to import",
         "unsupported": "Unsupported"
+      },
+      "fallback": {
+        "header": "Import account",
+        "title": "Camera access",
+        "descIOS": "To import account, Ledger Live needs to <1><0>access your camera</0></1>. You’ll be taken to iOS settings to activate it",
+        "buttonIOS": "Open iPhone Settings",
+        "descAndroid": "To import account, Ledger Live needs to <1><0>access your camera</0></1>. You’ll be taken to Android settings to activate it",
+        "buttonAndroid": "Open Android Settings"
       }
     }
   },

--- a/src/navigators.js
+++ b/src/navigators.js
@@ -38,6 +38,7 @@ import DisplayResult from "./screens/ImportAccounts/DisplayResult";
 import EditFees from "./screens/EditFees";
 import VerifyAddress from "./screens/VerifyAddress";
 import ReceiveConfirmation from "./screens/ReceiveComfirmation";
+import FallBackCameraScreen from "./screens/ImportAccounts/FallBackCameraScreen";
 
 // TODO look into all FlowFixMe
 
@@ -209,6 +210,7 @@ const ImportAccounts = createStackNavigator(
       navigationOptions: TransparentHeaderNavigationOptions,
     },
     DisplayResult,
+    FallBackCameraScreen,
   },
   StackNavigatorConfig,
 );

--- a/src/screens/ImportAccounts/FallBackCamera.js
+++ b/src/screens/ImportAccounts/FallBackCamera.js
@@ -1,0 +1,21 @@
+/* @flow */
+import { PureComponent } from "react";
+import type { NavigationScreenProp } from "react-navigation";
+
+class FallBackCamera extends PureComponent<{
+  navigation: NavigationScreenProp<*>,
+}> {
+  componentDidMount() {
+    // TODO do it better way to not have flickering
+
+    const { navigation } = this.props;
+    // $FlowFixMe
+    navigation.replace("FallBackCameraScreen");
+  }
+
+  render() {
+    return null;
+  }
+}
+
+export default FallBackCamera;

--- a/src/screens/ImportAccounts/FallBackCameraScreen.android.js
+++ b/src/screens/ImportAccounts/FallBackCameraScreen.android.js
@@ -1,0 +1,135 @@
+/* @flow */
+import React, { PureComponent } from "react";
+import { translate, Trans } from "react-i18next";
+import { View, StyleSheet, AppState } from "react-native";
+import type { NavigationScreenProp } from "react-navigation";
+import OpenSettings from "react-native-open-settings";
+import i18next from "i18next";
+import Icon from "react-native-vector-icons/dist/Feather";
+import colors from "../../colors";
+import type { T } from "../../types/common";
+import LText from "../../components/LText";
+import BlueButton from "../../components/BlueButton";
+import HeaderRightClose from "../../components/HeaderRightClose";
+import FallbackCamera from "../../icons/FallbackCamera";
+
+type Props = {
+  navigation: NavigationScreenProp<*>,
+  t: T,
+};
+type State = {
+  appSTate: string,
+  openSettingsPressed: boolean,
+};
+class FallBackCameraScreen extends PureComponent<Props, State> {
+  state = {
+    appState: AppState.currentState,
+    openSettingsPressed: false,
+  };
+
+  static navigationOptions = ({
+    navigation,
+  }: {
+    navigation: NavigationScreenProp<*>,
+  }) => ({
+    title: i18next.t("account.import.fallback.header"),
+    headerRight: (
+      <HeaderRightClose
+        // $FlowFixMe
+        navigation={navigation.dangerouslyGetParent()}
+        color={colors.grey}
+      />
+    ),
+    headerLeft: null,
+  });
+
+  componentDidMount() {
+    AppState.addEventListener("change", this.handleAppStateChange);
+  }
+
+  componentWillUnmount() {
+    AppState.removeEventListener("change", this.handleAppStateChange);
+  }
+
+  handleAppStateChange = nextAppState => {
+    const { appState, openSettingsPressed } = this.state;
+    const { navigation } = this.props;
+    if (
+      appState.match(/inactive|background/) &&
+      nextAppState === "active" &&
+      openSettingsPressed
+    ) {
+      navigation.replace("ScanAccounts");
+    }
+    this.setState({ appState: nextAppState });
+  };
+
+  openNativeSettings = () => {
+    this.setState({ openSettingsPressed: true });
+    OpenSettings.openSettings();
+  };
+
+  render() {
+    const { t } = this.props;
+    return (
+      <View style={styles.root}>
+        <View style={styles.body}>
+          <FallbackCamera />
+          <LText secondary bold style={styles.title}>
+            {t("account.import.fallback.title")}
+          </LText>
+          <LText style={styles.desc}>
+            <Trans i18nKey="account.import.fallback.descAndroid">
+              {"To import account, Ledger Live needs to"}
+              <LText bold style={styles.descBold}>
+                {"access your camera"}
+              </LText>
+              {"You’ll be taken to Android settings to activate it"}
+            </Trans>
+          </LText>
+          <BlueButton
+            title={t("account.import.fallback.buttonAndroid")}
+            onPress={this.openNativeSettings}
+            containerStyle={styles.buttonContainer}
+            titleStyle={styles.buttonTitle}
+            iconLeft={<Icon name="settings" size={16} color={colors.white} />}
+          />
+        </View>
+      </View>
+    );
+  }
+}
+
+export default translate()(FallBackCameraScreen);
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  body: {
+    alignItems: "center",
+  },
+  title: {
+    marginTop: 40,
+    marginBottom: 16,
+    fontSize: 16,
+  },
+  desc: {
+    color: colors.grey,
+    marginHorizontal: 40,
+    textAlign: "center",
+    marginBottom: 48,
+  },
+  descBold: {
+    color: colors.black,
+  },
+  buttonContainer: {
+    height: 48,
+    width: 290,
+  },
+  buttonTitle: {
+    fontSize: 16,
+  },
+});

--- a/src/screens/ImportAccounts/FallBackCameraScreen.ios.js
+++ b/src/screens/ImportAccounts/FallBackCameraScreen.ios.js
@@ -1,0 +1,102 @@
+/* @flow */
+import React, { PureComponent } from "react";
+import { translate, Trans } from "react-i18next";
+import { View, StyleSheet, Linking } from "react-native";
+import type { NavigationScreenProp } from "react-navigation";
+import i18next from "i18next";
+import Icon from "react-native-vector-icons/dist/Feather";
+import colors from "../../colors";
+import type { T } from "../../types/common";
+import LText from "../../components/LText";
+import BlueButton from "../../components/BlueButton";
+import HeaderRightClose from "../../components/HeaderRightClose";
+import FallbackCamera from "../../icons/FallbackCamera";
+
+class FallBackCameraScreen extends PureComponent<{
+  navigation: NavigationScreenProp<*>,
+  t: T,
+}> {
+  static navigationOptions = ({
+    navigation,
+  }: {
+    navigation: NavigationScreenProp<*>,
+  }) => ({
+    title: i18next.t("account.import.fallback.header"),
+    headerRight: (
+      <HeaderRightClose
+        // $FlowFixMe
+        navigation={navigation.dangerouslyGetParent()}
+        color={colors.grey}
+      />
+    ),
+    headerLeft: null,
+  });
+
+  openNativeSettings = () => {
+    Linking.openURL("app-settings:");
+  };
+
+  render() {
+    const { t } = this.props;
+    return (
+      <View style={styles.root}>
+        <View style={styles.body}>
+          <FallbackCamera />
+          <LText secondary bold style={styles.title}>
+            {t("account.import.fallback.title")}
+          </LText>
+          <LText style={styles.desc}>
+            <Trans i18nKey="account.import.fallback.descIOS">
+              {"To import account, Ledger Live needs to"}
+              <LText bold style={styles.descBold}>
+                {"access your camera"}
+              </LText>
+              {"You’ll be taken to iOS settings to activate it"}
+            </Trans>
+          </LText>
+          <BlueButton
+            title={t("account.import.fallback.buttonIOS")}
+            onPress={this.openNativeSettings}
+            containerStyle={styles.buttonContainer}
+            titleStyle={styles.buttonTitle}
+            iconLeft={<Icon name="settings" size={16} color={colors.white} />}
+          />
+        </View>
+      </View>
+    );
+  }
+}
+
+export default translate()(FallBackCameraScreen);
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  body: {
+    alignItems: "center",
+  },
+  title: {
+    marginTop: 40,
+    marginBottom: 16,
+    fontSize: 16,
+  },
+  desc: {
+    color: colors.grey,
+    marginHorizontal: 40,
+    textAlign: "center",
+    marginBottom: 48,
+  },
+  descBold: {
+    color: colors.black,
+  },
+  buttonContainer: {
+    height: 48,
+    width: 290,
+  },
+  buttonTitle: {
+    fontSize: 16,
+  },
+});

--- a/src/screens/ImportAccounts/Scan.js
+++ b/src/screens/ImportAccounts/Scan.js
@@ -18,6 +18,7 @@ import HeaderRightClose from "../../components/HeaderRightClose";
 import StyledStatusBar from "../../components/StyledStatusBar";
 import LText, { getFontStyle } from "../../components/LText";
 import colors, { rgba } from "../../colors";
+import FallBackCamera from "./FallBackCamera";
 
 type Props = {
   navigation: NavigationScreenProp<*>,
@@ -125,7 +126,7 @@ class Scan extends PureComponent<
 
   render() {
     const { progress, width, height } = this.state;
-    const { t } = this.props;
+    const { t, navigation } = this.props;
 
     // Make the viewfinder borders 2/3 of the screen shortest border
     const viewFinderSize = (width > height ? height : width) * (2 / 3);
@@ -139,6 +140,7 @@ class Scan extends PureComponent<
           onBarCodeRead={this.onBarCodeRead}
           ratio="16:9"
           style={{ width, height }}
+          notAuthorizedView={<FallBackCamera navigation={navigation} />}
         >
           <View style={[styles.darken, styles.centered]}>
             <LText semibold style={styles.text}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6660,6 +6660,10 @@ react-native-modal@^6.5.0:
     prop-types "^15.6.1"
     react-native-animatable "^1.2.4"
 
+react-native-open-settings@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-open-settings/-/react-native-open-settings-1.0.1.tgz#1c0ae3d25fd3fd6de94b6d538333d47245cc5a0c"
+
 react-native-progress@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/react-native-progress/-/react-native-progress-3.5.0.tgz#d1ccc7f96dc17c609aedb43b2e6695d67deae0ec"


### PR DESCRIPTION
When we press on 'Deny' to reject camera access on Import Account it will go to an intermediary screen to display an option to open the settings of your phone in the directory of the Live app to allow camera from there. 
On navigation back to the app iOS natively refreshes and Android programmatically goes back to an appropriate page. 

Potential TODO: the camera prop for fallback requires an element and the fallback screen should be a proper screen with navigation and a header. Android and iOS also have different behavior in frequency of asking for permissions. All these constrains might bring slight flickering of the page, especially for Android. To be decided later if has to be changed.

Tested on iPhone X device and Android device.

## iOS
<img src="https://user-images.githubusercontent.com/10082039/45671568-00b7d880-bb26-11e8-8a4b-aac313bf8993.PNG" width="200"/>
