### PR TITLE
Introduce core.modern

### DIFF
--- a/src/libcore/load.js
+++ b/src/libcore/load.js
@@ -95,5 +95,23 @@ async function loadCore() {
     console.log({ core }); // eslint-disable-line
   }
 
+  // PoC of a "modern" view of libcore. eventually we should switch over
+  const modern = {};
+  modules.forEach(m => {
+    const native = getNativeModule(m);
+    const decorate = instance => {
+      const proto = {};
+      Object.keys(native).forEach(k => {
+        proto[k] = (...arg) => {
+          const res = native[k].call(native, instance, ...arg);
+          return res;
+        };
+      });
+      return Object.create(proto, instance);
+    };
+    modern[m] = decorate;
+  });
+  core.modern = modern;
+
   return core;
 }


### PR DESCRIPTION
This is a PoC that decorates libcore interface into a more prototype based one.
i've not tested it much but should work^^

we can decorate all place where we get instances from libcore, for instance:

```
coreAccount = core.modern.Account(await core.coreWallet.getAccount(coreWallet, index));
```

and then you can directly do things like

```
await coreAccount.synchronize();
```

and no longer

```
await core.coreAccount.synchronize(coreAccount);
```

ultimately we would no longer use the low level core.core* objects because everything can be moved in modern but that means figure out how to define the mapping (and that will require specific code unless we can infer the type from the id itself and automatically decorate it? problem is sometimes it's an array of ids, like for inputs – anyway it could be more or less automatic)


