### PR TITLE
Make the install spinner start at 0% when at 0%

### DIFF
--- a/src/screens/Manager/AppAction.js
+++ b/src/screens/Manager/AppAction.js
@@ -32,7 +32,7 @@ class PendingProgress extends PureComponent<{
     return (
       <View style={progressStyles.centered}>
         <ProgressCircle
-          progress={0.15 + 0.85 * progress}
+          progress={progress}
           color={colors.live}
           unfilledColor={colors.fog}
           borderWidth={0}


### PR DESCRIPTION
This was only making sense because previous implementation didn't had the disk style.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->


<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->


<!-- e.g. GitHub issue #45 / contextual discussion -->

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
