### PR TITLE
LL-783 Replaced all "Contact Us" button's urls with the new request url

### DIFF
--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -2,6 +2,7 @@
 
 export const urls = {
   faq: "https://support.ledgerwallet.com/hc/en-us",
+  contact: "https://support.ledger.com/hc/en-us/requests/new",
   terms: "https://www.ledger.com/pages/terms-of-use-and-disclaimer",
   privacyPolicy: "https://www.ledgerwallet.com/privacy-policy",
   buyNanoX: "https://www.ledger.com/products/ledger-nano-x",

--- a/src/screens/Onboarding/steps/security-checklist.js
+++ b/src/screens/Onboarding/steps/security-checklist.js
@@ -81,7 +81,7 @@ class OnboardingStepSecurityChecklist extends Component<
     }
   };
 
-  contactSupport = () => Linking.openURL(urls.faq);
+  contactSupport = () => Linking.openURL(urls.contact);
 
   scrollView = createRef();
 

--- a/src/screens/ReceiveFunds/03-Confirmation.js
+++ b/src/screens/ReceiveFunds/03-Confirmation.js
@@ -106,7 +106,7 @@ class ReceiveConfirmation extends Component<Props, State> {
   }
 
   contactUs = () => {
-    Linking.openURL(urls.faq);
+    Linking.openURL(urls.contact);
   };
 
   verifyOnDevice = async (deviceId: string) => {

--- a/src/screens/SendFunds/07-ValidationError.js
+++ b/src/screens/SendFunds/07-ValidationError.js
@@ -39,7 +39,7 @@ class ValidationError extends Component<Props> {
   };
 
   contactUs = () => {
-    Linking.openURL(urls.faq);
+    Linking.openURL(urls.contact);
   };
 
   retry = () => {


### PR DESCRIPTION
We were using a single url for both "need help" and "contact us" links, according to LL-783 the "contact us" links should go to directly open a new request. This addresses that issue.