### PR TITLE
Tentative solution to glitchy switches

### DIFF
--- a/src/navigation/navigatorConfig.js
+++ b/src/navigation/navigatorConfig.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import type { NavigationScreenProp } from "react-navigation";
+import { Platform, Easing, Animated } from "react-native";
 
 import HeaderRightClose from "../components/HeaderRightClose";
 import HeaderTitle from "../components/HeaderTitle";
@@ -14,12 +15,38 @@ export const navigationOptions = {
   headerBackTitle: null,
   headerBackImage: HeaderBackImage,
 };
-
-export const stackNavigatorConfig = {
+export const stackNavigatorConfig: any = {
   navigationOptions,
   cardStyle: styles.card,
   headerLayoutPreset: "center",
 };
+
+if (Platform.OS === "android") {
+  stackNavigatorConfig.transitionConfig = () => ({
+    transitionSpec: {
+      duration: 200,
+      easing: Easing.out(Easing.poly(4)),
+      timing: Animated.timing,
+    },
+    screenInterpolator: sceneProps => {
+      const { layout, position, scene } = sceneProps;
+      const { index } = scene;
+
+      const height = layout.initHeight;
+      const translateY = position.interpolate({
+        inputRange: [index - 1, index, index + 1],
+        outputRange: [height, 0, 0],
+      });
+
+      const opacity = position.interpolate({
+        inputRange: [index - 1, index - 0.99, index],
+        outputRange: [0, 1, 1],
+      });
+
+      return { opacity, transform: [{ translateY }] };
+    },
+  });
+}
 
 export const closableNavigationOptions = ({
   navigation,


### PR DESCRIPTION
The bug affected only Android 28+ and it made the switches render only _after the transition animation had completed_. This meant that when going into or out of the General settings page it would look like this. Well, that's slowed down x5 but you get the idea.
![nov-27-2018 14-37-10](https://user-images.githubusercontent.com/4631227/49098079-646d2900-f26e-11e8-9fdf-bab38dcad4bd.gif)

I modified the transition animation for stacked navigation only on Android, since iOS uses that horizontal swap that I'm sure would make everyone angry if we lost it. Now, after running yarn again since we don't have the blocking network connectivity issues, it works pretty well to my standards.
![solution](https://user-images.githubusercontent.com/4631227/49098406-13116980-f26f-11e8-9f20-82acf5bf773a.gif)
