### PR TITLE
Fix AuthScreen forgot password behavior

### DIFF
--- a/src/components/BottomModal.js
+++ b/src/components/BottomModal.js
@@ -10,7 +10,7 @@ import colors from "../colors";
 import ButtonUseTouchable from "../context/ButtonUseTouchable";
 
 export type Props = {
-  id: string,
+  id?: string,
   isOpened: boolean,
   onClose: () => *,
   children?: *,
@@ -37,7 +37,7 @@ class BottomModal extends Component<Props> {
           {...rest}
         >
           <View style={[styles.modal, style]}>
-            {isOpened ? <TrackScreen category={id} /> : null}
+            {isOpened && id ? <TrackScreen category={id} /> : null}
             <StyledStatusBar
               backgroundColor={
                 Platform.OS === "android" ? "rgba(0,0,0,0.7)" : "transparent"

--- a/src/components/InfoModal.js
+++ b/src/components/InfoModal.js
@@ -19,7 +19,7 @@ type BulletItem = {
 };
 
 type Props = ModalProps & {
-  id: string,
+  id?: string,
   title: string | React$Element<*>,
   desc: string | React$Element<*>,
   bullets: BulletItem[],

--- a/src/context/AuthPass/AuthScreen.js
+++ b/src/context/AuthPass/AuthScreen.js
@@ -229,11 +229,7 @@ class AuthScreen extends PureComponent<Props, State> {
               <PoweredByLedger />
             </View>
           )}
-          <BottomModal
-            id="AuthScreenHardResetModal"
-            isOpened={isModalOpened}
-            onClose={this.onRequestClose}
-          >
+          <BottomModal isOpened={isModalOpened} onClose={this.onRequestClose}>
             <HardResetModal
               onRequestClose={this.onRequestClose}
               onHardReset={this.onHardReset}

--- a/src/index.js
+++ b/src/index.js
@@ -46,8 +46,6 @@ class App extends Component<*> {
   render() {
     return (
       <View style={styles.root}>
-        <StyledStatusBar />
-
         <DBSave
           dbKey="countervalues"
           throttle={2000}
@@ -113,6 +111,7 @@ export default class Root extends Component<{}, { appState: * }> {
           {(ready, store) =>
             ready ? (
               <Fragment>
+                <StyledStatusBar />
                 <HookSentry />
                 <HookAnalytics store={store} />
                 <AuthPass>


### PR DESCRIPTION
The fact that AuthScreen is outside of navigator make tracking
impossibru. So, this PR make `id` optional in Modal.

It also move StyledStatusBar to top top top level, because having it
outside of AuthScreen was making view blink when opening modal,
and it was producing heart attack.