### PR TITLE
EmptyStateAccount : iconLeft -> IconLeft

### DIFF
--- a/src/screens/Account/EmptyStateAccount.js
+++ b/src/screens/Account/EmptyStateAccount.js
@@ -42,7 +42,7 @@ class EmptyStateAccount extends PureComponent<{
             title={<Trans i18nKey="account.emptyState.buttons.receiveFunds" />}
             onPress={this.goToReceiveFunds}
             containerStyle={styles.receiveButton}
-            iconLeft={Receive}
+            IconLeft={Receive}
           />
         </View>
       </View>


### PR DESCRIPTION
The reason there was an inconsistency in between the new no-op portfolio and the empty account screens in that the receive button had/hadn't an icon on the left was because of this typo.
![image](https://user-images.githubusercontent.com/4631227/49830822-8b5d4c00-fd92-11e8-803a-2057507e884e.png)
