### PR TITLE
Links the contact us buttons and allows to close bottom modal

### DIFF
--- a/src/screens/ReceiveFunds/03-Confirmation.js
+++ b/src/screens/ReceiveFunds/03-Confirmation.js
@@ -103,6 +103,10 @@ class ReceiveConfirmation extends Component<Props, State> {
     }
   }
 
+  contactUs = () => {
+    Linking.openURL(urls.faq);
+  };
+
   verifyOnDevice = async (deviceId: string) => {
     const { account, navigation } = this.props;
 
@@ -285,6 +289,7 @@ class ReceiveConfirmation extends Component<Props, State> {
         <BottomModal
           id="ReceiveConfirmationModal"
           isOpened={isModalOpened}
+          onClose={this.onModalClose}
           onModalHide={onModalHide}
         >
           {error ? (
@@ -306,7 +311,7 @@ class ReceiveConfirmation extends Component<Props, State> {
                   type="secondary"
                   title={<Trans i18nKey="common.contactUs" />}
                   containerStyle={styles.button}
-                  onPress={() => {}} // TODO do something
+                  onPress={this.contactUs}
                 />
                 <Button
                   event="ReceiveRetry"

--- a/src/screens/SendFunds/07-ValidationError.js
+++ b/src/screens/SendFunds/07-ValidationError.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { Component } from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, Linking } from "react-native";
 import { connect } from "react-redux";
 import { translate } from "react-i18next";
 import type { NavigationScreenProp } from "react-navigation";
@@ -10,6 +10,7 @@ import { accountScreenSelector } from "../../reducers/accounts";
 import { TrackScreen } from "../../analytics";
 import colors from "../../colors";
 import ValidateError from "./ValidateError";
+import { urls } from "../../config/urls";
 
 type Props = {
   account: Account,
@@ -37,7 +38,7 @@ class ValidationError extends Component<Props> {
   };
 
   contactUs = () => {
-    console.warn("not implemented");
+    Linking.openURL(urls.faq);
   };
 
   retry = () => {


### PR DESCRIPTION
Error modals on Send/Validation and Receive/Confirmation were not doing anything, linked to the support URL until we have something else, and also fixed the linked issue where the bottom modal didn't have a linked `onClose` prop so... it didn't close `onBackdropPress` or `onBackButtonPress`.