### PR TITLE
Fixed the minimum height of the three headers 

### DIFF
--- a/src/components/HeaderErrorTitle.js
+++ b/src/components/HeaderErrorTitle.js
@@ -36,6 +36,8 @@ class HeaderErrorTitle extends PureComponent<{
 const styles = StyleSheet.create({
   root: {
     marginHorizontal: 16,
+    justifyContent: "center",
+    minHeight: 48,
   },
   title: {
     fontSize: 16,

--- a/src/components/HeaderSynchronizing.js
+++ b/src/components/HeaderSynchronizing.js
@@ -27,6 +27,7 @@ const styles = StyleSheet.create({
     marginHorizontal: 16,
     flexDirection: "row",
     alignItems: "center",
+    minHeight: 48,
   },
   title: {
     fontSize: 16,

--- a/src/screens/Portfolio/Greetings.js
+++ b/src/screens/Portfolio/Greetings.js
@@ -49,6 +49,8 @@ class Greetings extends PureComponent<{
 const styles = StyleSheet.create({
   root: {
     marginHorizontal: 16,
+    justifyContent: "center",
+    minHeight: 48,
   },
   title: {
     fontSize: 16,


### PR DESCRIPTION
To prevent the jumpy flow when transitioning between the greeting header and a sync/error one, fixed to a minimum height that works for both iOS and Android. Attached gifs of both setups
![android](https://user-images.githubusercontent.com/4631227/49185840-3ddcea00-f363-11e8-8ef4-db57ed694776.gif)
![ios](https://user-images.githubusercontent.com/4631227/49185841-3e758080-f363-11e8-9a94-b0778d64f2d3.gif)
