### PR TITLE
Adds a clipboard watcher inside the app to remove non-text content

### DIFF
--- a/android/app/src/main/java/com/ledger/live/MainActivity.java
+++ b/android/app/src/main/java/com/ledger/live/MainActivity.java
@@ -1,5 +1,8 @@
 package com.ledger.live;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.os.Bundle;
 
 import com.facebook.react.ReactFragmentActivity;
@@ -27,6 +30,28 @@ public class MainActivity extends ReactFragmentActivity {
             SplashScreen.show(this, true);
         }
         super.onCreate(savedInstanceState);
+
+        /**
+         * Addresses an inconvenient side-effect of using `password-visible`, that allowed styled
+         * texts to be pasted (receiver's address for instance) retaining the styles of the source
+         * text.
+         */
+        final ClipboardManager clipboard = (ClipboardManager) this.getSystemService(Context.CLIPBOARD_SERVICE);
+        clipboard.addPrimaryClipChangedListener( new ClipboardManager.OnPrimaryClipChangedListener() {
+            boolean breakLoop = false;
+            public void onPrimaryClipChanged() {
+                if(breakLoop){
+                    breakLoop = false;
+                    return;
+                }
+
+                ClipData clipData = clipboard.getPrimaryClip();
+                ClipData.Item item = clipData.getItemAt(0);
+                ClipData clip = ClipData.newPlainText("overriden text", item.coerceToText(MainActivity.this).toString());
+                breakLoop = true;
+                clipboard.setPrimaryClip(clip);
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
For most this might be an unknown issue but on some (all?) Android devices, when you copy an address from Operation details for instance and paste it as the recipient address, it was pasting the styles of the operation details text.

This looks for changes on the clipboard using the `ClipboardManager` natively on Android and overrides the content to fetch a text-only version of it.