### PR TITLE
Multiline and remove uninstall cta back to account

### DIFF
--- a/src/screens/Manager/AppAction.js
+++ b/src/screens/Manager/AppAction.js
@@ -135,6 +135,8 @@ class AppAction extends PureComponent<
     const { pending, error, progress } = this.state;
     const path = `${action.type}.${pending ? "loading" : "done"}`;
     const progressPercentage = Math.round(progress * 100);
+    const installing = action.type === "install";
+
     const icon = error ? (
       <ErrorIcon error={error} />
     ) : (
@@ -208,14 +210,17 @@ class AppAction extends PureComponent<
           <View style={styles.buttonsContainer}>
             <Button
               event="ManagerAppActionDone"
-              type={error ? "primary" : "secondary"}
+              type={
+                error || (!pending && !installing) ? "primary" : "secondary"
+              }
               containerStyle={styles.button}
               onPress={onClose}
               disabled={pending}
               title={buttonTitle}
             />
             {!error &&
-              !pending && (
+              !pending &&
+              installing && (
                 <Button
                   event="ManagerAppActionDoneGoToAccounts"
                   type="primary"

--- a/src/screens/SendFunds/02-SelectRecipient.js
+++ b/src/screens/SendFunds/02-SelectRecipient.js
@@ -213,6 +213,7 @@ class SendSelectRecipient extends Component<Props, State> {
                 onChangeText={this.onChangeText}
                 value={address}
                 ref={this.input}
+                multiline
                 blurOnSubmit
                 autoCapitalize="none"
                 clearButtonMode="always"


### PR DESCRIPTION
Brought the multiline flag to the recipient input so it breaks on iOS, removed the CTA that goes back to accounts after uninstalling. @aramab 
![image](https://user-images.githubusercontent.com/4631227/50607162-8e96b400-0ec8-11e9-8367-1ba99a5adb50.png)
