### PR TITLE
Fixes BLE connect on Android

### DIFF
--- a/src/react-native-hw-transport-ble/BleTransport.js
+++ b/src/react-native-hw-transport-ble/BleTransport.js
@@ -216,7 +216,9 @@ export default class BluetoothTransport extends Transport<Device | string> {
       device = deviceOrId;
     }
 
-    await device.connect();
+    if (!(await device.isConnected())) {
+      await device.connect();
+    }
     await device.discoverAllServicesAndCharacteristics();
 
     const characteristics = await device.characteristicsForService(ServiceUuid);


### PR DESCRIPTION
NB: current implementation of BLETransport open() is very naïve and we'll need to implement smart things, figure out what is really necessary and also have a system that don't `disconnect()` at each t.close()