### PR TITLE
Fixes a warning during opening of manager for Nano X

### DIFF
--- a/src/screens/Manager/Device.js
+++ b/src/screens/Manager/Device.js
@@ -53,9 +53,9 @@ class DeviceLabel extends Component<Props & { tintColor: string }, State> {
   async componentDidMount() {
     const { navigation } = this.props;
     const { deviceInfo } = navigation.getParam("meta");
-    const { osu, final } = await manager
-      .getLatestFirmwareForDevice(deviceInfo)
-      .catch(() => null);
+    const firmware = await manager.getLatestFirmwareForDevice(deviceInfo);
+    if (!firmware) return;
+    const { osu, final } = firmware;
     this.setState({
       haveUpdate: !!osu,
       osu,


### PR DESCRIPTION
- first, we don't want to silent the error to be thrown (in promise uncaught, fine for now)
- second, we don't want to have a weird "osu is not in null" runtime cryptic error