### PR TITLE
Sentry-841639779 Add a failsafe for clipboard cleanup

### DIFF
--- a/android/app/src/main/java/com/ledger/live/MainActivity.java
+++ b/android/app/src/main/java/com/ledger/live/MainActivity.java
@@ -37,21 +37,25 @@ public class MainActivity extends ReactFragmentActivity {
          * text.
          */
         final ClipboardManager clipboard = (ClipboardManager) this.getSystemService(Context.CLIPBOARD_SERVICE);
-        clipboard.addPrimaryClipChangedListener( new ClipboardManager.OnPrimaryClipChangedListener() {
-            boolean breakLoop = false;
-            public void onPrimaryClipChanged() {
-                if(breakLoop){
-                    breakLoop = false;
-                    return;
+        if(clipboard != null){
+            clipboard.addPrimaryClipChangedListener( new ClipboardManager.OnPrimaryClipChangedListener() {
+                boolean breakLoop = false;
+                public void onPrimaryClipChanged() {
+                    if(breakLoop){
+                        breakLoop = false;
+                        return;
+                    }
+                    if (clipboard.hasPrimaryClip()) {
+                        ClipData clipData = clipboard.getPrimaryClip();
+                        ClipData.Item item = clipData.getItemAt(0);
+                        ClipData clip = ClipData.newPlainText("overriden text", item.coerceToText(MainActivity.this).toString());
+                        breakLoop = true;
+                        clipboard.setPrimaryClip(clip);
+                    }
                 }
+            });
+        }
 
-                ClipData clipData = clipboard.getPrimaryClip();
-                ClipData.Item item = clipData.getItemAt(0);
-                ClipData clip = ClipData.newPlainText("overriden text", item.coerceToText(MainActivity.this).toString());
-                breakLoop = true;
-                clipboard.setPrimaryClip(clip);
-            }
-        });
     }
 
     @Override


### PR DESCRIPTION
Some android distributions may handle clipboard management differently (Huawei, Oneplus, Samsung) than we expect, this pr adds a few fail-safes to avoid attempting to run null code.