### PR TITLE
Removed the right X navigation button from some secondary screens

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -550,6 +550,9 @@
         "desc": "Describe this account",
         "placeholder": "Account Name"
       },
+      "accountUnits": {
+        "title": "Edit Units"
+      },
       "unit": {
         "title": "Unit",
         "desc": "Choose the unit to display"

--- a/src/screens/AccountSettings/EditAccountName.js
+++ b/src/screens/AccountSettings/EditAccountName.js
@@ -42,6 +42,7 @@ class EditAccountName extends PureComponent<Props, State> {
 
   static navigationOptions = {
     title: i18next.t("account.settings.accountName.title"),
+    headerRight: null,
   };
 
   onChangeText = (accountName: string) => {

--- a/src/screens/AccountSettings/EditAccountNode.js
+++ b/src/screens/AccountSettings/EditAccountNode.js
@@ -70,6 +70,7 @@ class EditAccountNode extends PureComponent<Props, State> {
 
   static navigationOptions = {
     title: i18next.t("account.settings.endpointConfig.title"),
+    headerRight: null,
   };
 
   onChangeText = (accountNode: string) => {

--- a/src/screens/AccountSettings/EditAccountUnits.js
+++ b/src/screens/AccountSettings/EditAccountUnits.js
@@ -1,5 +1,6 @@
 /* @flow */
 import React, { PureComponent } from "react";
+import i18next from "i18next";
 import { ScrollView, FlatList, View, StyleSheet } from "react-native";
 import type { NavigationScreenProp } from "react-navigation";
 import type { Account } from "@ledgerhq/live-common/lib/types";
@@ -28,7 +29,8 @@ const mapDispatchToProps = {
 };
 class EditAccountUnits extends PureComponent<Props> {
   static navigationOptions = {
-    title: "Edit Units",
+    title: i18next.t("account.settings.accountUnits.title"),
+    headerRight: null,
   };
 
   keyExtractor = (item: any) => item.code;

--- a/src/screens/Settings/Currencies/CurrencySettings.js
+++ b/src/screens/Settings/Currencies/CurrencySettings.js
@@ -54,6 +54,7 @@ const mapDispatchToProps = {
 class EachCurrencySettings extends Component<Props, LocalState> {
   static navigationOptions = ({ navigation }) => ({
     headerTitle: navigation.state.params.headerTitle,
+    headerRight: null,
   });
 
   componentDidMount() {

--- a/src/screens/Settings/General/RateProviderSettings.js
+++ b/src/screens/Settings/General/RateProviderSettings.js
@@ -60,6 +60,9 @@ const Screen = makeGenericSelectScreen({
   title: i18next.t("settings.display.exchangeHeader"),
   keyExtractor: item => item.id,
   formatItem: item => item.name,
+  navigationOptions: {
+    headerRight: null,
+  },
 });
 
 export default injectItems(

--- a/src/screens/makeGenericSelectScreen.js
+++ b/src/screens/makeGenericSelectScreen.js
@@ -19,6 +19,7 @@ type Opts<Item> = {
   keyExtractor: Item => string,
   formatItem?: Item => string,
   Entry?: EntryComponent<Item>,
+  navigationOptions?: Object,
   // TODO in future: searchable: boolean
 };
 
@@ -53,7 +54,13 @@ const styles = StyleSheet.create({
 });
 
 export default <Item>(opts: Opts<Item>) => {
-  const { id, itemEventProperties, title, keyExtractor } = opts;
+  const {
+    id,
+    itemEventProperties,
+    title,
+    keyExtractor,
+    navigationOptions = {},
+  } = opts;
   const Entry = getEntryFromOptions(opts);
 
   return class GenericSelectScreen extends Component<{
@@ -62,7 +69,7 @@ export default <Item>(opts: Opts<Item>) => {
     onValueChange: (Item, *) => void,
     navigation: NavigationScreenProp<*>,
   }> {
-    static navigationOptions = { title };
+    static navigationOptions = { title, ...navigationOptions };
 
     onPress = (item: Item) => {
       const { navigation, onValueChange } = this.props;


### PR DESCRIPTION
 Although the original bug report (by me) focused on the account name as the only odd behavior, we decided to remove the X button on all secondary account settings screens since they'd go away from the flow completely.

Hopefully, this makes more sense.

![image](https://user-images.githubusercontent.com/4631227/51903890-94938e00-23bd-11e9-8d74-5e1eb43e83e2.png)
