### PR TITLE
LL-811 Limited the flag change to install only

### DIFF
--- a/src/screens/Manager/AppAction.js
+++ b/src/screens/Manager/AppAction.js
@@ -118,7 +118,7 @@ class AppAction extends PureComponent<
       },
       complete: () => {
         this.setState({ pending: false, error: null });
-        if (!hasInstalledAnyApp) installAppFirstTime();
+        if (!hasInstalledAnyApp && type === "install") installAppFirstTime();
       },
       error: error => {
         this.setState({ pending: false, error });


### PR DESCRIPTION
Made the flag only change when we install for the first time to avoid the edge case of a user uninstalling first and seeing the empty state as if they had installed one.