### PR TITLE
Show placeholders while countervalues are not loaded yet

### DIFF
--- a/src/colors.js
+++ b/src/colors.js
@@ -45,4 +45,5 @@ export default {
   pillForeground: "#999999",
   pillActiveBackground: rgba("#6490f1", 0.1),
   pillActiveForeground: "#6490f1",
+  pillActiveDisabledForeground: "#999999",
 };

--- a/src/components/CounterValue.js
+++ b/src/components/CounterValue.js
@@ -4,6 +4,7 @@ import type { BigNumber } from "bignumber.js";
 import { connect } from "react-redux";
 import type { Currency } from "@ledgerhq/live-common/lib/types";
 import type { State } from "../reducers";
+import Placeholder from "./Placeholder";
 
 import {
   counterValueCurrencySelector,
@@ -23,6 +24,13 @@ type OwnProps = {
   date?: Date,
 
   value: BigNumber,
+
+  // display grey placeholder if no value
+  withPlaceholder?: boolean,
+  placeholderProps?: mixed,
+  // as we can't render View inside Text, provide ability to pass
+  // wrapper component from outside
+  Wrapper?: React$ComponentType<*>,
 };
 
 type Props = OwnProps & {
@@ -54,17 +62,33 @@ const mapStateToProps = (state: State, props: OwnProps) => {
 
 class CounterValue extends Component<Props> {
   render() {
-    const { value, counterValueCurrency, date, ...props } = this.props;
-    if (!value) {
-      return null;
-    }
-    return (
+    const {
+      value,
+      counterValueCurrency,
+      date,
+      withPlaceholder,
+      placeholderProps,
+      Wrapper,
+      ...props
+    } = this.props;
+
+    const inner = (
       <CurrencyUnitValue
         {...props}
         unit={counterValueCurrency.units[0]}
         value={value}
       />
     );
+
+    if (!value) {
+      return withPlaceholder ? <Placeholder {...placeholderProps} /> : null;
+    }
+
+    if (Wrapper) {
+      return <Wrapper>{inner}</Wrapper>;
+    }
+
+    return inner;
   }
 }
 

--- a/src/components/GraphCard.js
+++ b/src/components/GraphCard.js
@@ -21,6 +21,7 @@ import Pills from "./Pills";
 import Card from "./Card";
 import LText from "./LText";
 import CurrencyUnitValue from "./CurrencyUnitValue";
+import Placeholder from "./Placeholder";
 
 import type { Item } from "./Graph";
 
@@ -58,6 +59,7 @@ class GraphCard extends PureComponent<Props, State> {
     const { summary, renderTitle, useCounterValue } = this.props;
 
     const {
+      isAvailable,
       accounts,
       balanceHistory,
       balanceStart,
@@ -74,6 +76,7 @@ class GraphCard extends PureComponent<Props, State> {
     return (
       <Card style={styles.root}>
         <GraphCardHeader
+          isLoading={!isAvailable}
           from={balanceStart}
           to={balanceEnd}
           hoveredItem={hoveredItem}
@@ -81,16 +84,18 @@ class GraphCard extends PureComponent<Props, State> {
           renderTitle={renderTitle}
         />
         <Graph
-          isInteractive
+          isInteractive={isAvailable}
+          isLoading={!isAvailable}
           height={100}
           width={Dimensions.get("window").width - 40}
-          color={graphColor}
+          color={isAvailable ? graphColor : colors.grey}
           data={balanceHistory}
           onItemHover={this.onItemHover}
           useCounterValue={useCounterValue}
         />
         <View style={styles.pillsContainer}>
           <Pills
+            isDisabled={!isAvailable}
             value={selectedTimeRange}
             onChange={this.onTimeRangeChange}
             items={this.timeRangeItems}
@@ -102,6 +107,7 @@ class GraphCard extends PureComponent<Props, State> {
 }
 
 class GraphCardHeader extends PureComponent<{
+  isLoading: boolean,
   from: Item,
   to: Item,
   unit: Unit,
@@ -109,12 +115,14 @@ class GraphCardHeader extends PureComponent<{
   renderTitle?: ({ counterValueUnit: Unit, item: Item }) => React$Node,
 }> {
   render() {
-    const { unit, from, to, hoveredItem, renderTitle } = this.props;
+    const { unit, from, to, hoveredItem, renderTitle, isLoading } = this.props;
     const item = hoveredItem || to;
     return (
       <Fragment>
         <View style={styles.balanceTextContainer}>
-          {renderTitle ? (
+          {isLoading ? (
+            <Placeholder width={228} containerHeight={27} />
+          ) : renderTitle ? (
             renderTitle({ counterValueUnit: unit, item })
           ) : (
             <LText tertiary style={styles.balanceText}>
@@ -123,7 +131,16 @@ class GraphCardHeader extends PureComponent<{
           )}
         </View>
         <View style={styles.subtitleContainer}>
-          {hoveredItem ? (
+          {isLoading ? (
+            <Fragment>
+              <Placeholder
+                width={50}
+                containerHeight={19}
+                style={{ marginRight: 10 }}
+              />
+              <Placeholder width={50} containerHeight={19} />
+            </Fragment>
+          ) : hoveredItem ? (
             <LText>
               <FormatDate date={hoveredItem.date} format="MMMM D, YYYY" />
             </LText>
@@ -165,6 +182,7 @@ const styles = StyleSheet.create({
   balanceTextContainer: {
     marginBottom: 5,
     alignItems: "center",
+    justifyContent: "center",
   },
   balanceText: {
     fontSize: 22,
@@ -173,6 +191,7 @@ const styles = StyleSheet.create({
   subtitleContainer: {
     flexDirection: "row",
     justifyContent: "center",
+    alignItems: "center",
     marginBottom: 20,
   },
   pillsContainer: {

--- a/src/components/OperationRow.js
+++ b/src/components/OperationRow.js
@@ -26,6 +26,11 @@ type Props = {
   isLast: boolean,
 };
 
+const placeholderProps = {
+  width: 40,
+  containerHeight: 20,
+};
+
 class OperationRow extends PureComponent<Props, *> {
   static defaultProps = {
     displayCurrencyLogo: false,
@@ -126,19 +131,17 @@ class OperationRow extends PureComponent<Props, *> {
                   {text} <OperationRowDate date={operation.date} />
                 </LText>
               )}
-              <LText
-                tertiary
-                numberOfLines={1}
-                ellipsizeMode="tail"
-                style={[styles.bottomRow, styles.bodyRight]}
-              >
+              <View style={styles.bodyRight}>
                 <CounterValue
                   showCode
                   currency={account.currency}
                   value={amount}
                   alwaysShowSign
+                  withPlaceholder
+                  placeholderProps={placeholderProps}
+                  Wrapper={OpCounterValue}
                 />
-              </LText>
+              </View>
             </View>
           </View>
         </RectButton>
@@ -146,6 +149,17 @@ class OperationRow extends PureComponent<Props, *> {
     );
   }
 }
+
+const OpCounterValue = ({ children }: { children: * }) => (
+  <LText
+    tertiary
+    numberOfLines={1}
+    ellipsizeMode="tail"
+    style={styles.bottomRow}
+  >
+    {children}
+  </LText>
+);
 
 export default OperationRow;
 
@@ -193,6 +207,7 @@ const styles = StyleSheet.create({
     flexShrink: 1,
   },
   bodyRight: {
+    height: 20,
     alignItems: "flex-end",
   },
 });

--- a/src/components/Pills.js
+++ b/src/components/Pills.js
@@ -16,11 +16,12 @@ type Props = {
   value: string,
   items: Item[],
   onChange: Item => void,
+  isDisabled?: boolean,
 };
 
 class Pills extends Component<Props> {
   render() {
-    const { items, value, onChange } = this.props;
+    const { items, value, onChange, isDisabled } = this.props;
     return (
       <View style={styles.root}>
         {items.map((item, i) => (
@@ -30,6 +31,7 @@ class Pills extends Component<Props> {
             first={i === 0}
             item={item}
             onPress={onChange}
+            isDisabled={isDisabled}
           />
         ))}
       </View>
@@ -42,9 +44,37 @@ class Pill extends PureComponent<{
   first: boolean,
   active: boolean,
   onPress: Item => void,
+  isDisabled?: boolean,
 }> {
   render() {
-    const { item, first, active, onPress } = this.props;
+    const { item, first, active, onPress, isDisabled } = this.props;
+    const inner = (
+      <LText
+        style={[
+          styles.pillText,
+          active && !isDisabled && styles.pillActiveText,
+          active && isDisabled && styles.pillActiveDisabledText,
+        ]}
+        semiBold={active}
+      >
+        {item.label}
+      </LText>
+    );
+
+    if (isDisabled) {
+      return (
+        <View
+          style={[
+            styles.pill,
+            active && styles.pillActiveDisabled,
+            first && styles.pillFirst,
+          ]}
+        >
+          {inner}
+        </View>
+      );
+    }
+
     return (
       <TouchableOpacity
         style={[
@@ -54,12 +84,7 @@ class Pill extends PureComponent<{
         ]}
         onPress={() => onPress(item)}
       >
-        <LText
-          style={[styles.pillText, active && styles.pillActiveText]}
-          semiBold={active}
-        >
-          {item.label}
-        </LText>
+        {inner}
       </TouchableOpacity>
     );
   }
@@ -81,11 +106,17 @@ const styles = StyleSheet.create({
   pillActiveText: {
     color: colors.pillActiveForeground,
   },
+  pillActiveDisabledText: {
+    color: colors.pillActiveDisabledForeground,
+  },
   pillFirst: {
     marginLeft: 0,
   },
   pillActive: {
     backgroundColor: colors.pillActiveBackground,
+  },
+  pillActiveDisabled: {
+    backgroundColor: colors.lightGrey,
   },
 });
 

--- a/src/components/Placeholder.js
+++ b/src/components/Placeholder.js
@@ -1,0 +1,36 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { View, StyleSheet } from "react-native";
+
+import colors from "../colors";
+
+class Placeholder extends PureComponent<{
+  width?: number,
+  containerHeight?: number,
+  style?: *,
+}> {
+  render() {
+    const { width, containerHeight, style } = this.props;
+    return (
+      <View
+        style={[styles.root, containerHeight && { height: containerHeight }]}
+      >
+        <View style={[styles.inner, { width: width || 100 }, style]} />
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  root: {
+    justifyContent: "center",
+  },
+  inner: {
+    height: 8,
+    backgroundColor: colors.fog,
+    borderRadius: 4,
+  },
+});
+
+export default Placeholder;

--- a/src/screens/Accounts/AccountRow.js
+++ b/src/screens/Accounts/AccountRow.js
@@ -28,6 +28,11 @@ type Props = {
   isLast: boolean,
 };
 
+const placeholderProps = {
+  width: 40,
+  containerHeight: 20,
+};
+
 const TICK_W = 6;
 const TICK_H = 20;
 
@@ -64,13 +69,14 @@ class AccountRow extends PureComponent<Props> {
               />
             </LText>
             <View style={styles.balanceCounterContainer}>
-              <LText tertiary semiBold style={styles.balanceCounterText}>
-                <CounterValue
-                  showCode
-                  currency={account.currency}
-                  value={account.balance}
-                />
-              </LText>
+              <CounterValue
+                showCode
+                currency={account.currency}
+                value={account.balance}
+                withPlaceholder
+                placeholderProps={placeholderProps}
+                Wrapper={AccountCv}
+              />
             </View>
           </View>
         </View>
@@ -78,6 +84,12 @@ class AccountRow extends PureComponent<Props> {
     );
   }
 }
+
+const AccountCv = ({ children }: { children: * }) => (
+  <LText tertiary semiBold style={styles.balanceCounterText}>
+    {children}
+  </LText>
+);
 
 export default connect(mapStateToProps)(AccountRow);
 
@@ -119,6 +131,7 @@ const styles = StyleSheet.create({
   },
   balanceCounterContainer: {
     marginTop: 5,
+    height: 20,
   },
   balanceCounterText: {
     fontSize: 14,


### PR DESCRIPTION
```
/!\  WARNING
     There is actually a bug while retrieving connectivity:

     1. navigate to portfolio, ensure countervalues are loaded
     2. turn *ON* airplaine mode
     3. navigate to countervalues settings and change the currency
     4. navigate to portfolio
     5. countervalues are not refreshed, and we still are in "placeholder" mode

nb: the bug is independant from the PR
```

Display grey placeholders fallbacks when countervalue is not available, in Graph and Op/Account rows. Other countervalues renders to `null`.

![countervalue](https://user-images.githubusercontent.com/315259/49292410-7688da80-f4ad-11e8-831d-c12eb6d3ea98.gif)
