### PR TITLE
LL-816 Fixes styling of error on xrp node edit

### DIFF
--- a/src/screens/AccountSettings/EditAccountNode.js
+++ b/src/screens/AccountSettings/EditAccountNode.js
@@ -133,6 +133,11 @@ class EditAccountNode extends PureComponent<Props, State> {
                   bridge.getDefaultEndpointConfig()) ||
                 ""
               }
+              placeholder={
+                (bridge.getDefaultEndpointConfig &&
+                  bridge.getDefaultEndpointConfig()) ||
+                ""
+              }
               returnKeyType="done"
               onChangeText={accountNode =>
                 this.setState({ accountNode, error: null })


### PR DESCRIPTION
The error used to be shown above the button and without margins, it should've been like this from the beginning.

![image](https://user-images.githubusercontent.com/4631227/50837614-5b3aa600-135c-11e9-9525-5db4a15360f1.png)
