### PR TITLE
Fix select account list bottom padding

### DIFF
--- a/src/screens/SendFunds/01-SelectAccount.js
+++ b/src/screens/SendFunds/01-SelectAccount.js
@@ -47,6 +47,7 @@ class SendFundsSelectAccount extends Component<Props, State> {
       keyExtractor={this.keyExtractor}
       showsVerticalScrollIndicator={false}
       keyboardDismissMode="on-drag"
+      contentContainerStyle={styles.list}
     />
   );
 
@@ -104,7 +105,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   list: {
-    paddingTop: 8,
+    paddingBottom: 32,
   },
   emptyResults: {
     flex: 1,


### PR DESCRIPTION
LL-563

Added same padding as crypto list (32px)

![2018-11-27-122313_661x340_escrotum](https://user-images.githubusercontent.com/315259/49078906-91561780-f23f-11e8-8d7a-448a4f00164a.png)
