### PR TITLE
broadcast success prevent gesture swipe and navigation back

### DIFF
--- a/src/screens/SendFunds/07-ValidationSuccess.js
+++ b/src/screens/SendFunds/07-ValidationSuccess.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { Component } from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, BackHandler } from "react-native";
 import { connect } from "react-redux";
 import { translate } from "react-i18next";
 import type { NavigationScreenProp } from "react-navigation";
@@ -26,8 +26,14 @@ type Props = {
 class ValidationSuccess extends Component<Props> {
   static navigationOptions = {
     header: null,
+    gesturesEnabled: false,
   };
-
+  componentDidMount() {
+    BackHandler.addEventListener("hardwareBackPress", () => true);
+  }
+  componentWillUnmount() {
+    BackHandler.removeEventListener("hardwareBackPress");
+  }
   dismiss = () => {
     const { navigation } = this.props;
     if (navigation.dismiss) {


### PR DESCRIPTION
When transaction was broadcasted successfully on iOS it was possible to swipe back and on Android it was possible to navigate back with the back button. This PR fixes both cases.