### PR TITLE
Block send confirmation UI only while signing

### DIFF
--- a/src/bridge/types.js
+++ b/src/bridge/types.js
@@ -19,6 +19,7 @@ import type {
 export type DeviceId = string;
 
 export type SignAndBroadcastEvent =
+  | { type: "signing" }
   | { type: "signed" }
   | { type: "broadcasted", operation: Operation };
 


### PR DESCRIPTION
The back (button & gesture) is now disabled only while the device is signing the transaction