### PR TITLE
Fix connection failure on BT < 4.2

### DIFF
--- a/src/react-native-hw-transport-ble/BleTransport.js
+++ b/src/react-native-hw-transport-ble/BleTransport.js
@@ -30,7 +30,7 @@ const ServiceUuid = "d973f2e0-b19e-11e2-9e96-0800200c9a66";
 const WriteCharacteristicUuid = "d973f2e2-b19e-11e2-9e96-0800200c9a66";
 const NotifyCharacteristicUuid = "d973f2e1-b19e-11e2-9e96-0800200c9a66";
 
-const connectOptions = {
+let connectOptions = {
   requestMTU: 156,
 };
 
@@ -146,6 +146,7 @@ export default class BluetoothTransport extends Transport<Device | string> {
           device = await bleManager.connectToDevice(deviceOrId, connectOptions);
         } catch (e) {
           if (e.errorCode === BleErrorCode.DeviceMTUChangeFailed) {
+            connectOptions = {};
             device = await bleManager.connectToDevice(deviceOrId);
           } else {
             throw e;
@@ -169,6 +170,7 @@ export default class BluetoothTransport extends Transport<Device | string> {
         await device.connect(connectOptions);
       } catch (e) {
         if (e.errorCode === BleErrorCode.DeviceMTUChangeFailed) {
+          connectOptions = {};
           await device.connect();
         } else {
           throw e;


### PR DESCRIPTION
When `connect` fails because of the `requestMTU` option,  re-try without said option.

### Type

Bug fix

### Context

On BlueTooth < 4.2 it shouldn't be possible to set `requestMTU`, but we have a 4.1 test phone (_Samsung Galaxy Note 4_) which is totally OK with that.
On the other hand, our 4.1 _Xiaomi Redmi Note 3_ behaves as expected and fails.

~~This naïve fix tries **every time** to do a connect with a `requestMTU` and re-do without it on fail.~~

~~TO DO: be smarter than that.~~
~~HODL for now.~~

### Parts of the app affected / Test plan

Try to pair/connect a balenos on a _Xiaomi Redmi Note 3_
