### PR TITLE
CircleCI config for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/node:8-browsers
+
+    working_directory: ~/ledger-live-mobile
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      # run tests!
+      - run: yarn lint
+      - run: ./node_modules/.bin/prettier -l "src/**/*.js"
+      - run: yarn flow
+      - run: yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - "8"
-script:
-  - yarn lint
-  - yarn flow
-  - yarn test


### PR DESCRIPTION
CI validation for PR disappeared when the repo was switched to private, so I ported the old travis config to CircleCI (to stay consistent with the desktop app) in the perspective to restore it.

(Also I don't have admin rights on `LedgerHQ/ledger-live-mobile` for setting up the integration)