### PR TITLE
Fixes for BLE

### DIFF
--- a/ios/ledgerlivemobile/Info.plist
+++ b/ios/ledgerlivemobile/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/src/api/Manager.js
+++ b/src/api/Manager.js
@@ -230,25 +230,24 @@ const API = {
   ),
 
   install: (transport: Transport<*>, context: string, params: *) =>
-    createDeviceSocket(
-      transport,
-      URL.format({
+    createDeviceSocket(transport, {
+      url: URL.format({
         pathname: `${BASE_SOCKET_URL}/install`,
         query: params,
       }),
-    ).pipe(remapSocketError(context)),
+      ignoreWebsocketErrorDuringBulk: true,
+    }).pipe(remapSocketError(context)),
 
   genuineCheck: (
     transport: Transport<*>,
     { targetId, perso }: { targetId: *, perso: * },
   ) =>
-    createDeviceSocket(
-      transport,
-      URL.format({
+    createDeviceSocket(transport, {
+      url: URL.format({
         pathname: `${BASE_SOCKET_URL}/genuine`,
         query: { targetId, perso },
       }),
-    ).pipe(
+    }).pipe(
       last(),
       filter(o => o.type === "result"),
       map(o => o.payload || ""),
@@ -259,13 +258,13 @@ const API = {
     context: string,
     { targetId, version }: { targetId: *, version: * },
   ) =>
-    createDeviceSocket(
-      transport,
-      URL.format({
+    createDeviceSocket(transport, {
+      url: URL.format({
         pathname: `${BASE_SOCKET_URL}/mcu`,
         query: { targetId, version },
       }),
-    ).pipe(
+      ignoreWebsocketErrorDuringBulk: true,
+    }).pipe(
       remapSocketError(context),
       last(), // not yet using the events
     ),

--- a/src/react-native-hw-transport-ble/BleTransport.js
+++ b/src/react-native-hw-transport-ble/BleTransport.js
@@ -64,6 +64,10 @@ export default class BluetoothTransport extends Transport<Device | string> {
   };
 
   static listen(observer: *) {
+    logSubject.next({
+      type: "verbose",
+      message: `listen...`,
+    });
     const stateSub = bleManager.onStateChange(state => {
       if (state === "PoweredOn") {
         stateSub.remove();
@@ -80,6 +84,10 @@ export default class BluetoothTransport extends Transport<Device | string> {
     const unsubscribe = () => {
       bleManager.stopDeviceScan();
       stateSub.remove();
+      logSubject.next({
+        type: "verbose",
+        message: `done listening.`,
+      });
     };
     return { unsubscribe };
   }
@@ -224,6 +232,10 @@ export default class BluetoothTransport extends Transport<Device | string> {
   }
 
   static disconnect = async (id: *) => {
+    logSubject.next({
+      type: "verbose",
+      message: `user disconnect(${id})`,
+    });
     await bleManager.cancelDeviceConnection(id);
   };
 

--- a/src/screens/DebugBLE.js
+++ b/src/screens/DebugBLE.js
@@ -70,7 +70,9 @@ class LogItem extends PureComponent<{ log: Log }> {
           flexDirection: "row",
         }}
       >
-        <LText style={{ fontSize: 10, flex: 1, color }}>{text}</LText>
+        <LText selectable style={{ fontSize: 10, flex: 1, color }}>
+          {text}
+        </LText>
         <LText style={{ marginRight: 5, fontSize: 8 }}>
           {log.date
             .toISOString()


### PR DESCRIPTION
- characteristic.monitor can return null data
- socket often terminate before the bulk was all run on device especially because slow nature of BLE. introduced a flag that would ignore socket to close during bulk. it seems there is a timeout on the hsm that close the WebSocket :( . Maybe it would benefit the desktop later too, maybe it's why many users can never finish the firmware update!!