### PR TITLE
fees edit unit drawer

### DIFF
--- a/src/components/CurrencyInput.js
+++ b/src/components/CurrencyInput.js
@@ -70,6 +70,7 @@ type Props = {
   renderRight?: any,
   renderError?: any,
   hasError: boolean,
+  autoFocus?: boolean,
 };
 
 type State = {
@@ -81,14 +82,13 @@ class CurrencyInput extends PureComponent<Props, State> {
   static defaultProps = {
     onFocus: noop,
     onChange: noop,
-    renderRight: noop,
-    renderError: noop,
     value: null,
     showAllDigits: false,
     subMagnitude: 0,
     allowZero: false,
     isActive: false,
     hasError: false,
+    autoFocus: false,
   };
 
   state = {
@@ -163,6 +163,7 @@ class CurrencyInput extends PureComponent<Props, State> {
       renderRight,
       renderError,
       hasError,
+      autoFocus,
     } = this.props;
     const { displayValue } = this.state;
     return (
@@ -175,6 +176,7 @@ class CurrencyInput extends PureComponent<Props, State> {
           ]}
           onChangeText={this.handleChange}
           value={displayValue}
+          autoFocus={autoFocus}
           onFocus={this.handleFocus}
           onBlur={this.handleBlur}
           placeholder={format(unit, BigNumber(0), {

--- a/src/families/EditFeeUnit.js
+++ b/src/families/EditFeeUnit.js
@@ -1,0 +1,193 @@
+/* @flow */
+import React, { PureComponent, Fragment } from "react";
+import { FlatList, View, StyleSheet, Keyboard } from "react-native";
+import type { NavigationScreenProp } from "react-navigation";
+import Icon from "react-native-vector-icons/dist/FontAwesome";
+import type { Account } from "@ledgerhq/live-common/lib/types";
+import { connect } from "react-redux";
+import { translate } from "react-i18next";
+import { BigNumber } from "bignumber.js";
+import { getAccountBridge } from "../bridge";
+import { updateAccount } from "../actions/accounts";
+import type { T } from "../types/common";
+import SettingsRow from "../components/SettingsRow";
+import LText from "../components/LText";
+import CurrencyInput from "../components/CurrencyInput";
+import Touchable from "../components/Touchable";
+import BottomModal from "../components/BottomModal";
+import Button from "../components/Button";
+import colors from "../colors";
+import CloseIcon from "../icons/Close";
+
+type Props = {
+  updateAccount: Function,
+  account: Account,
+  t: T,
+  transaction: *,
+  navigation: NavigationScreenProp<*>,
+};
+
+type State = {
+  fee: ?BigNumber,
+  isModalOpened: boolean,
+};
+
+const mapDispatchToProps = {
+  updateAccount,
+};
+class EditFeeUnit extends PureComponent<Props, State> {
+  constructor({ account, transaction }) {
+    super();
+    const bridge = getAccountBridge(account);
+    this.state = {
+      fee: bridge.getTransactionExtra(account, transaction, "fee"),
+      isModalOpened: false,
+    };
+  }
+
+  onRequestClose = () => {
+    this.setState({ isModalOpened: false });
+  };
+  onPress = () => {
+    this.setState({ isModalOpened: true });
+  };
+
+  keyExtractor = (item: any) => item.code;
+  onChange = (fee: ?BigNumber) => this.setState({ fee });
+  updateAccount = (item: any) => {
+    const { account, updateAccount } = this.props;
+    const updatedAccount = {
+      ...account,
+      unit: item,
+    };
+    updateAccount(updatedAccount);
+  };
+
+  onValidateFees = () => {
+    const { navigation, account } = this.props;
+    const { fee } = this.state;
+    const bridge = getAccountBridge(account);
+    const transaction = navigation.getParam("transaction");
+    Keyboard.dismiss();
+
+    navigation.navigate("SendSummary", {
+      accountId: account.id,
+      transaction: bridge.editTransactionExtra(
+        account,
+        transaction,
+        "fee",
+        fee,
+      ),
+    });
+  };
+
+  render() {
+    const { account, t } = this.props;
+    const { isModalOpened, fee } = this.state;
+    return (
+      <Fragment>
+        <View style={styles.inputContainer}>
+          <View style={styles.inputRow}>
+            <CurrencyInput
+              autoFocus
+              unit={account.unit}
+              value={fee}
+              onChange={this.onChange}
+            />
+            <Touchable onPress={this.onPress} style={styles.unitContainer}>
+              <View style={styles.unitSelectRow}>
+                <LText secondary semiBold style={styles.unitStyle}>
+                  {account.unit.code}
+                </LText>
+                <View style={styles.arrowDown}>
+                  <Icon name="angle-down" size={12} />
+                </View>
+              </View>
+            </Touchable>
+          </View>
+          <View style={styles.buttonContainer}>
+            <Button
+              type="primary"
+              title={t("common.confirm")}
+              containerStyle={styles.continueButton}
+              onPress={this.onValidateFees}
+            />
+          </View>
+        </View>
+        <BottomModal isOpened={isModalOpened} onClose={this.onRequestClose}>
+          <View style={styles.editFeesUnitsModalTitleRow}>
+            <LText secondary semiBold style={styles.editFeesUnitModalTitle}>
+              {t("send.fees.edit.title")}
+            </LText>
+            <Touchable
+              style={{ position: "absolute", top: 2, right: 16 }}
+              onPress={this.onRequestClose}
+            >
+              <CloseIcon size={16} color={colors.grey} />
+            </Touchable>
+          </View>
+          <FlatList
+            data={account.currency.units}
+            keyExtractor={this.keyExtractor}
+            renderItem={({ item }) => (
+              <Touchable
+                onPress={() => {
+                  this.updateAccount(item);
+                }}
+              >
+                <SettingsRow
+                  title={item.code}
+                  selected={account.unit.code === item.code}
+                />
+              </Touchable>
+            )}
+          >
+            {account.unit.code}
+          </FlatList>
+        </BottomModal>
+      </Fragment>
+    );
+  }
+}
+export default connect(
+  null,
+  mapDispatchToProps,
+)(translate()(EditFeeUnit));
+
+const styles = StyleSheet.create({
+  buttonContainer: {
+    flex: 1,
+    padding: 16,
+    justifyContent: "flex-end",
+  },
+  continueButton: {
+    alignSelf: "stretch",
+  },
+  inputContainer: {
+    flex: 1,
+    padding: 16,
+  },
+  inputRow: {
+    flexDirection: "row",
+  },
+  unitContainer: {
+    justifyContent: "center",
+  },
+  unitStyle: {
+    marginRight: 8,
+  },
+  unitSelectRow: {
+    flexDirection: "row",
+  },
+  arrowDown: {
+    justifyContent: "center",
+  },
+  editFeesUnitModalTitle: {
+    fontSize: 16,
+  },
+  editFeesUnitsModalTitleRow: {
+    flexDirection: "row",
+    marginTop: 16,
+    justifyContent: "center",
+  },
+});

--- a/src/families/ripple/RippleFeeRow.js
+++ b/src/families/ripple/RippleFeeRow.js
@@ -47,10 +47,7 @@ export default class RippleFeeRow extends Component<Props> {
           <View style={styles.accountContainer}>
             {fee ? (
               <LText style={styles.valueText}>
-                <CurrencyUnitValue
-                  unit={account.currency.units[0]}
-                  value={fee}
-                />
+                <CurrencyUnitValue unit={account.unit} value={fee} />
               </LText>
             ) : null}
 

--- a/src/families/ripple/ScreenEditFee.js
+++ b/src/families/ripple/ScreenEditFee.js
@@ -1,27 +1,19 @@
 // @flow
 import React, { Component } from "react";
-import {
-  SafeAreaView,
-  View,
-  StyleSheet,
-  TouchableWithoutFeedback,
-  Keyboard,
-} from "react-native";
+import { SafeAreaView, StyleSheet } from "react-native";
 import { connect } from "react-redux";
-import { translate } from "react-i18next";
+import i18next from "i18next";
 import { createStructuredSelector } from "reselect";
 import type { NavigationScreenProp } from "react-navigation";
 import type { Account } from "@ledgerhq/live-common/lib/types";
-import { BigNumber } from "bignumber.js";
 
 import colors from "../../colors";
 import { accountScreenSelector } from "../../reducers/accounts";
-import { getAccountBridge } from "../../bridge";
 import type { Transaction } from "../../bridge/RippleJSBridge";
+import type { T } from "../../types/common";
 
-import CurrencyInput from "../../components/CurrencyInput";
-import Button from "../../components/Button";
 import KeyboardView from "../../components/KeyboardView";
+import EditFeeUnit from "../EditFeeUnit";
 
 type Props = {
   account: Account,
@@ -31,71 +23,27 @@ type Props = {
       transaction: Transaction,
     },
   }>,
-};
-type State = {
-  fee: ?BigNumber,
+  updateAccount: Function,
+  t: T,
 };
 
-class RippleEditFee extends Component<Props, State> {
+class RippleEditFee extends Component<Props> {
   static navigationOptions = {
-    title: "Edit fees",
-  };
-
-  constructor({ account, navigation }) {
-    super();
-    const bridge = getAccountBridge(account);
-    const transaction = navigation.getParam("transaction");
-    this.state = {
-      fee: bridge.getTransactionExtra(account, transaction, "fee"),
-    };
-  }
-
-  onChange = (fee: ?BigNumber) => this.setState({ fee });
-
-  onValidateFees = () => {
-    const { navigation, account } = this.props;
-    const { fee } = this.state;
-    const bridge = getAccountBridge(account);
-    const transaction = navigation.getParam("transaction");
-    Keyboard.dismiss();
-
-    navigation.navigate("SendSummary", {
-      accountId: account.id,
-      transaction: bridge.editTransactionExtra(
-        account,
-        transaction,
-        "fee",
-        fee,
-      ),
-    });
+    title: i18next.t("send.fees.title"),
   };
 
   render() {
     const { navigation, account } = this.props;
-    const { fee } = this.state;
     const transaction: Transaction = navigation.getParam("transaction");
     if (!transaction) return null;
     return (
       <SafeAreaView style={styles.root}>
         <KeyboardView style={styles.container}>
-          <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
-            <View style={{ flex: 1 }}>
-              <CurrencyInput
-                unit={account.unit}
-                value={fee}
-                onChange={this.onChange}
-              />
-
-              <View style={styles.buttonContainer}>
-                <Button
-                  type="primary"
-                  title="Validate Fees"
-                  containerStyle={styles.continueButton}
-                  onPress={this.onValidateFees}
-                />
-              </View>
-            </View>
-          </TouchableWithoutFeedback>
+          <EditFeeUnit
+            account={account}
+            transaction={transaction}
+            navigation={navigation}
+          />
         </KeyboardView>
       </SafeAreaView>
     );
@@ -107,14 +55,6 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.white,
   },
-  buttonContainer: {
-    flex: 1,
-    padding: 16,
-    justifyContent: "flex-end",
-  },
-  continueButton: {
-    alignSelf: "stretch",
-  },
   container: {
     flex: 1,
   },
@@ -124,4 +64,4 @@ const mapStateToProps = createStructuredSelector({
   account: accountScreenSelector,
 });
 
-export default connect(mapStateToProps)(translate()(RippleEditFee));
+export default connect(mapStateToProps)(RippleEditFee);

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -12,7 +12,8 @@
     "contactUs": "Contact us",
     "noCryptoFound": "No crypto assets found",
     "edit": "Edit",
-    "close": "Close"
+    "close": "Close",
+    "confirm": "Confirm",
   },
   "errors": {
     "AccountNameRequired": {
@@ -501,6 +502,12 @@
       "button": {
         "details": "View details",
         "retry": "Retry"
+      }
+    },
+    "fees": {
+      "title": "Network fees",
+      "edit": {
+        "title": "Choose Unit"
       }
     }
   },


### PR DESCRIPTION
Added a flat list drawer to Edit Fee Unit. Separated it out so it can be re-used for other families when we have it.

<image src="https://user-images.githubusercontent.com/10082039/47995543-f06bb500-e0f5-11e8-94e8-16cd89e71ed0.PNG" width="200" />

Selected row on the drawer is done with just select icon, consistent with all other select rows. 