### PR TITLE
Integrate react-native-gesture-handler

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -178,6 +178,7 @@ configurations.all {
 }
 
 dependencies {
+    compile project(':react-native-gesture-handler')
     compile project(':react-native-open-settings')
     compile project(':react-native-config')
     compile project(':react-native-svg')

--- a/android/app/src/main/java/com/ledgerlivemobile/MainApplication.java
+++ b/android/app/src/main/java/com/ledgerlivemobile/MainApplication.java
@@ -3,6 +3,7 @@ package com.ledgerlivemobile;
 import android.app.Application;
 
 import com.facebook.react.ReactApplication;
+import com.swmansion.gesturehandler.react.RNGestureHandlerPackage;
 import com.opensettings.OpenSettingsPackage;
 import com.lugg.ReactNativeConfig.ReactNativeConfigPackage;
 import com.horcrux.svg.SvgPackage;
@@ -33,6 +34,7 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
+            new RNGestureHandlerPackage(),
             new OpenSettingsPackage(),
             new ReactNativeConfigPackage(),
             new SvgPackage(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'ledgerlivemobile'
+include ':react-native-gesture-handler'
+project(':react-native-gesture-handler').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-gesture-handler/android')
 include ':react-native-open-settings'
 project(':react-native-open-settings').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-open-settings/android')
 include ':react-native-config'

--- a/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		BF09D4F9214BF76B0040397B /* libTouchID.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 342B43652088E41C00E34118 /* libTouchID.a */; };
 		BF09D4FA214BF7730040397B /* libRNVectorIcons.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8FAC6EE921490C0C00FA9316 /* libRNVectorIcons.a */; };
 		BF60DBE7214A955600912E7C /* libART.a in Frameworks */ = {isa = PBXBuildFile; fileRef = BF60DBB5214A954900912E7C /* libART.a */; };
+		C1E2A1AC36C040B689A72E76 /* libRNGestureHandler.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 76B12D3F99F7436CAD186C2C /* libRNGestureHandler.a */; };
 		CA5797050376415D92BB71C6 /* FontAwesome.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 7850F04BA5D2428A9AC29653 /* FontAwesome.ttf */; };
 		D38D9E8A1BA34222AFFD6469 /* Octicons.ttf in Resources */ = {isa = PBXBuildFile; fileRef = C3CB4695C9554CACBA1EDD1F /* Octicons.ttf */; };
 		D5C1F1874ECE48F4AA5693AF /* MuseoSans-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = CEDB8CDC561E4D4BBA7A64CD /* MuseoSans-SemiBold.otf */; };
@@ -269,6 +270,13 @@
 			remoteGlobalIDString = EB2648DF1C7BE17A00B8F155;
 			remoteInfo = ReactNativeConfig;
 		};
+		34DE44042155286100259C93 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3E46E77C7D524ECDB200DA38 /* RNGestureHandler.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RNGestureHandler;
+		};
 		3DAD3E831DF850E9000B6D8A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 00C302BB1ABCB91800DB3ED1 /* RCTImage.xcodeproj */;
@@ -442,6 +450,7 @@
 		3263CCC7104E4B86AC2ADDB4 /* MuseoSans-Regular.otf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "MuseoSans-Regular.otf"; path = "../assets/fonts/MuseoSans-Regular.otf"; sourceTree = "<group>"; };
 		349F66542045ADCC002149B4 /* RNCamera.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RNCamera.xcodeproj; path = "../node_modules/react-native-camera/ios/RNCamera.xcodeproj"; sourceTree = "<group>"; };
 		3A45C4CF346C4C9594B2EC36 /* libRNVectorIcons.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNVectorIcons.a; sourceTree = "<group>"; };
+		3E46E77C7D524ECDB200DA38 /* RNGestureHandler.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNGestureHandler.xcodeproj; path = "../node_modules/react-native-gesture-handler/ios/RNGestureHandler.xcodeproj"; sourceTree = "<group>"; };
 		4396DC4264644851ADA99A35 /* MaterialCommunityIcons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = MaterialCommunityIcons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/MaterialCommunityIcons.ttf"; sourceTree = "<group>"; };
 		44387CB2EE84464C83A75FD7 /* OpenSans-Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = "OpenSans-Regular.ttf"; path = "../assets/fonts/OpenSans-Regular.ttf"; sourceTree = "<group>"; };
 		4AC7737A0FD34720B8F1599A /* SplashScreen.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = SplashScreen.xcodeproj; path = "../node_modules/react-native-splash-screen/ios/SplashScreen.xcodeproj"; sourceTree = "<group>"; };
@@ -455,6 +464,7 @@
 		64C6A31B337D471B93E32DCD /* RNSentry.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSentry.xcodeproj; path = "../node_modules/react-native-sentry/ios/RNSentry.xcodeproj"; sourceTree = "<group>"; };
 		66CCF21752714BD5AB584A88 /* RNSVG.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RNSVG.xcodeproj; path = "../node_modules/react-native-svg/ios/RNSVG.xcodeproj"; sourceTree = "<group>"; };
 		6DC818670C904605A8FBA62A /* FontAwesome5_Regular.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome5_Regular.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome5_Regular.ttf"; sourceTree = "<group>"; };
+		76B12D3F99F7436CAD186C2C /* libRNGestureHandler.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRNGestureHandler.a; sourceTree = "<group>"; };
 		7850F04BA5D2428A9AC29653 /* FontAwesome.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = FontAwesome.ttf; path = "../node_modules/react-native-vector-icons/Fonts/FontAwesome.ttf"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
 		793F2C3B8DC0475194262928 /* libRCTCamera.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTCamera.a; sourceTree = "<group>"; };
@@ -536,6 +546,7 @@
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
 				DEF1B1546B36491B9894A599 /* libz.tbd in Frameworks */,
 				7EDEA35621D64751B73F49C7 /* libReact Native Open Settings.a in Frameworks */,
+				C1E2A1AC36C040B689A72E76 /* libRNGestureHandler.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -681,6 +692,7 @@
 				E17D41657FAD4BEDBE62C1B2 /* libTouchID.a */,
 				3A45C4CF346C4C9594B2EC36 /* libRNVectorIcons.a */,
 				88F6163E74364066BC1A5713 /* libReact Native Open Settings.a */,
+				76B12D3F99F7436CAD186C2C /* libRNGestureHandler.a */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -730,6 +742,14 @@
 			isa = PBXGroup;
 			children = (
 				34BE1FF120092032009E8710 /* libReactNativeConfig.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		34DE44012155286100259C93 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				34DE44052155286100259C93 /* libRNGestureHandler.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -805,6 +825,7 @@
 				EE89361C161C48FB98136880 /* PasscodeAuth.xcodeproj */,
 				4AD2AECC687D45E9BBCCED05 /* RNVectorIcons.xcodeproj */,
 				A49125B8906C40DFB2011F37 /* React Native Open Settings.xcodeproj */,
+				3E46E77C7D524ECDB200DA38 /* RNGestureHandler.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -1044,6 +1065,10 @@
 					ProjectRef = 349F66542045ADCC002149B4 /* RNCamera.xcodeproj */;
 				},
 				{
+					ProductGroup = 34DE44012155286100259C93 /* Products */;
+					ProjectRef = 3E46E77C7D524ECDB200DA38 /* RNGestureHandler.xcodeproj */;
+				},
+				{
 					ProductGroup = 347AB1EC2049885900BE6F60 /* Products */;
 					ProjectRef = 64C6A31B337D471B93E32DCD /* RNSentry.xcodeproj */;
 				},
@@ -1260,6 +1285,13 @@
 			fileType = archive.ar;
 			path = libReactNativeConfig.a;
 			remoteRef = 34BE1FF020092032009E8710 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		34DE44052155286100259C93 /* libRNGestureHandler.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRNGestureHandler.a;
+			remoteRef = 34DE44042155286100259C93 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		3DAD3E841DF850E9000B6D8A /* libRCTImage-tvOS.a */ = {
@@ -1561,12 +1593,14 @@
 					"$(SRCROOT)/../node_modules/@ledgerhq/react-native-passcode-auth",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-open-settings",
+					"$(SRCROOT)/../node_modules/react-native-gesture-handler/ios/**",
 				);
 				INFOPLIST_FILE = ledgerlivemobileTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1600,12 +1634,14 @@
 					"$(SRCROOT)/../node_modules/@ledgerhq/react-native-passcode-auth",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-open-settings",
+					"$(SRCROOT)/../node_modules/react-native-gesture-handler/ios/**",
 				);
 				INFOPLIST_FILE = ledgerlivemobileTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 					"\"$(SRCROOT)/$(TARGET_NAME)\"",
 				);
 				OTHER_LDFLAGS = (
@@ -1643,6 +1679,7 @@
 					"$(SRCROOT)/../node_modules/@ledgerhq/react-native-passcode-auth",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-open-settings",
+					"$(SRCROOT)/../node_modules/react-native-gesture-handler/ios/**",
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
@@ -1684,6 +1721,7 @@
 					"$(SRCROOT)/../node_modules/@ledgerhq/react-native-passcode-auth",
 					"$(SRCROOT)/../node_modules/react-native-vector-icons/RNVectorIconsManager",
 					"$(SRCROOT)/../node_modules/react-native-open-settings",
+					"$(SRCROOT)/../node_modules/react-native-gesture-handler/ios/**",
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-native-ble-plx": "^0.10.0",
     "react-native-camera": "1.2.0",
     "react-native-config": "0.11.5",
+    "react-native-gesture-handler": "^1.0.7",
     "react-native-locale": "0.0.19",
     "react-native-modal": "^6.5.0",
     "react-native-open-settings": "^1.0.1",

--- a/src/components/GraphCard.js
+++ b/src/components/GraphCard.js
@@ -34,8 +34,6 @@ type Props = {
   t: T,
   summary: Summary,
   setSelectedTimeRange: string => void,
-  onPanResponderStart: () => *,
-  onPanResponderRelease: () => *,
   useCounterValue?: boolean,
   renderTitle?: ({ counterValueUnit: Unit, item: Item }) => React$Node,
 };
@@ -59,18 +57,8 @@ class GraphCard extends PureComponent<Props, State> {
 
   onItemHover = hoveredItem => this.setState({ hoveredItem });
 
-  onPanResponderRelease = () => {
-    this.props.onPanResponderRelease();
-    this.setState({ hoveredItem: null });
-  };
-
   render() {
-    const {
-      summary,
-      onPanResponderStart,
-      renderTitle,
-      useCounterValue,
-    } = this.props;
+    const { summary, renderTitle, useCounterValue } = this.props;
 
     const {
       accounts,
@@ -102,8 +90,6 @@ class GraphCard extends PureComponent<Props, State> {
           color={graphColor}
           data={balanceHistory}
           onItemHover={this.onItemHover}
-          onPanResponderStart={onPanResponderStart}
-          onPanResponderRelease={this.onPanResponderRelease}
           useCounterValue={useCounterValue}
         />
         <View style={styles.pillsContainer}>

--- a/src/screens/Account/index.js
+++ b/src/screens/Account/index.js
@@ -44,7 +44,6 @@ type Props = {
 
 type State = {
   opCount: number,
-  scrollEnabled: boolean,
 };
 
 const AnimatedSectionList = Animated.createAnimatedComponent(SectionList);
@@ -61,12 +60,7 @@ class AccountScreen extends PureComponent<Props, State> {
 
   state = {
     opCount: 100,
-    scrollEnabled: true,
   };
-
-  disableScroll = () => this.setState({ scrollEnabled: false });
-
-  enableScroll = () => this.setState({ scrollEnabled: true });
 
   keyExtractor = (item: Operation) => item.id;
 
@@ -110,13 +104,12 @@ class AccountScreen extends PureComponent<Props, State> {
 
   ListHeaderComponent = () => {
     const { summary } = this.props;
+    // TODO: we need to make a different GraphCard for Account screen:
+    // - we can optimize more (e.g. only need to calculate the balance of this account, which is cached btw. no need for countervalues and the more complex algo)
+    // - less if logic in graph (we shouldn't have magically guess if it's a "countervalue" mode or a "crypto" one)
+    // - the fact we want later to diverge both a bit (graph differ already, and later if we intro the idea to switch between modes)
     return (
-      <GraphCard
-        summary={summary}
-        onPanResponderStart={this.disableScroll}
-        onPanResponderRelease={this.enableScroll}
-        renderTitle={this.renderListHeaderTitle}
-      />
+      <GraphCard summary={summary} renderTitle={this.renderListHeaderTitle} />
     );
   };
 
@@ -149,7 +142,7 @@ class AccountScreen extends PureComponent<Props, State> {
 
   render() {
     const { account, navigation, syncState } = this.props;
-    const { opCount, scrollEnabled } = this.state;
+    const { opCount } = this.state;
 
     if (!account) return null;
 
@@ -173,7 +166,6 @@ class AccountScreen extends PureComponent<Props, State> {
           ref={this.ref}
           sections={sections}
           style={styles.sectionList}
-          scrollEnabled={scrollEnabled}
           ListFooterComponent={
             !completed
               ? LoadingFooter

--- a/src/screens/Portfolio/GraphCardContainer.js
+++ b/src/screens/Portfolio/GraphCardContainer.js
@@ -5,23 +5,10 @@ import type { Summary } from "../../components/provideSummary";
 import GraphCard from "../../components/GraphCard";
 import Greetings from "./Greetings";
 
-const GraphCardContainer = ({
-  summary,
-  onPanResponderStart,
-  onPanResponderRelease,
-}: {
-  summary: Summary,
-  onPanResponderStart: () => *,
-  onPanResponderRelease: () => *,
-}) => (
+const GraphCardContainer = ({ summary }: { summary: Summary }) => (
   <View>
     <Greetings nbAccounts={summary.accounts.length} />
-    <GraphCard
-      summary={summary}
-      useCounterValue
-      onPanResponderStart={onPanResponderStart}
-      onPanResponderRelease={onPanResponderRelease}
-    />
+    <GraphCard summary={summary} useCounterValue />
   </View>
 );
 

--- a/src/screens/Portfolio/index.js
+++ b/src/screens/Portfolio/index.js
@@ -58,7 +58,6 @@ class Portfolio extends Component<
   {
     opCount: number,
     scrollY: AnimatedValue,
-    scrollEnabled: boolean,
   },
 > {
   static navigationOptions = navigationOptions;
@@ -66,7 +65,6 @@ class Portfolio extends Component<
   state = {
     opCount: 50,
     scrollY: new Animated.Value(0),
-    scrollEnabled: true,
   };
 
   ref = React.createRef();
@@ -92,16 +90,8 @@ class Portfolio extends Component<
 
   keyExtractor = (item: Operation) => item.id;
 
-  disableScroll = () => this.setState({ scrollEnabled: false });
-
-  enableScroll = () => this.setState({ scrollEnabled: true });
-
   ListHeaderComponent = () => (
-    <GraphCardContainer
-      summary={this.props.summary}
-      onPanResponderStart={this.disableScroll}
-      onPanResponderRelease={this.enableScroll}
-    />
+    <GraphCardContainer summary={this.props.summary} />
   );
 
   renderItem = ({ item }: { item: Operation }) => {
@@ -129,7 +119,7 @@ class Portfolio extends Component<
 
   render() {
     const { summary, accounts, navigation } = this.props;
-    const { opCount, scrollY, scrollEnabled } = this.state;
+    const { opCount, scrollY } = this.state;
 
     if (accounts.length === 0) {
       return (
@@ -160,7 +150,6 @@ class Portfolio extends Component<
             stickySectionHeadersEnabled={false}
             showsVerticalScrollIndicator={false}
             scrollEventThrottle={16}
-            scrollEnabled={scrollEnabled}
             onScroll={Animated.event(
               [{ nativeEvent: { contentOffset: { y: scrollY } } }],
               { useNativeDriver: true },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6682,6 +6682,14 @@ react-native-drawer-layout@1.3.2:
   dependencies:
     react-native-dismiss-keyboard "1.0.0"
 
+react-native-gesture-handler@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.0.7.tgz#86677c709c42d04555210cad9759b09e2c657720"
+  dependencies:
+    hoist-non-react-statics "^2.3.1"
+    invariant "^2.2.2"
+    prop-types "^15.5.10"
+
 react-native-locale@0.0.19:
   version "0.0.19"
   resolved "https://registry.yarnpkg.com/react-native-locale/-/react-native-locale-0.0.19.tgz#336842dfb97510a539f98a39331fb7430acdc498"


### PR DESCRIPTION
the tradeoff here is to only start graph interaction after a X panning. the idea is to not trigger it at all if you are just scrolling or pull to refresh, which is most of the time.
The change here:
- simplify code
- fix race condition
- remove the hack to disable the scroll & solve it on native side