### PR TITLE
LL-487 Fix amount field use commas on re-focus

### DIFF
--- a/src/components/CurrencyInput.js
+++ b/src/components/CurrencyInput.js
@@ -116,6 +116,7 @@ class CurrencyInput extends PureComponent<Props, State> {
   setDisplayValue = (isFocused: boolean = false) => {
     const { value, showAllDigits, unit, subMagnitude, allowZero } = this.props;
     this.setState({
+      isFocused,
       displayValue:
         !value || (value.isZero() && !allowZero)
           ? ""
@@ -150,7 +151,6 @@ class CurrencyInput extends PureComponent<Props, State> {
 
   syncInput = ({ isFocused }: { isFocused: boolean }) => {
     if (isFocused !== this.state.isFocused) {
-      this.setState({ isFocused });
       this.setDisplayValue(isFocused);
     }
   };


### PR DESCRIPTION
Re-focusing on an amount field in the send flow incorrectly format it with number grouping, this PR fixes this.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-487

### Test plan

- Follow the _Send_ flow up to the _Amount_ screen
- Tap on a field to focus it
- Enter a big number
- Tap outside of the field, the formatting changes to use number grouping (eg `9001` becomes `9,001`)
- Tap on the previous field again to focus it, the number should now revert to unformatted (eg `9001` again)
