### PR TITLE
Fix #216 Make the package name consistent

### DIFF
--- a/android/app/BUCK
+++ b/android/app/BUCK
@@ -45,12 +45,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "com.ledgerlivemobile",
+    package = "com.ledger.live",
 )
 
 android_resource(
     name = "res",
-    package = "com.ledgerlivemobile",
+    package = "com.ledger.live",
     res = "src/main/res",
 )
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -111,7 +111,7 @@ android {
     buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        applicationId "com.ledgerlivemobile"
+        applicationId "com.ledger.live"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
@@ -119,7 +119,7 @@ android {
         ndk {
             abiFilters "armeabi-v7a", "x86"
         }
-        resValue "string", "build_config_package", "com.ledgerlivemobile"
+        resValue "string", "build_config_package", "com.ledger.live"
     }
     splits {
         abi {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.ledgerlivemobile">
+    package="com.ledger.live">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>

--- a/android/app/src/main/java/com/ledgerlivemobile/MainActivity.java
+++ b/android/app/src/main/java/com/ledgerlivemobile/MainActivity.java
@@ -1,4 +1,4 @@
-package com.ledgerlivemobile;
+package com.ledger.live;
 
 import android.os.Bundle;
 

--- a/android/app/src/main/java/com/ledgerlivemobile/MainApplication.java
+++ b/android/app/src/main/java/com/ledgerlivemobile/MainApplication.java
@@ -1,4 +1,4 @@
-package com.ledgerlivemobile;
+package com.ledger.live;
 
 import android.app.Application;
 

--- a/ios/ledgerlivemobile/Info.plist
+++ b/ios/ledgerlivemobile/Info.plist
@@ -24,7 +24,7 @@
 	<array>
 		<dict>
 			<key>CFBundleURLName</key>
-			<string>com.ledgerwallet</string>
+			<string>com.ledger.live</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>ledgerhq</string>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "react-native start",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
-    "staging-android": "ADB=$ANDROID_HOME/platform-tools/adb && cd android && ./gradlew assembleStagingRelease && $ADB install -r app/build/outputs/apk/stagingRelease/app-stagingRelease.apk && $ADB shell monkey -p com.ledgerlivemobile.staging 1",
+    "staging-android": "ADB=$ANDROID_HOME/platform-tools/adb && cd android && ./gradlew assembleStagingRelease && $ADB install -r app/build/outputs/apk/stagingRelease/app-stagingRelease.apk && $ADB shell monkey -p com.ledger.live.staging 1",
     "prettier": "prettier --write \"src/**/*.js\"",
     "lint": "eslint src",
     "flow": "flow",


### PR DESCRIPTION
The package name is now `com.ledger.live` everywhere (not only on iOS)