### PR TITLE
Added counter value polling to account refresh

### DIFF
--- a/src/components/accountSyncRefreshControl.js
+++ b/src/components/accountSyncRefreshControl.js
@@ -8,6 +8,7 @@ import type { BehaviorAction } from "../bridge/BridgeSyncContext";
 import type { AsyncState } from "../reducers/bridgeSync";
 import { accountSyncStateSelector } from "../reducers/bridgeSync";
 import { BridgeSyncConsumer } from "../bridge/BridgeSyncContext";
+import CounterValues from "../countervalues";
 
 const mapStateToProps = createStructuredSelector({
   accountSyncState: accountSyncStateSelector,
@@ -24,11 +25,16 @@ const Connector = (Decorated: React$ComponentType<any>) => {
       {setSyncBehavior => {
         const isPending = accountSyncState.pending;
         return (
-          <Decorated
-            isPending={isPending}
-            setSyncBehavior={setSyncBehavior}
-            {...rest}
-          />
+          <CounterValues.PollingConsumer>
+            {cvPolling => (
+              <Decorated
+                cvPoll={cvPolling.poll}
+                isPending={isPending}
+                setSyncBehavior={setSyncBehavior}
+                {...rest}
+              />
+            )}
+          </CounterValues.PollingConsumer>
         );
       }}
     </BridgeSyncConsumer>
@@ -69,6 +75,7 @@ export default (ScrollListLike: any) => {
 
     onPress = () => {
       const { setSyncBehavior, accountId } = this.props;
+      this.props.cvPoll();
       setSyncBehavior({
         type: "SYNC_ONE_ACCOUNT",
         accountId,


### PR DESCRIPTION
Unless there is a reason to not do this (very well could be) that I'm not aware of, this solves a bug/annoyance. It became apparent when we got the balance back from no internet on. 

### Before
![without](https://user-images.githubusercontent.com/4631227/49951305-e6f61980-fef9-11e8-96e2-3d98e5611dba.gif)

### After
![with](https://user-images.githubusercontent.com/4631227/49951309-e8bfdd00-fef9-11e8-878f-2fe63faee22a.gif)
