### PR TITLE
Prevent the getDouble error in coreExtendedKeyAccountCreationInfo

### DIFF
--- a/src/libcore/index.js
+++ b/src/libcore/index.js
@@ -199,9 +199,10 @@ const getOrCreateAccount = atomicQueue(
         index,
       );
 
-      const infosIndex = getValue(
-        await core.coreExtendedKeyAccountCreationInfo.getIndex(extendedInfos),
-      );
+      const infosIndex = (await core.coreExtendedKeyAccountCreationInfo.getIndex(
+        extendedInfos,
+      )).value; // TODO get rid of .value
+
       const extendedKeys = getValue(
         await core.coreExtendedKeyAccountCreationInfo.getExtendedKeys(
           extendedInfos,


### PR DESCRIPTION
We were sending an object to `coreExtendedKeyAccountCreationInfo` instead of the value of `infosIndex`