### PR TITLE
Regressions on textinput android

### DIFF
--- a/src/components/TextInput.android.js
+++ b/src/components/TextInput.android.js
@@ -16,17 +16,26 @@ type State = {
 };
 
 class TextInput extends PureComponent<*, State> {
+  updated = false;
+
   constructor(props) {
     super(props);
-
     this.state = {
       focused: false,
-      value: this.props.value || this.props.defaultValue || "",
+      value: "",
     };
   }
 
   componentWillReceiveProps(nextProps) {
-    this.setState({ value: nextProps.value });
+    if (this.updated) {
+      this.setState({ value: nextProps.value });
+    } else {
+      this.setState({ value: nextProps.value || nextProps.defaultValue });
+    }
+  }
+
+  componentWillUpdate() {
+    this.updated = true;
   }
 
   onFocus = () => {
@@ -54,10 +63,7 @@ class TextInput extends PureComponent<*, State> {
     this.setState({ value: "", focused: true });
     if (this.props.onInputCleared) {
       this.props.onInputCleared();
-    } else if (this.props.onChangeText) {
-      this.props.onChangeText("");
     }
-    return true;
   };
 
   render() {
@@ -65,6 +71,7 @@ class TextInput extends PureComponent<*, State> {
       containerStyle,
       withSuggestions,
       innerRef,
+      defaultValue,
       clearButtonMode, // Don't pass this down to use our own impl
       ...otherProps
     } = this.props;
@@ -81,8 +88,8 @@ class TextInput extends PureComponent<*, State> {
       !!value &&
       ((focused && clearButtonMode === "while-editing") ||
         clearButtonMode === "always");
-
     // {...otherProps} needs to come first to allow an override.
+
     return (
       <View style={[styles.container, containerStyle]}>
         <ReactNativeTextInput
@@ -114,7 +121,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
   },
   clearWrapper: {
-    paddingHorizontal: 10,
+    padding: 10,
     alignItems: "center",
     justifyContent: "center",
   },

--- a/src/screens/AccountSettings/EditAccountName.js
+++ b/src/screens/AccountSettings/EditAccountName.js
@@ -74,6 +74,7 @@ class EditAccountName extends PureComponent<Props, State> {
               autoFocus
               style={styles.textInputAS}
               defaultValue={account.name}
+              value={this.state.accountName}
               returnKeyType="done"
               maxLength={20}
               onChangeText={accountName => this.setState({ accountName })}
@@ -119,9 +120,8 @@ const styles = StyleSheet.create({
   },
   textInputAS: {
     padding: 16,
-    marginRight: 8,
     fontSize: 20,
-    width: "100%",
+    flex: 1,
     color: colors.darkBlue,
     ...getFontStyle({ semiBold: true }),
   },

--- a/src/screens/AccountSettings/EditAccountNode.js
+++ b/src/screens/AccountSettings/EditAccountNode.js
@@ -176,6 +176,7 @@ const styles = StyleSheet.create({
     padding: 16,
     marginRight: 8,
     fontSize: 20,
+    flex: 1,
     color: colors.darkBlue,
     ...getFontStyle({ semiBold: true }),
   },


### PR DESCRIPTION
Addresses some regressions on Android specifically:

- QRCode scan was broken on input
- Clear button was overlapping input
- Account edit/any edit was missing default value
- DefaultValues were broken (really not implemented at all)