### PR TITLE
Fixes libcore flush() related bugs via withLibcore() protection

### DIFF
--- a/src/libcore/getFeesForTransaction.js
+++ b/src/libcore/getFeesForTransaction.js
@@ -4,7 +4,7 @@ import { BigNumber } from "bignumber.js";
 import { getWalletName } from "@ledgerhq/live-common/lib/account";
 import type { Account } from "@ledgerhq/live-common/lib/types";
 import { InvalidAddress } from "@ledgerhq/live-common/lib/errors";
-import load from "./load";
+import { withLibcoreF } from "./access";
 import { remapLibcoreErrors } from "./errors";
 import { getOrCreateWallet } from "./getOrCreateWallet";
 import { getOrCreateAccount } from "./getOrCreateAccount";
@@ -14,87 +14,88 @@ import {
 } from "./buildBigNumber";
 import { isValidRecipient } from "./isValidRecipient";
 
-export async function getFeesForTransaction({
-  account,
-  transaction,
-}: {
-  account: Account,
-  transaction: *,
-}): Promise<BigNumber> {
-  try {
-    const { derivationMode, currency, xpub, index } = account;
-    const core = await load();
-    const walletName = getWalletName(account);
+export const getFeesForTransaction = withLibcoreF(
+  core => async ({
+    account,
+    transaction,
+  }: {
+    account: Account,
+    transaction: *,
+  }): Promise<BigNumber> => {
+    try {
+      const { derivationMode, currency, xpub, index } = account;
+      const walletName = getWalletName(account);
 
-    const coreWallet = await getOrCreateWallet({
-      core,
-      walletName,
-      currency,
-      derivationMode,
-    });
+      const coreWallet = await getOrCreateWallet({
+        core,
+        walletName,
+        currency,
+        derivationMode,
+      });
 
-    const coreAccount = await getOrCreateAccount({
-      core,
-      coreWallet,
-      index,
-      xpub,
-    });
+      const coreAccount = await getOrCreateAccount({
+        core,
+        coreWallet,
+        index,
+        xpub,
+      });
 
-    const bitcoinLikeAccount = await core.coreAccount.asBitcoinLikeAccount(
-      coreAccount,
-    );
+      const bitcoinLikeAccount = await core.coreAccount.asBitcoinLikeAccount(
+        coreAccount,
+      );
 
-    const walletCurrency = await core.coreWallet.getCurrency(coreWallet);
+      const walletCurrency = await core.coreWallet.getCurrency(coreWallet);
 
-    const amount = await bigNumberToLibcoreAmount(
-      core,
-      walletCurrency,
-      BigNumber(transaction.amount),
-    );
+      const amount = await bigNumberToLibcoreAmount(
+        core,
+        walletCurrency,
+        BigNumber(transaction.amount),
+      );
 
-    const feesPerByte = await bigNumberToLibcoreAmount(
-      core,
-      walletCurrency,
-      BigNumber(transaction.feePerByte),
-    );
+      const feesPerByte = await bigNumberToLibcoreAmount(
+        core,
+        walletCurrency,
+        BigNumber(transaction.feePerByte),
+      );
 
-    const transactionBuilder = await core.coreBitcoinLikeAccount.buildTransaction(
-      bitcoinLikeAccount,
-    );
+      const transactionBuilder = await core.coreBitcoinLikeAccount.buildTransaction(
+        bitcoinLikeAccount,
+      );
 
-    const isValid = await isValidRecipient({
-      currency: account.currency,
-      recipient: transaction.recipient,
-    });
+      const isValid = await isValidRecipient({
+        currency: account.currency,
+        recipient: transaction.recipient,
+      });
 
-    if (isValid !== null) {
-      throw new InvalidAddress("", { currencyName: currency.name });
+      if (isValid !== null) {
+        throw new InvalidAddress("", { currencyName: currency.name });
+      }
+
+      await core.coreBitcoinLikeTransactionBuilder.sendToAddress(
+        transactionBuilder,
+        amount,
+        transaction.recipient,
+      );
+
+      await core.coreBitcoinLikeTransactionBuilder.pickInputs(
+        transactionBuilder,
+        0,
+        0xffffff,
+      );
+
+      await core.coreBitcoinLikeTransactionBuilder.setFeesPerByte(
+        transactionBuilder,
+        feesPerByte,
+      );
+
+      const builded = await core.coreBitcoinLikeTransactionBuilder.build(
+        transactionBuilder,
+      );
+      const feesAmount = await core.coreBitcoinLikeTransaction.getFees(builded);
+      const fees = await libcoreAmountToBigNumber(core, feesAmount);
+      return fees;
+    } catch (error) {
+      throw remapLibcoreErrors(error);
     }
-
-    await core.coreBitcoinLikeTransactionBuilder.sendToAddress(
-      transactionBuilder,
-      amount,
-      transaction.recipient,
-    );
-
-    await core.coreBitcoinLikeTransactionBuilder.pickInputs(
-      transactionBuilder,
-      0,
-      0xffffff,
-    );
-
-    await core.coreBitcoinLikeTransactionBuilder.setFeesPerByte(
-      transactionBuilder,
-      feesPerByte,
-    );
-
-    const builded = await core.coreBitcoinLikeTransactionBuilder.build(
-      transactionBuilder,
-    );
-    const feesAmount = await core.coreBitcoinLikeTransaction.getFees(builded);
-    const fees = await libcoreAmountToBigNumber(core, feesAmount);
-    return fees;
-  } catch (error) {
-    throw remapLibcoreErrors(error);
-  }
-}
+  },
+);

--- a/src/libcore/isValidRecipient.js
+++ b/src/libcore/isValidRecipient.js
@@ -2,28 +2,29 @@
 
 import type { CryptoCurrency } from "@ledgerhq/live-common/lib/types";
 import { InvalidAddress } from "@ledgerhq/live-common/lib/errors";
-import load from "./load";
+import { withLibcoreF } from "./access";
 
-export async function isValidRecipient({
-  currency,
-  recipient,
-}: {
-  currency: CryptoCurrency,
-  recipient: string,
-}): Promise<?Error> {
-  const core = await load();
-  const poolInstance = core.getPoolInstance();
-  const currencyCore = await core.coreWalletPool.getCurrency(
-    poolInstance,
-    currency.id,
-  );
-  const addr = core.coreAddress;
-  const { value } = await addr.isValid(recipient, currencyCore);
-  if (value) {
-    return Promise.resolve(null);
-  }
+export const isValidRecipient = withLibcoreF(
+  core => async ({
+    currency,
+    recipient,
+  }: {
+    currency: CryptoCurrency,
+    recipient: string,
+  }): Promise<?Error> => {
+    const poolInstance = core.getPoolInstance();
+    const currencyCore = await core.coreWalletPool.getCurrency(
+      poolInstance,
+      currency.id,
+    );
+    const addr = core.coreAddress;
+    const { value } = await addr.isValid(recipient, currencyCore);
+    if (value) {
+      return Promise.resolve(null);
+    }
 
-  return Promise.reject(
-    new InvalidAddress(null, { currencyName: currency.name }),
-  );
-}
+    return Promise.reject(
+      new InvalidAddress(null, { currencyName: currency.name }),
+    );
+  },
+);

--- a/src/libcore/scanAccountsOnDevice.js
+++ b/src/libcore/scanAccountsOnDevice.js
@@ -16,7 +16,7 @@ import type {
 } from "@ledgerhq/live-common/lib/types";
 
 import { open } from "../logic/hw";
-import loadLibcore from "./load";
+import { withLibcoreF } from "./access";
 import { shouldShowNewAccount } from "../cryptocurrencies";
 import { syncCoreAccount } from "./syncAccount";
 import { getOrCreateWallet } from "./getOrCreateWallet";
@@ -31,13 +31,10 @@ export const scanAccountsOnDevice = (
     const unsubscribe = () => (finished = true);
     const isUnsubscribed = () => finished;
 
-    async function main() {
+    const main = withLibcoreF(core => async () => {
       let transport;
       try {
         transport = await open(deviceId);
-        if (isUnsubscribed()) return;
-
-        const core = await loadLibcore();
         if (isUnsubscribed()) return;
 
         const derivationModes = getDerivationModesForCurrency(currency);
@@ -100,7 +97,7 @@ export const scanAccountsOnDevice = (
       if (transport) {
         await transport.close();
       }
-    }
+    });
 
     main();
 

--- a/src/libcore/signAndBroadcast.js
+++ b/src/libcore/signAndBroadcast.js
@@ -20,7 +20,7 @@ import {
 } from "./buildBigNumber";
 import { remapLibcoreErrors } from "./errors";
 import { getValue } from "./specific";
-import load from "./load";
+import { withLibcoreF } from "./access";
 import { open } from "../logic/hw";
 
 type Transaction = {
@@ -231,195 +231,200 @@ async function signTransaction({
   return signedTransaction; // eslint-disable-line
 }
 
-async function doSignAndBroadcast({
-  accountId,
-  derivationMode,
-  blockHeight,
-  seedIdentifier,
-  currency,
-  xpub,
-  index,
-  transaction,
-  deviceId,
-  isCancelled,
-  onSigned,
-  onOperationBroadcasted,
-}: {
-  accountId: string,
-  derivationMode: DerivationMode,
-  seedIdentifier: string,
-  blockHeight: number,
-  currency: CryptoCurrency,
-  xpub: string,
-  index: number,
-  transaction: Transaction,
-  deviceId: string,
-  isCancelled: () => boolean,
-  onSigned: () => void,
-  onOperationBroadcasted: (optimisticOp: Operation) => void,
-}): Promise<void> {
-  const { feePerByte } = transaction;
-  if (!feePerByte) throw FeeNotLoaded();
-  const core = await load();
-  if (isCancelled()) return;
-
-  const walletName = getWalletName({
-    currency,
-    seedIdentifier,
-    derivationMode,
-  });
-
-  const coreWallet = await getOrCreateWallet({
-    core,
-    walletName,
-    currency,
-    derivationMode,
-  });
-  if (isCancelled()) return;
-  const coreAccount = await core.coreWallet.getAccount(coreWallet, index);
-  if (isCancelled()) return;
-  const bitcoinLikeAccount = await core.coreAccount.asBitcoinLikeAccount(
-    coreAccount,
-  );
-  if (isCancelled()) return;
-  const coreWalletCurrency = await core.coreWallet.getCurrency(coreWallet);
-  if (isCancelled()) return;
-  const amount = await bigNumberToLibcoreAmount(
-    core,
-    coreWalletCurrency,
-    transaction.amount,
-  );
-  if (isCancelled()) return;
-  const fees = await bigNumberToLibcoreAmount(
-    core,
-    coreWalletCurrency,
-    feePerByte,
-  );
-  if (isCancelled()) return;
-  const transactionBuilder = await core.coreBitcoinLikeAccount.buildTransaction(
-    bitcoinLikeAccount,
-  );
-  if (isCancelled()) return;
-
-  await core.coreBitcoinLikeTransactionBuilder.sendToAddress(
-    transactionBuilder,
-    amount,
-    transaction.recipient,
-  );
-  if (isCancelled()) return;
-  await core.coreBitcoinLikeTransactionBuilder.pickInputs(
-    transactionBuilder,
-    0,
-    0xffffff,
-  );
-  if (isCancelled()) return;
-
-  await core.coreBitcoinLikeTransactionBuilder.setFeesPerByte(
-    transactionBuilder,
-    fees,
-  );
-  if (isCancelled()) return;
-
-  const builded = await core.coreBitcoinLikeTransactionBuilder.build(
-    transactionBuilder,
-  );
-  if (isCancelled()) return;
-
-  const networkParams = await core.coreCurrency.getBitcoinLikeNetworkParameters(
-    coreWalletCurrency,
-  );
-  if (isCancelled()) return;
-
-  const sigHashType = (await core.coreBitcoinLikeNetworkParameters.getSigHash(
-    networkParams,
-  )).value.replace(/[< >]/g, ""); // FIXME FIXME FIXME;
-  if (isCancelled()) return;
-
-  const hasTimestamp = (await core.coreBitcoinLikeNetworkParameters.getUsesTimestampedTransaction(
-    networkParams,
-  )).value;
-  if (isCancelled()) return;
-
-  const transport = await open(deviceId);
-  let signedTransaction;
-
-  try {
-    signedTransaction = await signTransaction({
-      core,
-      isCancelled,
-      hwApp: new Btc(transport),
-      currency,
-      blockHeight,
-      coreTransaction: builded,
-      sigHashType: parseInt(sigHashType, 16),
-      hasTimestamp,
-      derivationMode,
-    }).catch(e => {
-      if (e && e.statusCode === StatusCodes.INCORRECT_P1_P2) {
-        throw new UpdateYourApp(`UpdateYourApp ${currency.id}`, currency);
-      }
-      throw e;
-    });
-  } finally {
-    transport.close();
-  }
-  if (isCancelled()) return;
-
-  onSigned();
-
-  const txHash = getValue(
-    await core.coreBitcoinLikeAccount.broadcastRawTransaction(
-      bitcoinLikeAccount,
-      signedTransaction,
-    ),
-  );
-  if (isCancelled()) return;
-
-  const sendersInput = await core.coreBitcoinLikeTransaction.getInputs(builded);
-  if (isCancelled()) return;
-
-  const senders = (await Promise.all(
-    sendersInput.map(
-      async senderInput =>
-        (await core.coreBitcoinLikeInput.getAddress(senderInput)).value,
-    ),
-  )).filter(Boolean);
-  if (isCancelled()) return;
-
-  const recipientsOutput = await core.coreBitcoinLikeTransaction.getOutputs(
-    builded,
-  );
-  if (isCancelled()) return;
-
-  const recipients = (await Promise.all(
-    recipientsOutput.map(
-      async recipientOutput =>
-        (await core.coreBitcoinLikeOutput.getAddress(recipientOutput)).value,
-    ),
-  )).filter(Boolean);
-  if (isCancelled()) return;
-
-  const coreAmountFees = await core.coreBitcoinLikeTransaction.getFees(builded);
-  if (isCancelled()) return;
-
-  const fee = await await libcoreAmountToBigNumber(core, coreAmountFees);
-  if (isCancelled()) return;
-
-  // NB we don't check isCancelled() because the broadcast is not cancellable now!
-  const op: $Exact<Operation> = {
-    id: `${xpub}-${txHash}-OUT`,
-    hash: txHash,
-    type: "OUT",
-    value: BigNumber(transaction.amount).plus(fee),
-    fee,
-    blockHash: null,
-    blockHeight: null,
-    senders,
-    recipients,
+const doSignAndBroadcast = withLibcoreF(
+  core => async ({
     accountId,
-    date: new Date(),
-    extra: {},
-  };
+    derivationMode,
+    blockHeight,
+    seedIdentifier,
+    currency,
+    xpub,
+    index,
+    transaction,
+    deviceId,
+    isCancelled,
+    onSigned,
+    onOperationBroadcasted,
+  }: {
+    accountId: string,
+    derivationMode: DerivationMode,
+    seedIdentifier: string,
+    blockHeight: number,
+    currency: CryptoCurrency,
+    xpub: string,
+    index: number,
+    transaction: Transaction,
+    deviceId: string,
+    isCancelled: () => boolean,
+    onSigned: () => void,
+    onOperationBroadcasted: (optimisticOp: Operation) => void,
+  }): Promise<void> => {
+    const { feePerByte } = transaction;
+    if (!feePerByte) throw FeeNotLoaded();
+    if (isCancelled()) return;
 
-  onOperationBroadcasted(op);
-}
+    const walletName = getWalletName({
+      currency,
+      seedIdentifier,
+      derivationMode,
+    });
+
+    const coreWallet = await getOrCreateWallet({
+      core,
+      walletName,
+      currency,
+      derivationMode,
+    });
+    if (isCancelled()) return;
+    const coreAccount = await core.coreWallet.getAccount(coreWallet, index);
+    if (isCancelled()) return;
+    const bitcoinLikeAccount = await core.coreAccount.asBitcoinLikeAccount(
+      coreAccount,
+    );
+    if (isCancelled()) return;
+    const coreWalletCurrency = await core.coreWallet.getCurrency(coreWallet);
+    if (isCancelled()) return;
+    const amount = await bigNumberToLibcoreAmount(
+      core,
+      coreWalletCurrency,
+      transaction.amount,
+    );
+    if (isCancelled()) return;
+    const fees = await bigNumberToLibcoreAmount(
+      core,
+      coreWalletCurrency,
+      feePerByte,
+    );
+    if (isCancelled()) return;
+    const transactionBuilder = await core.coreBitcoinLikeAccount.buildTransaction(
+      bitcoinLikeAccount,
+    );
+    if (isCancelled()) return;
+
+    await core.coreBitcoinLikeTransactionBuilder.sendToAddress(
+      transactionBuilder,
+      amount,
+      transaction.recipient,
+    );
+    if (isCancelled()) return;
+    await core.coreBitcoinLikeTransactionBuilder.pickInputs(
+      transactionBuilder,
+      0,
+      0xffffff,
+    );
+    if (isCancelled()) return;
+
+    await core.coreBitcoinLikeTransactionBuilder.setFeesPerByte(
+      transactionBuilder,
+      fees,
+    );
+    if (isCancelled()) return;
+
+    const builded = await core.coreBitcoinLikeTransactionBuilder.build(
+      transactionBuilder,
+    );
+    if (isCancelled()) return;
+
+    const networkParams = await core.coreCurrency.getBitcoinLikeNetworkParameters(
+      coreWalletCurrency,
+    );
+    if (isCancelled()) return;
+
+    const sigHashType = (await core.coreBitcoinLikeNetworkParameters.getSigHash(
+      networkParams,
+    )).value.replace(/[< >]/g, ""); // FIXME FIXME FIXME;
+    if (isCancelled()) return;
+
+    const hasTimestamp = (await core.coreBitcoinLikeNetworkParameters.getUsesTimestampedTransaction(
+      networkParams,
+    )).value;
+    if (isCancelled()) return;
+
+    const transport = await open(deviceId);
+    let signedTransaction;
+
+    try {
+      signedTransaction = await signTransaction({
+        core,
+        isCancelled,
+        hwApp: new Btc(transport),
+        currency,
+        blockHeight,
+        coreTransaction: builded,
+        sigHashType: parseInt(sigHashType, 16),
+        hasTimestamp,
+        derivationMode,
+      }).catch(e => {
+        if (e && e.statusCode === StatusCodes.INCORRECT_P1_P2) {
+          throw new UpdateYourApp(`UpdateYourApp ${currency.id}`, currency);
+        }
+        throw e;
+      });
+    } finally {
+      transport.close();
+    }
+    if (isCancelled()) return;
+
+    onSigned();
+
+    const txHash = getValue(
+      await core.coreBitcoinLikeAccount.broadcastRawTransaction(
+        bitcoinLikeAccount,
+        signedTransaction,
+      ),
+    );
+    if (isCancelled()) return;
+
+    const sendersInput = await core.coreBitcoinLikeTransaction.getInputs(
+      builded,
+    );
+    if (isCancelled()) return;
+
+    const senders = (await Promise.all(
+      sendersInput.map(
+        async senderInput =>
+          (await core.coreBitcoinLikeInput.getAddress(senderInput)).value,
+      ),
+    )).filter(Boolean);
+    if (isCancelled()) return;
+
+    const recipientsOutput = await core.coreBitcoinLikeTransaction.getOutputs(
+      builded,
+    );
+    if (isCancelled()) return;
+
+    const recipients = (await Promise.all(
+      recipientsOutput.map(
+        async recipientOutput =>
+          (await core.coreBitcoinLikeOutput.getAddress(recipientOutput)).value,
+      ),
+    )).filter(Boolean);
+    if (isCancelled()) return;
+
+    const coreAmountFees = await core.coreBitcoinLikeTransaction.getFees(
+      builded,
+    );
+    if (isCancelled()) return;
+
+    const fee = await await libcoreAmountToBigNumber(core, coreAmountFees);
+    if (isCancelled()) return;
+
+    // NB we don't check isCancelled() because the broadcast is not cancellable now!
+    const op: $Exact<Operation> = {
+      id: `${xpub}-${txHash}-OUT`,
+      hash: txHash,
+      type: "OUT",
+      value: BigNumber(transaction.amount).plus(fee),
+      fee,
+      blockHash: null,
+      blockHeight: null,
+      senders,
+      recipients,
+      accountId,
+      date: new Date(),
+      extra: {},
+    };
+
+    onOperationBroadcasted(op);
+  },
+);

--- a/src/screens/DebugCrash.js
+++ b/src/screens/DebugCrash.js
@@ -5,7 +5,7 @@ import { StyleSheet, View } from "react-native";
 import type { NavigationScreenProp } from "react-navigation";
 import { Sentry } from "react-native-sentry";
 
-import loadLibcore from "../libcore/load";
+import { withLibcore } from "../libcore/access";
 
 import Button from "../components/Button";
 
@@ -29,10 +29,8 @@ class DebugBLE extends Component<
     throw new Error("DEBUG jsCrash");
   };
 
-  libcoreCrash = async () => {
-    const core = await loadLibcore();
-    await core.coreWalletPool.getWallet(null, null);
-  };
+  libcoreCrash = () =>
+    withLibcore(core => core.coreWalletPool.getWallet(null, null));
 
   nativeCrash = () => {
     Sentry.nativeCrash();


### PR DESCRIPTION
withLibcore() allows to track the pending job with the libcore and force to not flush() before everything is done, this was creating random crash in the app (iOS and Android).
we are scheduling the flush() a bit later so it might help a bit perf as well (basically it's a GC debounce)
