### PR TITLE
LL-791 Removes double padding on manager

### DIFF
--- a/src/navigators.js
+++ b/src/navigators.js
@@ -165,7 +165,7 @@ const ManagerMain = createMaterialTopTabNavigator(
       },
       style: {
         backgroundColor: colors.white,
-        ...styles.header,
+        height: 48,
       },
       indicatorStyle: {
         backgroundColor: colors.live,


### PR DESCRIPTION
For Android, we were applying the styles of the Header, which includes a 16 padding for the notification bar, to the tabbed header, Device/AppList. Unless we are using that screen in some other location that I can't locate, disregarding the padding should be safe.

![doublepadding](https://user-images.githubusercontent.com/4631227/50443257-b56e4c80-0902-11e9-8202-c4e4af959249.jpg)
