### PR TITLE
LL-789 Added back marketcap sorting to Manager

### DIFF
--- a/src/screens/Manager/AppsList.js
+++ b/src/screens/Manager/AppsList.js
@@ -20,6 +20,7 @@ import AppsListError from "./AppsListError";
 import AppRow from "./AppRow";
 import AppAction from "./AppAction";
 import { developerModeEnabledSelector } from "../../reducers/settings";
+import { getFullListSortedCryptoCurrencies } from "../../countervalues";
 
 const actionKey = action => `${action.app.id}_${action.type}`;
 
@@ -78,7 +79,11 @@ class ManagerAppsList extends Component<
       const { navigation, developerModeEnabled } = this.props;
       const { deviceInfo } = navigation.getParam("meta");
 
-      const apps = await manager.getAppsList(deviceInfo, developerModeEnabled);
+      const apps = await manager.getAppsList(
+        deviceInfo,
+        developerModeEnabled,
+        getFullListSortedCryptoCurrencies,
+      );
 
       if (this.unmount) return;
       this.setState({


### PR DESCRIPTION
At some point, we stopped using the cached sorted list of cryptocurrencies from `getFullListSortedCryptoCurrencies`, unless this was intentionally removed and meant to be integrated into live-common (@gre  ?) this brings back the order in the meantime.

![image](https://user-images.githubusercontent.com/4631227/50564134-de3b7b00-0d22-11e9-9c46-4dcea19b5ac2.png)
