### PR TITLE
Added the `ci` command for yarn, with the added integrity check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # run tests!
+      - run: yarn check --integrity
       - run: yarn lint
       - run: ./node_modules/.bin/prettier -l "src/**/*.js"
       - run: yarn flow

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prettier": "prettier --write \"src/**/*.js\"",
     "lint": "eslint src",
     "flow": "flow",
+    "ci": "yarn check --integrity && yarn lint && yarn flow && yarn prettier && yarn test",
     "test": "true",
     "sync-flowtyped": "flow-typed install -s -o && rm flow-typed/npm/axios_*",
     "sync-locales": "./scripts/sync-locales.sh"


### PR DESCRIPTION
With this, we can call `yarn ci` and run prettier, lint, flow and the integrity check for dependencies in case we haven't run `yarn` in a while to avoid pushing an outdated lock, left the `test` reference regardless of it being a placeholder for now.