### PR TITLE
Fix Android libcore blockheight

### DIFF
--- a/src/libcore/specific.android.js
+++ b/src/libcore/specific.android.js
@@ -16,7 +16,7 @@ export const getValue = (obj: any) => obj;
 export const getBlockHeightForAccount = async (core: *, coreAccount: *) => {
   const coreBlock = await core.coreAccount.getLastBlock(coreAccount);
   const blockHeightRes = await core.coreBlock.getHeight(coreBlock);
-  return blockHeightRes;
+  return blockHeightRes.value;
 };
 
 /* eslint-disable */


### PR DESCRIPTION
which is now wrapped in `.value`.
See you on next breaking change !

![waving-hand](https://user-images.githubusercontent.com/315259/49159739-71991f00-f325-11e8-85b3-48ddbda0a090.png)
