### PR TITLE
Generic error capped number of lines

### DIFF
--- a/src/components/GenericErrorView.js
+++ b/src/components/GenericErrorView.js
@@ -26,16 +26,12 @@ class GenericErrorRendering extends PureComponent<{
             <ErrorIcon error={error} />
           </View>
         ) : null}
-        <LText secondary semiBold style={styles.title}>
-          <TranslatedError error={error} numberOfLines={3} />
+        <LText secondary semiBold style={styles.title} numberOfLines={3}>
+          <TranslatedError error={error} />
         </LText>
         {withDescription ? (
-          <LText style={styles.description}>
-            <TranslatedError
-              error={error}
-              field="description"
-              numberOfLines={6}
-            />
+          <LText style={styles.description} numberOfLines={6}>
+            <TranslatedError error={error} field="description" />
           </LText>
         ) : null}
       </View>


### PR DESCRIPTION
Super long obnoxious errors were not being limited in size because the `numberOfLines` prop was passed to the `TranslatedError` and not the parent `LText`. `TranslatedError` does nothing with that value.

![screen shot 2018-12-13 at 15 17 41](https://user-images.githubusercontent.com/4631227/49944562-0174c680-feeb-11e8-902e-6b9f386fd116.png)
![screen shot 2018-12-13 at 15 04 14](https://user-images.githubusercontent.com/4631227/49944563-0174c680-feeb-11e8-8a2f-d611d5354760.png)

