### PR TITLE
Addresses LL-560, LL-561 and more lockscreen issues

### DIFF
--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -17,9 +17,23 @@ type Props = {
   onFocus?: *,
   onBlur?: *,
   error?: ?Error,
+  password?: string,
 };
 
-class PasswordInput extends PureComponent<Props> {
+class PasswordInput extends PureComponent<Props, { isFocused: boolean }> {
+  state = { isFocused: false };
+
+  onFocus = () => {
+    const { onFocus } = this.props;
+    this.setState({ isFocused: true });
+    onFocus && onFocus();
+  };
+  onBlur = () => {
+    const { onBlur } = this.props;
+    this.setState({ isFocused: false });
+    onBlur && onBlur();
+  };
+
   render() {
     const {
       autoFocus,
@@ -30,11 +44,26 @@ class PasswordInput extends PureComponent<Props> {
       toggleSecureTextEntry,
       placeholder,
       inline,
-      onFocus,
-      onBlur,
+      password,
     } = this.props;
+
+    let borderColorOverride = {};
+    if (!inline && this.state.isFocused) {
+      if (error) {
+        borderColorOverride = { borderColor: colors.alert };
+      } else {
+        borderColorOverride = { borderColor: colors.live };
+      }
+    }
+
     return (
-      <View style={[styles.container, !inline && styles.nonInlineContainer]}>
+      <View
+        style={[
+          styles.container,
+          !inline && styles.nonInlineContainer,
+          borderColorOverride,
+        ]}
+      >
         <TextInput
           autoFocus={autoFocus}
           style={[
@@ -51,8 +80,9 @@ class PasswordInput extends PureComponent<Props> {
           secureTextEntry={secureTextEntry}
           textContentType="password"
           autoCorrect={false}
-          onFocus={onFocus}
-          onBlur={onBlur}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
+          value={password}
         />
         {secureTextEntry ? (
           <Touchable style={styles.iconInput} onPress={toggleSecureTextEntry}>

--- a/src/context/AuthPass/FailBiometrics.js
+++ b/src/context/AuthPass/FailBiometrics.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { Component } from "react";
-import { StyleSheet, View } from "react-native";
+import { StyleSheet, View, TouchableWithoutFeedback } from "react-native";
 import { Trans } from "react-i18next";
 import LText from "../../components/LText";
 import type { Privacy } from "../../reducers/settings";
@@ -9,20 +9,23 @@ import BiometricsIcon from "../../components/BiometricsIcon";
 
 type Props = {
   privacy: Privacy,
+  lock: () => void,
 };
 
 class FailBiometrics extends Component<Props> {
   render() {
-    const { privacy } = this.props;
+    const { privacy, lock } = this.props;
     return (
       <View>
-        <View style={styles.iconStyle}>
-          <BiometricsIcon
-            biometricsType={privacy.biometricsType}
-            color={colors.alert}
-            size={80}
-          />
-        </View>
+        <TouchableWithoutFeedback onPress={lock}>
+          <View style={styles.iconStyle}>
+            <BiometricsIcon
+              biometricsType={privacy.biometricsType}
+              color={colors.alert}
+              size={80}
+            />
+          </View>
+        </TouchableWithoutFeedback>
         <View style={styles.textContainer}>
           <LText semiBold secondary style={styles.title}>
             <Trans

--- a/src/context/AuthPass/index.js
+++ b/src/context/AuthPass/index.js
@@ -97,6 +97,7 @@ class AuthPass extends PureComponent<Props, State> {
         <AuthScreen
           biometricsError={biometricsError}
           privacy={privacy}
+          lock={this.lock}
           unlock={this.unlock}
         />
       );

--- a/src/screens/Settings/General/ConfirmPassword.js
+++ b/src/screens/Settings/General/ConfirmPassword.js
@@ -75,6 +75,7 @@ class ConfirmPassword extends PureComponent<Props, State> {
     } else {
       this.setState({
         error: new PasswordsDontMatchError(),
+        confirmPassword: "",
       });
     }
   };

--- a/src/screens/Settings/General/PasswordForm.js
+++ b/src/screens/Settings/General/PasswordForm.js
@@ -50,6 +50,7 @@ class PasswordForm extends PureComponent<Props, State> {
               toggleSecureTextEntry={this.toggleSecureTextEntry}
               secureTextEntry={secureTextEntry}
               placeholder={placeholder}
+              password={value}
             />
           </View>
           {error && (

--- a/src/screens/Settings/General/PasswordRemove.js
+++ b/src/screens/Settings/General/PasswordRemove.js
@@ -54,7 +54,7 @@ class PasswordRemove extends PureComponent<Props, State> {
       disablePrivacy();
       navigation.dangerouslyGetParent().goBack();
     } catch (error) {
-      this.setState({ error });
+      this.setState({ error, confirmPassword: "" });
     }
   }
 


### PR DESCRIPTION
There were several issues solved here:
#### Adding the retry on touching the biometric icon.
The icon didn't have an action, I'm calling the lock method to reset the state of the screen, perhaps there's a better way for this. 

#### Added the border styles for focused/error states
I talked to @khalilbenihoud and he linked me to two uis that showed the input styles on ok/nok states. I respected the behaviour of deleting the value on error because it was there already. (The cursor is missing on the screen shot because it blinks)
![image](https://user-images.githubusercontent.com/4631227/48973828-0ca1a880-f049-11e8-8ce1-e8a55893023c.png)

#### Showing the login button as disabled if no password:
When we failed to confirm a password or entered an incorrect one, the button turned gray and there was an error message. This meant the button was disabled with no input after an error, but enabled on empty input by default. Now it's disabled on both cases for empty input.

#### Located a bug that painted the footer over the button, disabling it (image attached)
It was using the opacity of the footer to hide it and this (at least on a 5inch device) meant that it was drawing over the button and disabling the login. I was only able to see this after enabling the bouding box drawing on dev mode.
![image](https://user-images.githubusercontent.com/4631227/48973823-e7ad3580-f048-11e8-9efc-f6c4513e0f2d.png)

#### Correctly responds to keyboard closing
Addresses LL-560 where after losing focus on the input, we still didn't see the footer. 

#### After failed input bug
After setting an invalid password/password confirmation, the first character typed would be deleted. This is due to the input being rendered again and losing the value, I had to expose the value to a parent component to keep it the and still be able to reset it (respecting the current behaviour) on failure. 