### PR TITLE
LL-681 Add account setting "Node" for XRP

### DIFF
--- a/src/navigators.js
+++ b/src/navigators.js
@@ -71,6 +71,7 @@ import Transfer from "./screens/Transfer";
 import AccountSettingsMain from "./screens/AccountSettings";
 import EditAccountUnits from "./screens/AccountSettings/EditAccountUnits";
 import EditAccountName from "./screens/AccountSettings/EditAccountName";
+import EditAccountNode from "./screens/AccountSettings/EditAccountNode";
 import DebugBLE from "./screens/DebugBLE";
 import DebugBLEBenchmark from "./screens/DebugBLEBenchmark";
 import DebugCrash from "./screens/DebugCrash";
@@ -340,6 +341,7 @@ const AccountSettings = createStackNavigator(
     AccountSettingsMain,
     EditAccountUnits,
     EditAccountName,
+    EditAccountNode,
     AccountCurrencySettings: CurrencySettings,
     AccountRateProviderSettings: RateProviderSettings,
   },

--- a/src/screens/AccountSettings/AccountNodeRow.js
+++ b/src/screens/AccountSettings/AccountNodeRow.js
@@ -1,0 +1,59 @@
+/* @flow */
+import React, { PureComponent } from "react";
+import { Trans } from "react-i18next";
+import { StyleSheet } from "react-native";
+import type { NavigationScreenProp } from "react-navigation";
+import type { Account } from "@ledgerhq/live-common/lib/types";
+import SettingsRow from "../../components/SettingsRow";
+import { getAccountBridge } from "../../bridge";
+import LText from "../../components/LText";
+import colors from "../../colors";
+
+type Props = {
+  navigation: NavigationScreenProp<*>,
+  account: Account,
+};
+
+class AccountNodeRow extends PureComponent<Props> {
+  render() {
+    const { navigation, account } = this.props;
+    const bridge = getAccountBridge(account);
+
+    return (
+      <SettingsRow
+        event="AccountNodeRow"
+        title={<Trans i18nKey="account.settings.endpointConfig.title" />}
+        desc={<Trans i18nKey="account.settings.endpointConfig.desc" />}
+        arrowRight
+        alignedTop
+        onPress={() =>
+          navigation.navigate("EditAccountNode", {
+            accountId: account.id,
+          })
+        }
+      >
+        <LText
+          semiBold
+          numberOfLines={1}
+          ellipsizeMode="tail"
+          style={styles.accountNode}
+        >
+          {account.endpointConfig ||
+            (bridge.getDefaultEndpointConfig &&
+              bridge.getDefaultEndpointConfig()) ||
+            ""}
+        </LText>
+      </SettingsRow>
+    );
+  }
+}
+
+export default AccountNodeRow;
+
+const styles = StyleSheet.create({
+  accountNode: {
+    flexShrink: 1,
+    textAlign: "right",
+    color: colors.grey,
+  },
+});

--- a/src/screens/AccountSettings/EditAccountNode.js
+++ b/src/screens/AccountSettings/EditAccountNode.js
@@ -1,0 +1,194 @@
+/* @flow */
+import React, { PureComponent } from "react";
+import i18next from "i18next";
+import { ScrollView, View, StyleSheet } from "react-native";
+import { SafeAreaView } from "react-navigation";
+import type { NavigationScreenProp } from "react-navigation";
+import type { Account } from "@ledgerhq/live-common/lib/types";
+import { connect } from "react-redux";
+import { compose } from "redux";
+import { Trans, translate } from "react-i18next";
+import { createStructuredSelector } from "reselect";
+import Icon from "react-native-vector-icons/dist/Feather";
+import { accountScreenSelector } from "../../reducers/accounts";
+import { updateAccount } from "../../actions/accounts";
+import Button from "../../components/Button";
+import TextInput from "../../components/TextInput";
+import KeyboardView from "../../components/KeyboardView";
+import LText, { getFontStyle } from "../../components/LText";
+import TranslatedError from "../../components/TranslatedError";
+import { getAccountBridge } from "../../bridge";
+
+import colors from "../../colors";
+
+class FooterError extends PureComponent<{ error: Error }> {
+  render() {
+    const { error } = this.props;
+
+    return (
+      <LText style={styles.error} numberOfLines={2}>
+        <Icon color={colors.alert} size={16} name="alert-triangle" />{" "}
+        <TranslatedError error={error} />
+      </LText>
+    );
+  }
+}
+
+type Props = {
+  navigation: NavigationScreenProp<{
+    accountId: string,
+  }>,
+  updateAccount: Function,
+  account: Account,
+};
+
+type State = {
+  accountNode: string,
+  error: ?Error,
+};
+
+const mapStateToProps = createStructuredSelector({
+  account: accountScreenSelector,
+});
+
+const mapDispatchToProps = {
+  updateAccount,
+};
+
+class EditAccountNode extends PureComponent<Props, State> {
+  state = {
+    accountNode: "",
+    error: null,
+  };
+
+  static navigationOptions = {
+    title: i18next.t("account.settings.endpointConfig.title"),
+  };
+
+  onChangeText = (accountNode: string) => {
+    this.setState({ accountNode });
+  };
+
+  onNodeEndEditing = async () => {
+    const { updateAccount, account, navigation } = this.props;
+    const { accountNode } = this.state;
+
+    if (!accountNode.length) {
+      navigation.goBack();
+    }
+
+    const isValid = await this.validateNode();
+
+    if (isValid) {
+      updateAccount({
+        ...account,
+        endpointConfig: accountNode,
+      });
+      navigation.goBack();
+    }
+  };
+
+  validateNode = async () => {
+    const { account } = this.props;
+    const { accountNode } = this.state;
+
+    const bridge = getAccountBridge(account);
+
+    try {
+      if (bridge.validateEndpointConfig) {
+        await bridge.validateEndpointConfig(accountNode);
+      }
+      return true;
+    } catch (error) {
+      this.setState({ error });
+      return false;
+    }
+  };
+
+  render() {
+    const { account } = this.props;
+    const { error } = this.state;
+    const bridge = getAccountBridge(account);
+
+    return (
+      <SafeAreaView style={styles.safeArea}>
+        <KeyboardView style={styles.body}>
+          <ScrollView contentContainerStyle={styles.root}>
+            <TextInput
+              autoFocus
+              style={styles.textInputAS}
+              defaultValue={
+                account.endpointConfig ||
+                (bridge.getDefaultEndpointConfig &&
+                  bridge.getDefaultEndpointConfig()) ||
+                ""
+              }
+              returnKeyType="done"
+              onChangeText={accountNode =>
+                this.setState({ accountNode, error: null })
+              }
+              onSubmitEditing={this.onNodeEndEditing}
+              clearButtonMode="while-editing"
+              keyboardType="url"
+            />
+            <View style={styles.flex}>
+              {error ? <FooterError error={error} /> : null}
+              <Button
+                event="EditAccountNodeApply"
+                type="primary"
+                title={<Trans i18nKey="common.apply" />}
+                onPress={this.onNodeEndEditing}
+                containerStyle={styles.buttonContainer}
+              />
+            </View>
+          </ScrollView>
+        </KeyboardView>
+      </SafeAreaView>
+    );
+  }
+}
+
+export default compose(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+  ),
+  translate(),
+)(EditAccountNode);
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.white,
+  },
+  body: {
+    flexDirection: "column",
+    flex: 1,
+    backgroundColor: colors.white,
+  },
+  textInputAS: {
+    padding: 16,
+    marginRight: 8,
+    fontSize: 20,
+    color: colors.darkBlue,
+    ...getFontStyle({ semiBold: true }),
+  },
+  buttonContainer: {
+    marginHorizontal: 16,
+  },
+  flex: {
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "flex-end",
+    paddingBottom: 16,
+  },
+  error: {
+    alignSelf: "center",
+    color: colors.alert,
+    fontSize: 14,
+    marginBottom: 10,
+  },
+});

--- a/src/screens/AccountSettings/index.js
+++ b/src/screens/AccountSettings/index.js
@@ -16,6 +16,7 @@ import { TrackScreen } from "../../analytics";
 import AccountNameRow from "./AccountNameRow";
 import AccountUnitsRow from "./AccountUnitsRow";
 import AccountCurrencyRow from "./AccountCurrencyRow";
+import AccountNodeRow from "./AccountNodeRow";
 import DeleteAccountRow from "./DeleteAccountRow";
 import DeleteAccountModal from "./DeleteAccountModal";
 
@@ -74,6 +75,9 @@ class AccountSettings extends PureComponent<Props, State> {
             currency={account.currency}
             navigation={navigation}
           />
+          {account.currency.id === "ripple" ? (
+            <AccountNodeRow account={account} navigation={navigation} />
+          ) : null}
         </View>
         <View style={styles.sectionRow}>
           <DeleteAccountRow onPress={this.onPress} />


### PR DESCRIPTION
Add the ability the change node for XRP accounts via account settings

![screen shot 2018-12-13 at 18 13 25](https://user-images.githubusercontent.com/13920153/49955401-fcbc0c80-ff02-11e8-866f-889d182e5439.png)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-681

### Parts of the app affected / Test plan

- Open settings on a XRP account:
  - The _Node_ setting should be present
  - The default value should be `wss://s2.rippple.com`
  - Tapping the setting should open a screen to edit address
  - Pressing _Apply_ should save the new address if valid and display an error if not
  - Pressing _Apply_ with the field empty should dismiss the screen without saving
  - The screen should close on success
- Open settings on a non XRP account:
  - The _Node_ setting should not appear
