### PR TITLE
Android transition discussion

### DIFF
--- a/src/navigation/navigatorConfig.js
+++ b/src/navigation/navigatorConfig.js
@@ -24,26 +24,31 @@ export const stackNavigatorConfig: any = {
 if (Platform.OS === "android") {
   stackNavigatorConfig.transitionConfig = () => ({
     transitionSpec: {
-      duration: 200,
+      duration: 300,
       easing: Easing.out(Easing.poly(4)),
       timing: Animated.timing,
+      useNativeDriver: true,
     },
     screenInterpolator: sceneProps => {
-      const { layout, position, scene } = sceneProps;
-      const { index } = scene;
+      const { position, scene } = sceneProps;
 
-      const height = layout.initHeight;
-      const translateY = position.interpolate({
-        inputRange: [index - 1, index, index + 1],
-        outputRange: [height, 0, 0],
-      });
-
+      const index = scene.index;
       const opacity = position.interpolate({
-        inputRange: [index - 1, index - 0.99, index],
-        outputRange: [0, 1, 1],
+        inputRange: [index - 1, index - 0.8, index],
+        outputRange: [0, 0, 1],
+        extrapolate: "clamp",
       });
 
-      return { opacity, transform: [{ translateY }] };
+      const translateY = position.interpolate({
+        inputRange: [index - 1, index],
+        outputRange: [50, 0],
+      });
+      const translateX = 0;
+
+      return {
+        opacity,
+        transform: [{ translateX }, { translateY }],
+      };
     },
   });
 }

--- a/src/navigation/styles.js
+++ b/src/navigation/styles.js
@@ -26,7 +26,8 @@ if (Platform.OS === "ios") {
     elevation: 0,
   };
   headerStyleShadow = {
-    elevation: 1,
+    borderBottomWidth: 1,
+    borderBottomColor: colors.lightFog,
   };
 }
 

--- a/src/screens/Settings/General/AnalyticsRow.js
+++ b/src/screens/Settings/General/AnalyticsRow.js
@@ -59,7 +59,11 @@ class AnalyticsRow extends PureComponent<Props, State> {
           onHelpPress={this.onOpen}
           alignedTop
         >
-          <Switch value={analyticsEnabled} onValueChange={setAnalytics} />
+          <Switch
+            style={{ opacity: 0.99 }}
+            value={analyticsEnabled}
+            onValueChange={setAnalytics}
+          />
         </SettingsRow>
         <InfoModal
           id="AnalyticsModal"

--- a/src/screens/Settings/General/AuthSecurityToggle.js
+++ b/src/screens/Settings/General/AuthSecurityToggle.js
@@ -40,7 +40,11 @@ class AuthSecurityToggle extends Component<Props> {
           desc={<Trans i18nKey="settings.display.passwordDesc" />}
           alignedTop
         >
-          <Switch value={!!privacy} onValueChange={this.onValueChange} />
+          <Switch
+            style={{ opacity: 0.99 }}
+            value={!!privacy}
+            onValueChange={this.onValueChange}
+          />
         </SettingsRow>
         {privacy ? <BiometricsRow /> : null}
       </Fragment>

--- a/src/screens/Settings/General/DeveloperModeRow.js
+++ b/src/screens/Settings/General/DeveloperModeRow.js
@@ -37,7 +37,11 @@ class DeveloperModeRow extends PureComponent<Props> {
           event={developerModeEnabled ? "EnableDevMode" : "DisableDevMode"}
           onUpdate
         />
-        <Switch value={developerModeEnabled} onValueChange={setDeveloperMode} />
+        <Switch
+          style={{ opacity: 0.99 }}
+          value={developerModeEnabled}
+          onValueChange={setDeveloperMode}
+        />
       </SettingsRow>
     );
   }

--- a/src/screens/Settings/General/ReportErrorsRow.js
+++ b/src/screens/Settings/General/ReportErrorsRow.js
@@ -32,7 +32,11 @@ class ReportErrorsRow extends PureComponent<Props> {
         alignedTop
         {...props}
       >
-        <Switch value={reportErrorsEnabled} onValueChange={setReportErrors} />
+        <Switch
+          style={{ opacity: 0.99 }}
+          value={reportErrorsEnabled}
+          onValueChange={setReportErrors}
+        />
       </SettingsRow>
     );
   }


### PR DESCRIPTION
https://github.com/LedgerHQ/ledger-live-mobile/issues/589

Main problem with this is that we don't have a nice shadow over the accounts on the porfolio/accounts screens. In Android I remember we could do transitions leaving a shared element behind and I think there's something similar here, but I can't find anything with the library we are using for navigation.

What do we do?
