### PR TITLE
Add concept of "outer error" that improve error precision

### DIFF
--- a/src/components/ErrorIcon.js
+++ b/src/components/ErrorIcon.js
@@ -5,12 +5,14 @@ import Icon from "react-native-vector-icons/dist/Feather";
 import {
   CantOpenDevice,
   WrongDeviceForAccount,
+  PairingFailed,
 } from "@ledgerhq/live-common/lib/errors";
 import Rounded from "./Rounded";
 import IconNanoX from "../icons/NanoX";
 import ErrorBadge from "./ErrorBadge";
 import Circle from "./Circle";
 import colors, { lighten } from "../colors";
+import BluetoothScanning from "./BluetoothScanning";
 
 type Props = {
   error: ?Error,
@@ -24,6 +26,10 @@ class ErrorIcon extends PureComponent<Props> {
       // this case should not happen (it is supposed to be a ?Error)
       console.error(`ErrorIcon invalid usage: ${String(error)}`);
       return null;
+    }
+
+    if (error instanceof PairingFailed) {
+      return <BluetoothScanning isError />;
     }
 
     if (

--- a/src/components/GenericErrorView.js
+++ b/src/components/GenericErrorView.js
@@ -9,6 +9,10 @@ import TranslatedError from "./TranslatedError";
 
 class GenericErrorRendering extends PureComponent<{
   error: Error,
+  // sometimes we want to "hide" the technical error into a category
+  // for instance, for Genuine check we want to express "Genuine check failed" because "<actual error>"
+  // in such case, the outerError is GenuineCheckFailed and the actual error is still error
+  outerError?: ?Error,
   withDescription: boolean,
   withIcon: boolean,
 }> {
@@ -18,12 +22,14 @@ class GenericErrorRendering extends PureComponent<{
   };
 
   render() {
-    const { error, withDescription, withIcon } = this.props;
+    const { error, outerError, withDescription, withIcon } = this.props;
+    const titleError = outerError || error;
+    const subtitleError = outerError ? error : null;
     return (
       <View style={styles.root}>
         {withIcon ? (
           <View style={styles.headIcon}>
-            <ErrorIcon error={error} />
+            <ErrorIcon error={titleError} />
           </View>
         ) : null}
         <LText
@@ -33,8 +39,19 @@ class GenericErrorRendering extends PureComponent<{
           style={styles.title}
           numberOfLines={3}
         >
-          <TranslatedError error={error} />
+          <TranslatedError error={titleError} />
         </LText>
+        {subtitleError ? (
+          <LText
+            selectable
+            secondary
+            semiBold
+            style={styles.subtitle}
+            numberOfLines={3}
+          >
+            <TranslatedError error={subtitleError} />
+          </LText>
+        ) : null}
         {withDescription ? (
           <LText selectable style={styles.description} numberOfLines={6}>
             <TranslatedError error={error} field="description" />
@@ -62,8 +79,19 @@ const styles = StyleSheet.create({
     color: colors.darkBlue,
     textAlign: "center",
   },
+  subtitle: {
+    marginTop: -20,
+    paddingBottom: 20,
+    paddingHorizontal: 40,
+    fontSize: 14,
+    lineHeight: 21,
+    color: colors.alert,
+    textAlign: "center",
+  },
+
   description: {
     fontSize: 14,
+    lineHeight: 21,
     color: colors.smoke,
     paddingHorizontal: 24,
     textAlign: "center",

--- a/src/screens/PairDevices/RenderError.js
+++ b/src/screens/PairDevices/RenderError.js
@@ -3,7 +3,6 @@
 import React, { Component } from "react";
 import { StyleSheet, View } from "react-native";
 import { BleErrorCode } from "react-native-ble-plx";
-import Icon from "react-native-vector-icons/dist/Feather";
 import { Trans } from "react-i18next";
 import {
   PairingFailed,
@@ -14,10 +13,8 @@ import { TrackScreen } from "../../analytics";
 import Touchable from "../../components/Touchable";
 import LText from "../../components/LText";
 import Button from "../../components/Button";
-import TranslatedError from "../../components/TranslatedError";
-import BluetoothScanning from "../../components/BluetoothScanning";
+import GenericErrorView from "../../components/GenericErrorView";
 import HelpLink from "../../components/HelpLink";
-import Circle from "../../components/Circle";
 import IconArrowRight from "../../icons/ArrowRight";
 import colors from "../../colors";
 
@@ -35,16 +32,6 @@ const hitSlop = {
   bottom: 16,
 };
 
-const GenericErrorHeader = () => (
-  <Circle bg={colors.lightAlert} size={80}>
-    <LText>
-      <Icon name="alert-triangle" size={40} color={colors.alert} />
-    </LText>
-  </Circle>
-);
-
-const PairingFailure = () => <BluetoothScanning isError />;
-
 class RenderError extends Component<Props> {
   render() {
     const { error, status, onBypassGenuine, onRetry } = this.props;
@@ -59,26 +46,25 @@ class RenderError extends Component<Props> {
       return <LocationRequired onRetry={onRetry} errorType="unauthorized" />;
     }
 
-    const primaryError =
-      status === "pairing"
-        ? new PairingFailed()
-        : status === "genuinecheck"
-          ? new GenuineCheckFailed()
-          : error;
+    const isPairingStatus = status === "pairing";
+    const isGenuineCheckStatus = status === "genuinecheck";
 
-    const Header = status === "pairing" ? PairingFailure : GenericErrorHeader;
+    const outerError = isPairingStatus
+      ? new PairingFailed()
+      : isGenuineCheckStatus
+        ? new GenuineCheckFailed()
+        : null;
 
     return (
       <View style={styles.root}>
         <TrackScreen category="PairDevices" name="Error" />
         <View style={styles.body}>
-          <Header />
-          <LText semiBold secondary style={styles.title}>
-            <TranslatedError error={primaryError} />
-          </LText>
-          <LText style={styles.description}>
-            <TranslatedError error={primaryError} field="description" />
-          </LText>
+          <GenericErrorView
+            error={error}
+            outerError={outerError}
+            withDescription
+            withIcon
+          />
           <View style={styles.buttonContainer}>
             <Button
               event="PairDevicesRetry"
@@ -88,7 +74,7 @@ class RenderError extends Component<Props> {
               containerStyle={styles.button}
             />
           </View>
-          {status === "genuinecheck" ? (
+          {isGenuineCheckStatus ? (
             <Touchable
               event="PairDevicesBypassGenuine"
               onPress={onBypassGenuine}
@@ -104,7 +90,7 @@ class RenderError extends Component<Props> {
             <HelpLink style={styles.linkContainer} />
           )}
         </View>
-        {status === "genuinecheck" ? (
+        {isGenuineCheckStatus ? (
           <View style={styles.footer}>
             <HelpLink style={styles.linkContainerGenuine} />
           </View>

--- a/src/screens/PairDevices/ScanningTimeout.js
+++ b/src/screens/PairDevices/ScanningTimeout.js
@@ -29,15 +29,13 @@ class ScanningTimeout extends Component<Props> {
             <NanoX color={colors.alert} width={11} height={48} />
           </Circle>
           <LText secondary semiBold style={styles.titleText}>
-            {<Trans i18nKey="PairDevices.ScanningTimeout.title" />}
+            <Trans i18nKey="PairDevices.ScanningTimeout.title" />
           </LText>
           <LText style={styles.SubtitleText}>
-            {
-              <Trans
-                i18nKey="PairDevices.ScanningTimeout.desc"
-                values={deviceNames.nanoX}
-              />
-            }
+            <Trans
+              i18nKey="PairDevices.ScanningTimeout.desc"
+              values={deviceNames.nanoX}
+            />
           </LText>
 
           <View style={styles.buttonContainer}>


### PR DESCRIPTION
don't take the error itself into account in this screenshot but it basically generalize a new design for having contextual errors and not lose precision.

<img width="350" alt="capture d ecran 2019-02-06 a 12 32 25" src="https://user-images.githubusercontent.com/211411/52341672-84119200-2a13-11e9-8771-7d90d8b10fef.png"> <img width="280" src="https://user-images.githubusercontent.com/211411/52341733-adcab900-2a13-11e9-8412-24b36dec40b1.png" />



It is enabled at two spot for now: the pairing failure and the genuine check failure.

we can later enable at more places by using the new prop on `GenericErrorView`, quite simple.

### Type

UI Polish

### Context

LL-825

### Parts of the app affected / Test plan

error cases of pairing screens