### PR TITLE
LL-667 + LL-672

### DIFF
--- a/src/bridge/RNLibcoreAccountBridge.js
+++ b/src/bridge/RNLibcoreAccountBridge.js
@@ -1,7 +1,7 @@
 // @flow
 import invariant from "invariant";
 import { BigNumber } from "bignumber.js";
-import { FeeNotLoaded } from "@ledgerhq/live-common/lib/errors";
+import { FeeNotLoaded, InvalidAddress } from "@ledgerhq/live-common/lib/errors";
 
 import type { AccountBridge } from "./types";
 import { makeLRUCache } from "../logic/cache";
@@ -34,7 +34,10 @@ const startSync = (initialAccount, _observation) => syncAccount(initialAccount);
 
 const checkValidRecipient = makeLRUCache(
   (currency, recipient) => {
-    if (!recipient) return Promise.resolve(null);
+    if (!recipient)
+      return Promise.reject(
+        new InvalidAddress("", { currencyName: currency.name }),
+      );
     return isValidRecipient({ currency, recipient });
   },
   (currency, recipient) => `${currency.id}_${recipient}`,

--- a/src/screens/SendFunds/02-SelectRecipient.js
+++ b/src/screens/SendFunds/02-SelectRecipient.js
@@ -33,6 +33,7 @@ type Props = {
     params: {
       accountId: string,
       transaction: *,
+      justScanned?: boolean,
     },
   }>,
   t: T,
@@ -42,7 +43,6 @@ type State = {
   addressStatus: string,
   address: *,
   error: ?Error,
-  shouldUpdate: boolean,
 };
 
 class SendSelectRecipient extends Component<Props, State> {
@@ -86,16 +86,15 @@ class SendSelectRecipient extends Component<Props, State> {
   }
 
   componentDidUpdate(_, { address: prevAddress }) {
-    // FIXME we should refactor this in a more elegant way
     const { navigation, account } = this.props;
-    const { shouldUpdate } = this.state;
-    if (!shouldUpdate) {
+    if (navigation.getParam("justScanned")) {
+      delete navigation.state.params.justScanned;
       const transaction = navigation.getParam("transaction");
       if (transaction) {
         const bridge = getAccountBridge(account);
         const address = bridge.getTransactionRecipient(account, transaction);
         if (address && prevAddress !== address) {
-          this.onChangeText(address, false);
+          this.onChangeText(address);
         }
       }
     }
@@ -105,7 +104,6 @@ class SendSelectRecipient extends Component<Props, State> {
     addressStatus: "pending",
     address: "",
     error: null,
-    shouldUpdate: false,
   };
 
   input = React.createRef();
@@ -117,8 +115,8 @@ class SendSelectRecipient extends Component<Props, State> {
     this.onChangeText("");
   };
 
-  onChangeText = (address: string, shouldUpdate = true) => {
-    this.setState({ address, shouldUpdate });
+  onChangeText = (address: string) => {
+    this.setState({ address });
     this.validateAddress(address);
   };
 

--- a/src/screens/SendFunds/ScanRecipient.js
+++ b/src/screens/SendFunds/ScanRecipient.js
@@ -92,6 +92,7 @@ class ScanRecipient extends PureComponent<Props, State> {
     this.props.navigation.navigate("SendSelectRecipient", {
       accountId: account.id,
       transaction: t,
+      justScanned: true,
     });
   };
 


### PR DESCRIPTION
While solving the address validation reported (was only affecting bitcoin family) I found a bug where you weren't able to scan a qrcode if you have typed (even after deleting all) in the receiver input field. This functionality had a todo to address this, maybe this is enough. @gre it's your `todo`

Scratch that, it's https://ledgerhq.atlassian.net/browse/LL-672 (the unreported)

