### PR TITLE
LL-993 Added intent-filter to allow handling ledger devices via USB OTG

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,6 +42,11 @@
             <category android:name="android.intent.category.BROWSABLE"/>
             <data android:scheme="ledgerhq"/>
         </intent-filter>
+        <intent-filter>
+            <!-- http://developer.android.com/guide/topics/connectivity/usb/accessory.html -->
+            <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+        </intent-filter>
+        <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" android:resource="@xml/usb_device_filter" />
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
     </application>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"
+        android:launchMode="singleTop"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
         android:windowSoftInputMode="adjustResize"
         android:screenOrientation="portrait"

--- a/android/app/src/main/res/xml/usb_device_filter.xml
+++ b/android/app/src/main/res/xml/usb_device_filter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <usb-device vendor-id="2c97" product-id="00000" id='blue'/>
+    <usb-device vendor-id="2c97" product-id="00001" id='nanoS'/>
+    <usb-device vendor-id="2c97" product-id="00004" id='nanoX'/>
+</resources>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/52340334-cd5fe280-2a0f-11e9-883c-7f31707cd8c3.png)


### Only for Android
On the current develop version of the app, the experimental usb connections request user permission to access the connected device *everytime we want to interact with it*, meaning that if we disconnect the device and go to the manager again it will once again request user confirmation to access the device. The checkbox provided on that dialog seems to be ignored.

By setting an `intent-filter` on our activity that listens to the `USB_DEVICE_ATTACHED` event for a list of vendorId/productId pairs we can request the user to set Ledger Live Mobile as the default app when plugging in (and unlocking) the device, allowing us to skip the permission request when trying to interact with it.

It's a quick win that makes the ux better.
