### PR TITLE
LL-792 Fixes double summary screen on failed validation after retry

### DIFF
--- a/src/screens/SendFunds/07-ValidationError.js
+++ b/src/screens/SendFunds/07-ValidationError.js
@@ -44,10 +44,7 @@ class ValidationError extends Component<Props> {
 
   retry = () => {
     const { navigation } = this.props;
-    // $FlowFixMe
-    navigation.replace("SendSummary", {
-      ...navigation.state.params,
-    });
+    navigation.goBack();
   };
 
   render() {


### PR DESCRIPTION
> The numbers represent the screens in the send flow

## The bug
![asd2](https://user-images.githubusercontent.com/4631227/50445704-b3ab8580-0910-11e9-9af3-b5949665b666.png)

When going through the send flow, after a failed validation on the device/posting the transaction, we would replace the current screen with the summary one, leading to having the current summary page and one in the screen stack from before. Replacing made sense for the middle screens (5,6) but not for 7 to 4.

## The fix
![asd](https://user-images.githubusercontent.com/4631227/50445705-b4441c00-0910-11e9-9fae-6d5d39336182.jpg)
Simply going back to the previous screen, goes back to 4. 
