### PR TITLE
LL428 - Removes textinput autocomplete

### DIFF
--- a/src/components/FilteredSearchBar.js
+++ b/src/components/FilteredSearchBar.js
@@ -88,7 +88,6 @@ class FilteredSearchBar extends PureComponent<Props, State> {
             placeholderTextColor={colors.grey}
             style={styles.input}
             value={query}
-            noSuggestions
             ref={this.input}
           />
           {query ? <InputResetCross onPress={this.clear} /> : null}

--- a/src/components/TextInput.js
+++ b/src/components/TextInput.js
@@ -4,9 +4,9 @@ import { Platform, TextInput as ReactNativeTextInput } from "react-native";
 
 // $FlowFixMe https://github.com/facebook/flow/pull/5920
 const TextInput = React.forwardRef((props, ref) => {
-  const { noSuggestions, ...otherProps } = props;
+  const { withSuggestions, ...otherProps } = props;
   const flags = {};
-  if (noSuggestions) {
+  if (!withSuggestions) {
     flags.autoCorrect = false;
     if (Platform.OS === "android") {
       flags.keyboardType = "visible-password";

--- a/src/screens/AccountSettings/EditAccountName.js
+++ b/src/screens/AccountSettings/EditAccountName.js
@@ -73,7 +73,6 @@ class EditAccountName extends PureComponent<Props, State> {
               maxLength={20}
               onChangeText={accountName => this.setState({ accountName })}
               onSubmitEditing={this.onNameEndEditing}
-              noSuggestions
             />
             <View style={styles.flex}>
               <Button

--- a/src/screens/EditDeviceName.js
+++ b/src/screens/EditDeviceName.js
@@ -99,7 +99,6 @@ class EditDeviceName extends PureComponent<
               clearButtonMode="always"
               placeholder="Satoshi Nakamoto"
               style={[getFontStyle({ semiBold: true }), styles.input]}
-              noSuggestions
             />
             <LText style={styles.remainingText}>
               <Trans

--- a/src/screens/SendFunds/02-SelectRecipient.js
+++ b/src/screens/SendFunds/02-SelectRecipient.js
@@ -215,7 +215,6 @@ class SendSelectRecipient extends Component<Props, State> {
                 multiline
                 blurOnSubmit
                 autoCapitalize="none"
-                noSuggestions
               />
               {address ? <InputResetCross onPress={this.clear} /> : null}
             </View>


### PR DESCRIPTION
I opted to wrap the TextInput with our own implementation because text inputs in general tend to be super picky when you get hundreds of models of devices with different Roms and versions. This `visible-password` for example is needed because some devices (including my HTC p10) ignore the autocorrect/autocomplete flags.

![image](https://user-images.githubusercontent.com/4631227/49159686-5af2c800-f325-11e8-8cf2-5577057a5d46.png)
