### PR TITLE
Improve performance of SectionHeader

### DIFF
--- a/src/components/SectionHeader.js
+++ b/src/components/SectionHeader.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React from "react";
+import React, { Component } from "react";
 import moment from "moment";
 import { StyleSheet } from "react-native";
 import colors from "../colors";
@@ -13,11 +13,26 @@ const calendarOpts = {
   sameElse: "LL",
 };
 
-export default ({ section }: { section: { day: Date } }) => (
-  <LText numberOfLines={1} semiBold style={styles.sectionHeader}>
-    {moment(section.day).calendar(null, calendarOpts)}
-  </LText>
-);
+type Props = {
+  section: {
+    day: Date,
+  },
+};
+
+export default class SectionHeader extends Component<Props> {
+  shouldComponentUpdate(nextProps: Props) {
+    return nextProps.section.day.getTime() !== this.props.section.day.getTime();
+  }
+
+  render() {
+    const { section } = this.props;
+    return (
+      <LText numberOfLines={1} semiBold style={styles.sectionHeader}>
+        {moment(section.day).calendar(null, calendarOpts)}
+      </LText>
+    );
+  }
+}
 
 const styles = StyleSheet.create({
   sectionHeader: {


### PR DESCRIPTION
after being able to profile JSC (via safari), i notice moment() was one of the highest CPU intensive work going on in JS thread, this was due to SectionHeader always being re-rendered. moment() has shown very bad perf (we had same problem on desktop) and we should really cache it as much as possible.

the scenario is to enter the app with 12 mock accounts, you go to Accounts screen, you open one Account, you close it, you pull to refresh.

profiler show that 15% of overall CPU was lost on setHours, setMinutes, setMilliseconds, ...   from moment()

<img width="1238" alt="capture d ecran 2018-09-18 a 19 08 14" src="https://user-images.githubusercontent.com/211411/45705621-5918c580-bb7a-11e8-81fc-02e609390ae1.png">


this tool is kinda cool but we'll need to try to run it in Prod build (not dev build, because lot of bad perf from React is going to be ok on Prod mode)

if we are careful enough and locate our code specific part of these profile, it's quite useful. in the "main functions" mode you can notice the highest time & on which function it was. and i definitely spotted our `mapStateToProps` from provideSummary there, even after my minimal optim of today, so we'll need to dig more on these.