### PR TITLE
Reworded the restore recovery screen

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -314,6 +314,7 @@
       "OnboardingStepChooseDevice": "Choose your device",
       "OnboardingStepSetupPin": "Choose your PIN code",
       "OnboardingStepWriteRecovery": "Save recovery phrase",
+      "OnboardingStepWriteRecoveryRestore": "Enter recovery phrase",
       "OnboardingStepSecurityChecklist": "Security checklist",
       "OnboardingStepPairNew": "Pair your {{fullDeviceName}}",
       "OnboardingStepPassword": "Password lock",
@@ -366,10 +367,11 @@
       }
     },
     "stepWriteRecoveryRestore": {
-      "step1": "Choose the length of your recovery phrase.",
-      "step2": "Enter the first letters of <1><1>Word #1</1></1> until suggested words appear.",
-      "step3": "Choose <1><1>Word #1</1></1> from the suggested words by pressing both buttons.",
-      "step4": "Repeat the process until the last word."
+      "step1": "Take out your Recovery sheet.",
+      "step2": "Choose the length of your recovery phrase.",
+      "step3": "Enter the first letters of <1><1>Word #1</1></1> until suggested words appear.",
+      "step4": "Choose <1><1>Word #1</1></1> from the suggested words by pressing both buttons.",
+      "step5": "Repeat the process until the last word."
     },
     "stepSecurityChecklist": {
       "pinCode": {

--- a/src/screens/Onboarding/OnboardingHeader.js
+++ b/src/screens/Onboarding/OnboardingHeader.js
@@ -33,6 +33,12 @@ class OnboardingHeader extends PureComponent<Props> {
     const visibleSteps = steps.filter(s => !s.isGhost);
     const indexInSteps = visibleSteps.findIndex(s => s.id === stepId);
     const stepMsg = `${indexInSteps + 1} of ${visibleSteps.length}`; // TODO translate
+
+    let stepIdOverride = stepId;
+    if (mode === "restore" && stepId === "OnboardingStepWriteRecovery") {
+      stepIdOverride = "OnboardingStepWriteRecoveryRestore";
+    }
+
     return (
       <View style={styles.root}>
         <View style={styles.headerHeader}>
@@ -56,7 +62,7 @@ class OnboardingHeader extends PureComponent<Props> {
           {stepMsg}
         </LText>
         <LText secondary semiBold style={styles.title}>
-          {t(`onboarding.stepsTitles.${stepId}`, deviceNames.nanoX)}
+          {t(`onboarding.stepsTitles.${stepIdOverride}`, deviceNames.nanoX)}
         </LText>
       </View>
     );

--- a/src/screens/Onboarding/steps/write-recovery.js
+++ b/src/screens/Onboarding/steps/write-recovery.js
@@ -63,13 +63,7 @@ class OnboardingStepWriteRecovery extends Component<
               mode === "restore"
                 ? [
                     <Trans i18nKey="onboarding.stepWriteRecoveryRestore.step1" />,
-                    <Trans i18nKey="onboarding.stepWriteRecoveryRestore.step2">
-                      {"text"}
-                      <LText semiBold style={{ color: colors.darkBlue }}>
-                        bold text
-                      </LText>
-                      {"text"}
-                    </Trans>,
+                    <Trans i18nKey="onboarding.stepWriteRecoveryRestore.step2" />,
                     <Trans i18nKey="onboarding.stepWriteRecoveryRestore.step3">
                       {"text"}
                       <LText semiBold style={{ color: colors.darkBlue }}>
@@ -77,7 +71,14 @@ class OnboardingStepWriteRecovery extends Component<
                       </LText>
                       {"text"}
                     </Trans>,
-                    <Trans i18nKey="onboarding.stepWriteRecoveryRestore.step4" />,
+                    <Trans i18nKey="onboarding.stepWriteRecoveryRestore.step4">
+                      {"text"}
+                      <LText semiBold style={{ color: colors.darkBlue }}>
+                        bold text
+                      </LText>
+                      {"text"}
+                    </Trans>,
+                    <Trans i18nKey="onboarding.stepWriteRecoveryRestore.step5" />,
                   ]
                 : [
                     <Trans i18nKey="onboarding.stepWriteRecovery.step1">


### PR DESCRIPTION
I opted to override the title because the other option (unless I'm not getting how this is laid out) is to separate the recover from the recovery restore, and since it already had some logic relying on the mode inside this seems to be the least invasive.

Eventually, it should be separated, or refactored though.
![image](https://user-images.githubusercontent.com/4631227/49303769-dcd02600-f4ca-11e8-8100-3179e81441d1.png)
