### PR TITLE
Correct height for CurrencyRow

### DIFF
--- a/src/components/CurrencyRow.js
+++ b/src/components/CurrencyRow.js
@@ -34,7 +34,7 @@ class CurrencyRow extends PureComponent<Props> {
 const styles = StyleSheet.create({
   root: {
     flexDirection: "row",
-    height: 40,
+    height: 48,
     alignItems: "center",
     paddingHorizontal: 16,
   },


### PR DESCRIPTION
fixes #377

before/after

![res](https://user-images.githubusercontent.com/315259/47615416-c50e1800-daae-11e8-9efe-fc4ce9daf3c0.jpg)
