### PR TITLE
Fixes libcore android usage + kill toLong code + use Account/Operation

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ledgerhq/hw-transport-http": "^4.29.0",
     "@ledgerhq/live-common": "^4.1.4",
     "@ledgerhq/react-native-hid": "^4.21.0",
-    "@ledgerhq/react-native-ledger-core": "^0.3.24",
+    "@ledgerhq/react-native-ledger-core": "^0.3.26",
     "@ledgerhq/react-native-passcode-auth": "^2.0.0",
     "@tradle/react-native-http": "^2.0.0",
     "assert": "^1.4.1",

--- a/src/libcore/specific.android.js
+++ b/src/libcore/specific.android.js
@@ -12,11 +12,6 @@ export const getNativeModule = (name: string) => NativeModules[`Core${name}`];
 
 export const getValue = (obj: any) => obj;
 
-export const OperationTypeMap = {
-  SEND: "OUT",
-  RECEIVE: "IN",
-};
-
 /* eslint-disable */
 export const getBlockHeightForAccount = async (core: *, coreAccount: *) => {
   const coreBlock = await core.coreAccount.getLastBlock(coreAccount);

--- a/src/libcore/specific.ios.js
+++ b/src/libcore/specific.ios.js
@@ -18,11 +18,6 @@ export const getNativeModule = (name: string) => NativeModules[`CoreLG${name}`];
 // FIXME we should drop this need!
 export const getValue = (obj: any) => obj.value;
 
-export const OperationTypeMap = {
-  "0": "OUT",
-  "1": "IN",
-};
-
 export const getBlockHeightForAccount = async (core: *, coreAccount: *) => {
   const coreBlock = await core.coreAccount.getLastBlock(coreAccount);
   const blockHeightRes = await core.coreBlock.getHeight(coreBlock);

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,10 +821,10 @@
   dependencies:
     "@ledgerhq/hw-transport" "^4.24.0"
 
-"@ledgerhq/react-native-ledger-core@^0.3.24":
-  version "0.3.25"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-0.3.25.tgz#19b60bdb5ac9dd3312713e86df6bce2097400eb3"
-  integrity sha512-o06E2kBfvjDrU72HDuOCSbNPjypb7FO2zN46CsiqogXjnHOy92BNLXza8wOi2dWD26FoN6Pu0UUUNLKcU8KA7A==
+"@ledgerhq/react-native-ledger-core@^0.3.26":
+  version "0.3.26"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-0.3.26.tgz#994bb7c63cd525bad52a5f780fa3bc2a4a83cef2"
+  integrity sha512-TppnzfRfrmgBexRF2GUiuWwT0s+EIa8cDx2tT3vCEDukjjv73RAw8W2EAdGEdIrD/TJ0Zug/7xx7V01vwO5JbA==
 
 "@ledgerhq/react-native-passcode-auth@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
- new version of libcore had regression on android. now fixed.
- we were still using toLong() in the sync code, which is wrong because we lose JS number precision
- we were still using AccountRaw and OperationRaw which would have been quite costy specifically for the fact we use bignumber (conversions everytime we do a sync).. this is just the beginning of optim explained in #378 (we'll see later for the other optims)
- OperationTypeMap is now identical between ios and android