### PR TITLE
Disable keyboard hide on iOS on wrong password

### DIFF
--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -74,6 +74,7 @@ class PasswordInput extends PureComponent<Props, { isFocused: boolean }> {
           placeholder={placeholder}
           placeholderTextColor={error ? colors.alert : colors.fog}
           returnKeyType="done"
+          blurOnSubmit={false}
           onChangeText={onChange}
           onSubmitEditing={onSubmit}
           secureTextEntry={secureTextEntry}


### PR DESCRIPTION
When entering a password that requires validation (auth screen or password confirmation) pressing Done button on iOS made the Keyboard hide. This fixes that issue.
![out](https://user-images.githubusercontent.com/4631227/49387807-0d120180-f723-11e8-8553-3e6dd683caa9.gif)

