### PR TITLE
Connect Pairing with the Onboarding

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -695,6 +695,7 @@
   },
   "SelectDevice": {
     "deviceNotFoundPairNewDevice": "Pair a new device",
+    "chooseYourDevice": "Choose your device",
     "headerDescription": "Turn on your Nano X and the bluetooth on your phone",
     "steps": {
       "connecting": {

--- a/src/screens/Onboarding/index.js
+++ b/src/screens/Onboarding/index.js
@@ -13,6 +13,7 @@ import OnboardingStepShareData from "./steps/share-data";
 import OnboardingStepScanQR from "./steps/scan-qr";
 import OnboardingStepFinish from "./steps/finish";
 import ImportAccounts from "../ImportAccounts/importAccountsNavigator";
+import PairDevices from "../PairDevices";
 
 const OnboardingStack = createStackNavigator({
   OnboardingStepGetStarted,
@@ -25,9 +26,14 @@ const OnboardingStack = createStackNavigator({
   OnboardingStepPassword,
   OnboardingStepShareData,
   OnboardingStepFinish,
+
+  // this screens are dependencies of other screens
   ImportAccounts,
+  PairDevices,
 });
 
-OnboardingStack.navigationOptions = { header: null };
+OnboardingStack.navigationOptions = {
+  header: null,
+};
 
 export default OnboardingStack;

--- a/src/screens/Onboarding/steps/pair-new.js
+++ b/src/screens/Onboarding/steps/pair-new.js
@@ -1,20 +1,21 @@
 // @flow
 
-import React, { Component, PureComponent } from "react";
+import React, { Component } from "react";
 import { Trans } from "react-i18next";
-import { StyleSheet, View, TouchableOpacity, Linking } from "react-native";
-import Icon from "react-native-vector-icons/dist/Feather";
+import { StyleSheet, TouchableOpacity, Linking } from "react-native";
 
+import SelectDevice from "../../../components/SelectDevice";
+import {
+  connectingStep,
+  dashboard,
+  genuineCheck,
+} from "../../../components/DeviceJob/steps";
 import LText from "../../../components/LText";
-import Button from "../../../components/Button";
-import Rounded from "../../../components/Rounded";
-import Circle from "../../../components/Circle";
 import IconExternalLink from "../../../icons/ExternalLink";
 import OnboardingLayout from "../OnboardingLayout";
 import { withOnboardingContext } from "../onboardingContext";
-import colors, { rgba } from "../../../colors";
+import colors from "../../../colors";
 import { urls } from "../../../config/urls";
-import { deviceNames } from "../../../wording";
 
 import type { OnboardingStepProps } from "../types";
 
@@ -44,47 +45,20 @@ class OnboardingStepPairNew extends Component<OnboardingStepProps> {
   pairNew = () => this.props.navigation.navigate("PairDevices");
 
   render() {
+    const { next } = this.props;
     return (
       <OnboardingLayout
         header="OnboardingStepPairNew"
         Footer={this.Footer}
         borderedFooter
+        noHorizontalPadding
+        noTopPadding
       >
-        <View style={styles.hero}>
-          <Rounded bg={colors.pillActiveBackground}>
-            <Icon name="bluetooth" color={colors.live} size={28} />
-          </Rounded>
-        </View>
-        <LText semiBold style={styles.desc}>
-          <Trans
-            i18nKey="onboarding.stepPairNew.desc"
-            values={deviceNames.nanoX}
-          />
-        </LText>
-        <Cta onPress={this.pairNew} />
-        <Button
-          type="secondary"
-          title="skip this step"
-          containerStyle={{ marginTop: 24 }}
-          onPress={this.props.next}
+        <SelectDevice
+          onSelect={next}
+          steps={[connectingStep, dashboard, genuineCheck]}
         />
       </OnboardingLayout>
-    );
-  }
-}
-
-class Cta extends PureComponent<{ onPress: () => any }> {
-  render() {
-    const { onPress } = this.props;
-    return (
-      <TouchableOpacity style={styles.cta} onPress={onPress}>
-        <Circle size={32} bg={rgba(colors.live, 0.1)}>
-          <Icon name="plus" color={colors.live} size={16} />
-        </Circle>
-        <LText style={styles.ctaText} semiBold>
-          <Trans i18nKey="onboarding.stepPairNew.pairNew" />
-        </LText>
-      </TouchableOpacity>
     );
   }
 }

--- a/src/screens/PairDevices/index.js
+++ b/src/screens/PairDevices/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { Component } from "react";
+import i18next from "i18next";
 import { View, StyleSheet } from "react-native";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";
@@ -17,6 +18,7 @@ import genuineCheck from "../../logic/hw/theRealGenuineCheck";
 import getDeviceInfo from "../../logic/hw/getDeviceInfo";
 import colors from "../../colors";
 import RequiresBLE from "../../components/RequiresBLE";
+import HeaderRightClose from "../../components/HeaderRightClose";
 import PendingContainer from "./PendingContainer";
 import PendingPairing from "./PendingPairing";
 import PendingGenuineCheck from "./PendingGenuineCheck";
@@ -24,6 +26,7 @@ import Paired from "./Paired";
 import Scanning from "./Scanning";
 import ScanningTimeout from "./ScanningTimeout";
 import RenderError from "./RenderError";
+import { navigationOptions } from "../../navigation/navigatorConfig";
 
 type Props = {
   navigation: NavigationScreenProp<*>,
@@ -169,11 +172,21 @@ class PairDevices extends Component<Props, State> {
   }
 }
 
+type NavOptsProps = { navigation: NavigationScreenProp<*> };
+const hackyNavigationOptions = ({ navigation }: NavOptsProps) => ({
+  ...navigationOptions,
+  title: i18next.t("SelectDevice.chooseYourDevice"),
+  headerTitleStyle: {
+    textAlign: "center",
+    marginLeft: 60,
+    flex: 1,
+  },
+  headerLeft: null,
+  headerRight: <HeaderRightClose navigation={navigation} />,
+});
+
 class Screen extends Component<Props, State> {
-  static navigationOptions = {
-    title: "Choose your device",
-    headerLeft: null,
-  };
+  static navigationOptions = hackyNavigationOptions;
 
   render() {
     return (


### PR DESCRIPTION
I was forced to do horrible things to make the header correct on pairing screen.

And it brings regression to other pairing screens  (on other screens: text was correctly centered, i dunno why, and so the left margin f*** the thing up)

if someone has an idea..

a | b
--|---
![screenshot_20181116-173812](https://user-images.githubusercontent.com/315259/48635093-7d9cec80-e9c7-11e8-9638-13cc8cdcc1c6.jpg) | ![screenshot_20181116-173805](https://user-images.githubusercontent.com/315259/48635094-7d9cec80-e9c7-11e8-86bd-bfe61475614b.jpg)
