### PR TITLE
LL-543 Replaced websocket errors with more friendly versions

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -219,11 +219,11 @@
       "description": "Please retry or contact Ledger Support in case of doubt."
     },
     "WebsocketConnectionError": {
-      "title": "Sorry, try again (websocket error).",
+      "title": "Sorry, please try again with a better network connection",
       "description": null
     },
     "WebsocketConnectionFailed": {
-      "title": "Sorry, try again (websocket failed).",
+      "title": "Sorry, please try again with a better network connection",
       "description": null
     },
     "WrongDeviceForAccount": {


### PR DESCRIPTION
Replaced both the websocket failed and websocket error versions with the new text from @dasilvarosa  _"Sorry, please try again with a better network connection"_ 