### PR TITLE
Debug screen to trigger various crashes

### DIFF
--- a/src/navigators.js
+++ b/src/navigators.js
@@ -42,6 +42,7 @@ import VerifyAddress from "./screens/VerifyAddress";
 import ReceiveConfirmation from "./screens/ReceiveComfirmation";
 import FallBackCameraScreen from "./screens/ImportAccounts/FallBackCameraScreen";
 import DebugBLE from "./screens/DebugBLE";
+import DebugCrash from "./screens/DebugCrash";
 import BenchmarkQRStream from "./screens/BenchmarkQRStream";
 
 // TODO look into all FlowFixMe
@@ -106,6 +107,8 @@ const SettingsStack = createStackNavigator(
     DebugSettings,
     // $FlowFixMe
     DebugBLE,
+    // $FlowFixMe
+    DebugCrash,
     // $FlowFixMe
     BenchmarkQRStream,
   },

--- a/src/screens/DebugCrash.js
+++ b/src/screens/DebugCrash.js
@@ -1,0 +1,90 @@
+// @flow
+
+import React, { Component } from "react";
+import { StyleSheet, View } from "react-native";
+import type { NavigationScreenProp } from "react-navigation";
+import { Sentry } from "react-native-sentry";
+
+import loadLibcore from "../libcore/load";
+
+import Button from "../components/Button";
+
+class DebugBLE extends Component<
+  {
+    navigation: NavigationScreenProp<*>,
+  },
+  {
+    renderCrash: boolean,
+  },
+> {
+  static navigationOptions = {
+    title: "Debug Crash",
+  };
+
+  state = {
+    renderCrash: false,
+  };
+
+  jsCrash = () => {
+    throw new Error("DEBUG jsCrash");
+  };
+
+  libcoreCrash = async () => {
+    const core = await loadLibcore();
+    await core.coreWalletPool.getWallet(null, null);
+  };
+
+  nativeCrash = () => {
+    Sentry.nativeCrash();
+  };
+
+  displayRenderCrash = () => this.setState({ renderCrash: true });
+
+  render() {
+    const { renderCrash } = this.state;
+    return (
+      <View style={styles.root}>
+        <Button
+          type="primary"
+          title="JS Crash"
+          onPress={this.jsCrash}
+          containerStyle={styles.buttonStyle}
+        />
+        <Button
+          type="primary"
+          title="Native Crash"
+          onPress={this.nativeCrash}
+          containerStyle={styles.buttonStyle}
+        />
+        <Button
+          type="primary"
+          title="Libcore Crash"
+          onPress={this.libcoreCrash}
+          containerStyle={styles.buttonStyle}
+        />
+        <Button
+          type="primary"
+          title="Render crashing component"
+          onPress={this.displayRenderCrash}
+          containerStyle={styles.buttonStyle}
+        />
+        {renderCrash && <CrashingComponent />}
+      </View>
+    );
+  }
+}
+
+const CrashingComponent = () => {
+  throw new Error("DEBUG renderCrash");
+};
+
+const styles = StyleSheet.create({
+  root: {
+    padding: 16,
+  },
+  buttonStyle: {
+    marginBottom: 16,
+  },
+});
+
+export default DebugBLE;

--- a/src/screens/Settings/Debug/OpenDebugCrash.js
+++ b/src/screens/Settings/Debug/OpenDebugCrash.js
@@ -1,0 +1,13 @@
+// @flow
+import React from "react";
+import { withNavigation } from "react-navigation";
+import SettingsRow from "../../../components/SettingsRow";
+
+const OpenDebugCrash = ({ navigation }: { navigation: * }) => (
+  <SettingsRow
+    title="Debug crash"
+    onPress={() => navigation.navigate("DebugCrash")}
+  />
+);
+
+export default withNavigation(OpenDebugCrash);

--- a/src/screens/Settings/Debug/index.js
+++ b/src/screens/Settings/Debug/index.js
@@ -9,6 +9,7 @@ import { accountsSelector } from "../../../reducers/accounts";
 import GenerateMockAccounts from "./GenerateMockAccounts";
 import ImportBridgeStreamData from "./ImportBridgeStreamData";
 import OpenDebugBLE from "./OpenDebugBLE";
+import OpenDebugCrash from "./OpenDebugCrash";
 import BenchmarkQRStream from "./BenchmarkQRStream";
 
 class DebugSettings extends PureComponent<{
@@ -35,6 +36,7 @@ class DebugSettings extends PureComponent<{
         ) : null}
         <OpenDebugBLE />
         <BenchmarkQRStream />
+        <OpenDebugCrash />
       </ScrollView>
     );
   }


### PR DESCRIPTION
closes #215

_“— I had a **crash** on this feature.” Anonymous_

So as the title describe, this PR implement a new screen where you can make the app crash in diverse ways, to see how the app will behave. It will be useful to see what Sentry is reporting out, especially with teh `Sentry.nativeCrash()` ([ref](https://github.com/getsentry/react-native-sentry#additional-device-information)) (unfortunately, mixed stacktraces are only available for iOS).

Quick preview:

![2018-10-03_568x487](https://user-images.githubusercontent.com/315259/46404800-8cc12700-c706-11e8-895d-14fc4eff5908.png)
