### PR TITLE
Bump react-native-ledger-core to prevent postinstall error

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@ledgerhq/live-common": "3.8.0",
     "@ledgerhq/react-native-hid": "4.21.0",
     "@ledgerhq/react-native-hw-transport-ble": "4.21.0",
-    "@ledgerhq/react-native-ledger-core": "^0.3.16",
+    "@ledgerhq/react-native-ledger-core": "^0.3.18",
     "@ledgerhq/react-native-passcode-auth": "2.0.0",
     "async": "^2.6.1",
     "bignumber.js": "^7.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,10 +1006,10 @@
     "@ledgerhq/hw-transport" "^4.21.0"
     invariant "^2.2.4"
 
-"@ledgerhq/react-native-ledger-core@^0.3.15":
-  version "0.3.15"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-0.3.15.tgz#ac95ceebb2a504303b0c47e0233dad8900f8b464"
-  integrity sha512-qcjO2uuvqshRkSAQ8Nm46NnVkV5JkGqA9QZ4pdBgHbWw/4T4HAJjEuu8LudQggA5cPB1SOTMQq3dZneE8/7Lew==
+"@ledgerhq/react-native-ledger-core@^0.3.18":
+  version "0.3.18"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-0.3.18.tgz#1a5a1fc43de0b3a14b6c7e69863591bd359e1ff5"
+  integrity sha512-JOxmo0Jmf6Izg5voxYQR1e8NcFg6L9YfF7274dpU3nT5eAyekW4gZ11V0GXFbkzqwq74UEpyfm8cDm7nlwlXJA==
 
 "@ledgerhq/react-native-passcode-auth@2.0.0":
   version "2.0.0"


### PR DESCRIPTION
This get rid of errors like

    mkdir: cannot create directory ‘ios/Frameworks/x86/ledger-core.framework’: File exists