### PR TITLE
LL-821 Hides the bar from keyboard iOS

### DIFF
--- a/src/components/CurrencyInput.js
+++ b/src/components/CurrencyInput.js
@@ -144,6 +144,7 @@ class CurrencyInput extends PureComponent<Props, State> {
             hasError ? styles.error : null,
           ]}
           onChangeText={this.handleChange}
+          autoCorrect={false}
           value={displayValue}
           autoFocus={autoFocus}
           onFocus={this.handleFocus}
@@ -154,7 +155,6 @@ class CurrencyInput extends PureComponent<Props, State> {
             subMagnitude,
           })}
           keyboardType="numeric"
-          returnKeyType="done"
           blurOnSubmit
         />
         {renderRight}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/50908757-a8854900-142a-11e9-8f06-e4005a3d25cf.png)
We don't need the "done" bar because clicking outside hides the keyboard.