### PR TITLE
Make the pairing screen only strictly for BLE transport

### DIFF
--- a/src/components/SelectDevice/index.js
+++ b/src/components/SelectDevice/index.js
@@ -6,8 +6,8 @@ import { FlatList } from "react-navigation";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";
 import { discoverDevices } from "@ledgerhq/live-common/lib/hw";
+import type { TransportModule } from "@ledgerhq/live-common/lib/hw";
 import { knownDevicesSelector } from "../../reducers/ble";
-import { experimentalUSBEnabledSelector } from "../../reducers/settings";
 import { removeKnownDevice } from "../../actions/ble";
 import DeviceItem from "../DeviceItem";
 import DeviceJob from "../DeviceJob";
@@ -23,7 +23,6 @@ type Props = {
   steps: Step[],
   editMode?: boolean,
   // connect-ed
-  experimentalUSBEnabled: boolean,
   knownDevices: Array<{
     id: string,
     name: string,
@@ -32,6 +31,7 @@ type Props = {
   onStepEntered?: (number, Object) => void,
   setReadOnlyMode: boolean => void,
   onboarding?: boolean,
+  filter: TransportModule => boolean,
 };
 
 type State = {
@@ -48,6 +48,7 @@ type State = {
 class SelectDevice extends Component<Props, State> {
   static defaultProps = {
     steps: [],
+    filter: () => true,
   };
 
   state = {
@@ -63,11 +64,8 @@ class SelectDevice extends Component<Props, State> {
     this.observe();
   }
 
-  componentDidUpdate({ experimentalUSBEnabled, knownDevices }) {
-    if (
-      this.props.experimentalUSBEnabled !== experimentalUSBEnabled ||
-      this.props.knownDevices !== knownDevices
-    ) {
+  componentDidUpdate({ knownDevices }) {
+    if (this.props.knownDevices !== knownDevices) {
       this.observe();
     }
   }
@@ -81,14 +79,7 @@ class SelectDevice extends Component<Props, State> {
       this.listingSubscription.unsubscribe();
       this.setState({ devices: [] });
     }
-    this.listingSubscription = discoverDevices(m => {
-      switch (m.id) {
-        case "hid":
-          return this.props.experimentalUSBEnabled;
-        default:
-          return true;
-      }
-    }).subscribe({
+    this.listingSubscription = discoverDevices(this.props.filter).subscribe({
       complete: () => {
         this.setState({ scanning: false });
       },
@@ -183,7 +174,6 @@ const styles = StyleSheet.create({
 export default connect(
   createStructuredSelector({
     knownDevices: knownDevicesSelector,
-    experimentalUSBEnabled: experimentalUSBEnabledSelector,
   }),
   {
     removeKnownDevice,

--- a/src/screens/Onboarding/steps/pair-new.js
+++ b/src/screens/Onboarding/steps/pair-new.js
@@ -27,6 +27,8 @@ class OnboardingStepPairNew extends Component<OnboardingStepProps> {
 
   pairNew = () => this.props.navigation.navigate("PairDevices");
 
+  filterDeviceModule = m => m.id === "ble";
+
   render() {
     return (
       <OnboardingLayout
@@ -38,7 +40,11 @@ class OnboardingStepPairNew extends Component<OnboardingStepProps> {
         withNeedHelp
       >
         <TrackScreen category="Onboarding" name="PairNew" />
-        <SelectDevice onboarding onSelect={this.props.next} />
+        <SelectDevice
+          filter={this.filterDeviceModule}
+          onboarding
+          onSelect={this.props.next}
+        />
       </OnboardingLayout>
     );
   }


### PR DESCRIPTION
the pairing flow should only be for the ble devices (not the other transports like http proxy, usb, etc.)

### Type

bug fix

### Parts of the app affected / Test plan

that BLE pairing still works, that you can also still see "already paired" device in the list.