### PR TITLE
SVG optim (1)

### DIFF
--- a/src/components/Graph/Bar.js
+++ b/src/components/Graph/Bar.js
@@ -13,8 +13,6 @@ export type Item = {
 };
 
 type Props = {
-  x: number,
-  y: number,
   height: number,
   color: string,
 };
@@ -24,20 +22,20 @@ const FOCUS_RADIUS = 4;
 
 export default class Bar extends PureComponent<Props> {
   render() {
-    const { x, y, height, color } = this.props;
+    const { height, color } = this.props;
     return (
       <Fragment>
         <Line
-          x1={x}
-          x2={x}
-          y1={y}
+          x1={0}
+          x2={0}
+          y1={0}
           y2={height}
           stroke={rgba(color, 0.2)}
           strokeWidth={FOCUS_RADIUS}
         />
         <Circle
-          cx={x}
-          cy={y}
+          cx={0}
+          cy={0}
           r={5}
           stroke={color}
           strokeWidth={STROKE_WIDTH}

--- a/src/components/Graph/BarInteraction.js
+++ b/src/components/Graph/BarInteraction.js
@@ -1,0 +1,116 @@
+// @flow
+
+import React, { Component } from "react";
+import * as array from "d3-array";
+import { BigNumber } from "bignumber.js";
+import { View } from "react-native";
+import Svg, { G } from "react-native-svg";
+import { PanGestureHandler } from "react-native-gesture-handler";
+
+import Bar from "./Bar";
+
+export type Item = {
+  date: Date,
+  value: BigNumber,
+  originalValue: BigNumber,
+};
+
+type Props = {
+  width: number,
+  height: number,
+  data: Item[],
+  color: string,
+  useCounterValue: boolean,
+  onItemHover?: (?Item) => void,
+  children: *,
+  x: *,
+  y: *,
+};
+
+type State = {
+  barVisible: boolean,
+  barOffsetX: number,
+  barOffsetY: number,
+};
+
+const bisectDate = array.bisector(d => d.date).left;
+
+export default class BarInteraction extends Component<Props, State> {
+  state = {
+    barVisible: false,
+    barOffsetX: 0,
+    barOffsetY: 0,
+  };
+
+  collectHovered = (evt: *, isActive: boolean) => {
+    const { data, onItemHover, useCounterValue, x, y } = this.props;
+    const x0 = Math.round(evt.nativeEvent.x);
+    const hoveredDate = x.invert(x0);
+    const i = bisectDate(data, hoveredDate, 1);
+    const d0 = data[i - 1];
+    const d1 = data[i] || d0;
+    const xLeft = x(d0.date);
+    const xRight = x(d1.date);
+    const d = Math.abs(x0 - xLeft) < Math.abs(x0 - xRight) ? d0 : d1;
+    if (onItemHover) onItemHover(isActive ? d : null);
+    const value = (useCounterValue ? d.value : d.originalValue).toNumber();
+    return {
+      barOffsetX: x(d.date),
+      barOffsetY: y(value),
+    };
+  };
+
+  onHandlerStateChange = (e: *) => {
+    const barVisible = e.nativeEvent.numberOfPointers > 0;
+    const r = this.collectHovered(e, barVisible);
+    this.setState({
+      barVisible,
+      ...r,
+    });
+  };
+
+  onPanGestureEvent = (e: *) => {
+    const r = this.collectHovered(e, true);
+    this.setState(oldState => {
+      if (
+        oldState.barOffsetX === r.barOffsetX &&
+        oldState.barOffsetY === r.barOffsetY
+      ) {
+        return null; // do not setState if the position have not changed.
+      }
+      return r;
+    });
+  };
+
+  render() {
+    const { width, height, color, children } = this.props;
+    const { barVisible, barOffsetX, barOffsetY } = this.state;
+
+    return (
+      <PanGestureHandler
+        onHandlerStateChange={this.onHandlerStateChange}
+        onGestureEvent={this.onPanGestureEvent}
+        minDeltaX={10} // nb of pixel to wait before start point
+        maxDeltaY={20} // allow to scroll
+      >
+        <View style={{ width, height, position: "relative" }}>
+          {children}
+          <Svg
+            height={height}
+            width={width}
+            style={{
+              position: "absolute",
+              top: 0,
+              left: 0,
+              opacity: barVisible ? 1 : 0,
+            }}
+          >
+            <G x={barOffsetX} y={barOffsetY}>
+              <Bar height={height} color={color} />
+            </G>
+          </Svg>
+        </View>
+      </PanGestureHandler>
+    );
+  }
+}

--- a/src/components/Graph/index.js
+++ b/src/components/Graph/index.js
@@ -2,21 +2,17 @@
 
 // TODO
 // - render something else for non countervalues available case
-// - optim the interaction. just a translate !
 
 import React, { PureComponent } from "react";
-import * as array from "d3-array";
 import * as shape from "d3-shape";
 import * as scale from "d3-scale";
 import { BigNumber } from "bignumber.js";
-import { View } from "react-native";
 import maxBy from "lodash/maxBy";
 import Svg, { Path, Defs } from "react-native-svg";
-import { PanGestureHandler } from "react-native-gesture-handler";
 
 import colors from "../../colors";
 import DefGraph from "./DefGrad";
-import Bar from "./Bar";
+import BarInteraction from "./BarInteraction";
 
 export type Item = {
   date: Date,
@@ -34,72 +30,15 @@ type Props = {
   onItemHover?: (?Item) => void,
 };
 
-type State = {
-  barVisible: boolean,
-  barOffsetX: number,
-  barOffsetY: number,
-};
-
 const STROKE_WIDTH = 2;
 const FOCUS_RADIUS = 4;
-const bisectDate = array.bisector(d => d.date).left;
 
-export default class Graph extends PureComponent<Props, State> {
+export default class Graph extends PureComponent<Props> {
   static defaultProps = {
     data: [],
     color: colors.live,
     isInteractive: false,
     useCounterValue: false,
-  };
-
-  state = {
-    barVisible: false,
-    barOffsetX: 0,
-    barOffsetY: 0,
-  };
-
-  x: * = null;
-
-  y: * = null;
-
-  collectHovered = (evt: *, isActive: boolean) => {
-    const { data, onItemHover, useCounterValue } = this.props;
-    const x0 = Math.round(evt.nativeEvent.x);
-    const hoveredDate = this.x.invert(x0);
-    const i = bisectDate(data, hoveredDate, 1);
-    const d0 = data[i - 1];
-    const d1 = data[i] || d0;
-    const xLeft = this.x(d0.date);
-    const xRight = this.x(d1.date);
-    const d = Math.abs(x0 - xLeft) < Math.abs(x0 - xRight) ? d0 : d1;
-    if (onItemHover) onItemHover(isActive ? d : null);
-    const value = (useCounterValue ? d.value : d.originalValue).toNumber();
-    return {
-      barOffsetX: this.x(d.date),
-      barOffsetY: this.y(value),
-    };
-  };
-
-  onHandlerStateChange = (e: *) => {
-    const barVisible = e.nativeEvent.numberOfPointers > 0;
-    const r = this.collectHovered(e, barVisible);
-    this.setState({
-      barVisible,
-      ...r,
-    });
-  };
-
-  onPanGestureEvent = (e: *) => {
-    const r = this.collectHovered(e, true);
-    this.setState(oldState => {
-      if (
-        oldState.barOffsetX === r.barOffsetX &&
-        oldState.barOffsetY === r.barOffsetY
-      ) {
-        return null; // do not setState if the position have not changed.
-      }
-      return r;
-    });
   };
 
   render() {
@@ -110,71 +49,65 @@ export default class Graph extends PureComponent<Props, State> {
       color,
       isInteractive,
       useCounterValue,
+      onItemHover,
     } = this.props;
-    const { barVisible, barOffsetX, barOffsetY } = this.state;
 
     const maxY = useCounterValue
       ? maxBy(data, d => d.value.toNumber()).value.toNumber()
       : maxBy(data, d => d.originalValue.toNumber()).originalValue.toNumber();
 
     const yExtractor = useCounterValue
-      ? d => this.y(d.value.toNumber())
-      : d => this.y(d.originalValue.toNumber());
+      ? d => y(d.value.toNumber())
+      : d => y(d.originalValue.toNumber());
 
     const curve = useCounterValue ? shape.curveLinear : shape.curveStepBefore;
 
-    this.x = scale
+    const x = scale
       .scaleTime()
       .range([0, width])
       .domain([data[0].date, data[data.length - 1].date]);
 
-    this.y = scale
+    const y = scale
       .scaleLinear()
       .range([height - STROKE_WIDTH, STROKE_WIDTH + FOCUS_RADIUS])
       .domain([0, maxY]);
 
     const area = shape
       .area()
-      .x(d => this.x(d.date))
-      .y0(this.y(0))
+      .x(d => x(d.date))
+      .y0(y(0))
       .y1(yExtractor)
       .curve(curve)(data);
 
     const line = shape
       .line()
-      .x(d => this.x(d.date))
+      .x(d => x(d.date))
       .y(yExtractor)
       .curve(curve)(data);
 
     const content = (
-      <View style={{ width, height }}>
-        <Svg height={height} width={width}>
-          <Defs>
-            <DefGraph height={height} color={color} />
-          </Defs>
-          <Path d={area} fill="url(#grad)" />
-          <Path
-            d={line}
-            stroke={color}
-            strokeWidth={STROKE_WIDTH}
-            fill="none"
-          />
-          {!barVisible ? null : (
-            <Bar x={barOffsetX} y={barOffsetY} height={height} color={color} />
-          )}
-        </Svg>
-      </View>
+      <Svg height={height} width={width}>
+        <Defs>
+          <DefGraph height={height} color={color} />
+        </Defs>
+        <Path d={area} fill="url(#grad)" />
+        <Path d={line} stroke={color} strokeWidth={STROKE_WIDTH} fill="none" />
+      </Svg>
     );
 
     return isInteractive ? (
-      <PanGestureHandler
-        onHandlerStateChange={this.onHandlerStateChange}
-        onGestureEvent={this.onPanGestureEvent}
-        minDeltaX={10} // nb of pixel to wait before start point
-        maxDeltaY={20} // allow to scroll
+      <BarInteraction
+        width={width}
+        height={height}
+        data={data}
+        color={color}
+        useCounterValue={useCounterValue}
+        onItemHover={onItemHover}
+        x={x}
+        y={y}
       >
         {content}
-      </PanGestureHandler>
+      </BarInteraction>
     ) : (
       content
     );


### PR DESCRIPTION
this optimize a bit more the updates triggered when you pan over the graph

- 2 SVGs are now used. one for the graph itself, one for the interactive layer & the bar rendering.
- the bar is static, always positioned at 0,0. use a `<G>` to translate it for minimal update.

this is basically summarized by this update chart:

<img width="609" alt="capture d ecran 2018-09-21 a 17 23 38" src="https://user-images.githubusercontent.com/211411/45890383-20b7f800-bdc3-11e8-89c1-c0f0079ec66a.png">


on the left is the graph itself, it does not update during the interaction
on the right is the rendering, it is not re-updated


<img width="831" alt="capture d ecran 2018-09-21 a 17 29 17" src="https://user-images.githubusercontent.com/211411/45890699-e4d16280-bdc3-11e8-9201-ef51c10bbb7e.png">
