### PR TITLE
Refresh the account ordering more often (focus, open sort modal)

### DIFF
--- a/src/components/RefreshAccountOrdering.js
+++ b/src/components/RefreshAccountOrdering.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Component } from "react";
+import { PureComponent } from "react";
 import { connect } from "react-redux";
 import { refreshAccountsOrdering } from "../actions/general";
 
@@ -10,13 +10,20 @@ const mapDispatchToProps = {
   refreshAccountsOrdering,
 };
 
-class RefreshAccountsOrdering extends Component<{
+class RefreshAccountsOrdering extends PureComponent<{
   refreshAccountsOrdering: () => *,
   onMount?: boolean,
   onUnmount?: boolean,
+  onUpdate?: boolean,
 }> {
   componentDidMount() {
     if (this.props.onMount) {
+      this.props.refreshAccountsOrdering();
+    }
+  }
+
+  componentDidUpdate() {
+    if (this.props.onUpdate) {
       this.props.refreshAccountsOrdering();
     }
   }

--- a/src/screens/Accounts/AccountOrder.js
+++ b/src/screens/Accounts/AccountOrder.js
@@ -1,10 +1,21 @@
 // @flow
 
 import React, { PureComponent } from "react";
+import { withNavigationFocus } from "react-navigation";
 import Icon from "react-native-vector-icons/dist/Feather";
 import Touchable from "../../components/Touchable";
 import colors from "../../colors";
 import AccountOrderModal from "./AccountOrderModal";
+import RefreshAccountsOrdering from "../../components/RefreshAccountOrdering";
+
+// update at boot and each time focus or open state changes
+const RefreshAccounts = withNavigationFocus(({ isFocused, isOpened }) => (
+  <RefreshAccountsOrdering
+    onMount
+    onUpdate
+    nonce={`${isFocused}_${isOpened}`}
+  />
+));
 
 class AddAccount extends PureComponent<{}, { isOpened: boolean }> {
   state = {
@@ -20,6 +31,7 @@ class AddAccount extends PureComponent<{}, { isOpened: boolean }> {
     return (
       <Touchable style={{ marginHorizontal: 16 }} onPress={this.onPress}>
         <Icon name="sliders" color={colors.grey} size={20} />
+        <RefreshAccounts isOpened={isOpened} />
         <AccountOrderModal isOpened={isOpened} onClose={this.onClose} />
       </Touchable>
     );

--- a/src/screens/Accounts/index.js
+++ b/src/screens/Accounts/index.js
@@ -8,7 +8,6 @@ import type { Account } from "@ledgerhq/live-common/lib/types";
 import { accountsSelector } from "../../reducers/accounts";
 import AccountsIcon from "../../icons/Accounts";
 import provideSyncRefreshControl from "../../components/provideSyncRefreshControl";
-import RefreshAccountsOrdering from "../../components/RefreshAccountOrdering";
 import StyledStatusBar from "../../components/StyledStatusBar";
 import ImportedAccountsNotification from "../../components/ImportedAccountsNotification";
 import colors from "../../colors";
@@ -63,7 +62,6 @@ class Accounts extends Component<Props> {
     return (
       <Fragment>
         <StyledStatusBar backgroundColor={colors.white} />
-        <RefreshAccountsOrdering onMount />
         {enableImportNotif ? <ImportedAccountsNotification /> : null}
         <List
           data={accounts}


### PR DESCRIPTION
if you import accounts and countervalue are not yet loaded, your accounts were not properly sorted. the tradeoff is not to try to sort at any point in time, instead we attempt to do it at key point: when you open/close Accounts and when you open/close the sort action.