### PR TITLE
Fix iOS: fix simulator build 

### DIFF
--- a/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -477,8 +477,8 @@
 		B91C4698216812CD00E250AB /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
-			dstPath = x86;
-			dstSubfolderSpec = 7;
+			dstPath = x86_64;
+			dstSubfolderSpec = 10;
 			files = (
 				B91C46CC216812D800E250AB /* ledger-core.framework in Copy Files */,
 			);
@@ -1847,7 +1847,7 @@
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/Frameworks/x86 @executable_path/Frameworks/universal";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/Frameworks/x86_64 @executable_path/Frameworks/universal";
 				LIBRARY_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -1899,7 +1899,7 @@
 				);
 				INFOPLIST_FILE = ledgerlivemobile/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/Frameworks/x86 @executable_path/Frameworks/universal";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/Frameworks/x86_64 @executable_path/Frameworks/universal";
 				LIBRARY_SEARCH_PATHS = "";
 				OTHER_LDFLAGS = (
 					"$(inherited)",


### PR DESCRIPTION
x86 ledger-core.framework was copied to bundle resources instead of its frameworks