### PR TITLE
Correct next firmware version in manager device update infos

### DIFF
--- a/src/screens/Manager/FirmwareUpdateRow.js
+++ b/src/screens/Manager/FirmwareUpdateRow.js
@@ -70,17 +70,19 @@ class FirmwareVersionRow extends PureComponent<Props, State> {
   };
 
   render() {
-    const { deviceInfo } = this.props;
     const { latestFirmware } = this.state;
     if (!latestFirmware) {
       return null;
     }
+
     return (
       <View style={styles.root}>
         <LText semiBold numberOfLines={1} style={styles.title}>
           <Trans
             i18nKey="FirmwareUpdateRow.title"
-            values={{ version: deviceInfo.seVersion }}
+            values={{
+              version: manager.getFirmwareVersion(latestFirmware),
+            }}
           />
         </LText>
         <Button


### PR DESCRIPTION
![res](https://user-images.githubusercontent.com/315259/48918115-e0d8c400-ee8a-11e8-9e31-9b9e1e450dc5.jpg)

~~I'm not *really sure* on the fix, I used what the component receive, but sounds a bit hacky to extract the next firmware version..~~

**edit:** used `manager.getFirmwareVersion()`