### PR TITLE
LL-523 Passes device name back after modifying it, plus keyboard hide glitchy

### DIFF
--- a/src/screens/EditDeviceName.js
+++ b/src/screens/EditDeviceName.js
@@ -70,16 +70,11 @@ class EditDeviceName extends PureComponent<
     this.setState({ name });
   };
 
-  waitForKeyboardToHide = () => {
-    this.setState({ connecting: true });
-    Keyboard.removeListener("keyboardDidHide", this.waitForKeyboardToHide);
-  };
-
   onSubmit = async () => {
     const { name } = this.state;
     if (this.initialName !== name) {
-      Keyboard.addListener("keyboardDidHide", this.waitForKeyboardToHide);
       Keyboard.dismiss();
+      setTimeout(() => this.setState({ connecting: true }), 800);
     } else {
       this.props.navigation.goBack();
     }


### PR DESCRIPTION
![nov-29-2018 16-57-44](https://user-images.githubusercontent.com/4631227/49234469-62cf6c80-f3f8-11e8-8e40-389034d5a8bf.gif)


To test it:

- Enable debug mode (flag or tap 7 times on the footer “powered by ledger")
- Settings>Debug>Debug http transport
- Set the IP of your machine on the device


**Update**
This approach does not work (confirmed) with a hardware keyboard connected to the device, which means that in the rare case of someone using a plugged/bt connected keyboard they'd be unable to confirm the new name. Clicking the button will wait for the keyboard to be dismissed, this never happens, we are toast.