### PR TITLE
Fix BottomTabBar label font-weight warning on Android

### DIFF
--- a/src/navigators.js
+++ b/src/navigators.js
@@ -150,7 +150,7 @@ AccountsStack.navigationOptions = {
 const labelStyle = {
   fontFamily: "Museo Sans",
   fontSize: 12,
-  fontWeight: Platform.OS === "android" ? "SemiBold" : "400",
+  fontWeight: "400",
 };
 
 const CustomTabBar = props => (


### PR DESCRIPTION
For ? reasons, a warning was occuring when using the value `SemiBold` on navigator BottomTabBar label. It's strange because we use this value in `getFontStyle.android.js`.

![2018-10-11_604x158](https://user-images.githubusercontent.com/315259/46795367-46914680-cd4a-11e8-9102-4e2abcffaa12.png)

So this quick workaround is to set a numeric value, I chose `400` as on iOS but it can be debated. cc @khalilbenihoud 

400 | 500
----|------
![2018-10-11_635x86](https://user-images.githubusercontent.com/315259/46795459-7fc9b680-cd4a-11e8-9843-2875fcb6f6d2.png) |  ![2018-10-11_632x90](https://user-images.githubusercontent.com/315259/46795471-848e6a80-cd4a-11e8-8efa-b6e1ddb8523f.png)

