### PR TITLE
Bump libcore and fix some tx cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ledgerhq/hw-transport-http": "^4.29.0",
     "@ledgerhq/live-common": "^4.4.2",
     "@ledgerhq/react-native-hid": "^4.21.0",
-    "@ledgerhq/react-native-ledger-core": "^0.3.30",
+    "@ledgerhq/react-native-ledger-core": "^0.3.32",
     "@ledgerhq/react-native-passcode-auth": "^2.0.0",
     "@tradle/react-native-http": "^2.0.0",
     "assert": "^1.4.1",

--- a/src/libcore/index.js
+++ b/src/libcore/index.js
@@ -415,9 +415,9 @@ async function buildOperation({
   const coreFee = await core.coreOperation.getFees(coreOperation);
   const fee = await libcoreAmountToBigNumber(core, coreFee);
 
-  const { value: blockHeight } = await core.coreOperation.getBlockHeight(
-    coreOperation,
-  );
+  // if tx is pending, libcore returns null (not wrapped with `value`)
+  const blockHeightRes = await core.coreOperation.getBlockHeight(coreOperation);
+  const blockHeight = blockHeightRes ? blockHeightRes.value : null;
 
   const [{ value: recipients }, { value: senders }] = await Promise.all([
     core.coreOperation.getRecipients(coreOperation),

--- a/src/libcore/signAndBroadcast.js
+++ b/src/libcore/signAndBroadcast.js
@@ -180,7 +180,9 @@ async function signTransaction({
     );
     if (isCancelled()) return;
 
-    if (derivationPath.uid) {
+    const isDerivationPathNull = await core.coreDerivationPath.isNull(derivationPath);
+
+    if (!isDerivationPathNull && derivationPath.uid) {
       const strDerivationPath = (await core.coreDerivationPath.toString(
         derivationPath,
       )).value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -822,10 +822,10 @@
   dependencies:
     "@ledgerhq/hw-transport" "^4.24.0"
 
-"@ledgerhq/react-native-ledger-core@^0.3.30":
-  version "0.3.30"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-0.3.30.tgz#d7af9771648f4b9381d6400af3bc1154e5fa9139"
-  integrity sha512-20BRCboVMwedxnAnyNHOnwSgWMAjcQk+WU/62y9eahEUSUt32XfE/VFjaWGnWJt0EgA94/Td/ZUj2e7rkwWl8g==
+"@ledgerhq/react-native-ledger-core@^0.3.32":
+  version "0.3.32"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-0.3.32.tgz#ed176752ad0e7ef9dbf9ce25b5a79d7176cf2a4e"
+  integrity sha512-ZocuHoPYP9BMXu7jWf9CkwCkkI/6LLkObS3lfWiaZzpHyBgmZ5rVrwiKvG5QaLEz6G1tkzCl9DCovMhuQqz7Mw==
 
 "@ledgerhq/react-native-passcode-auth@^2.0.0":
   version "2.0.0"


### PR DESCRIPTION
this fixes:

- LL-198 : Operations date time is incorrect on Android app
- LL-32 : Operation not confirmed, wrong operation state picture

and also error that was occuring when tx outputs derivationPaths are null (this case is handled on desktop, the code just wasnt't being ported from it)