### PR TITLE
Added failsafe screen for non-synced imported accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ DEBUG_COMM_HTTP_PROXY=http://localhost:8435   # enable a dev mode to use the dev
 BRIDGESTREAM_DATA=...       # come from console.log of the desktop app during the qrcode export. allow to bypass the bridgestream scanning
 DEBUG_RNDEBUGGER=1          # enable react native debugger
 DISABLE_READ_ONLY=1         # disables readonly mode by default
-EXPERIMENTAL_WS_EXPORT=1    # enables the websocket experimental import
 ```
 
 ## Maintenance

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -737,6 +737,10 @@
       "copyAddress": "Copy address",
       "shareAddress": "Share address",
       "addressCopied": "Address copied!",
+      "notSynced": {
+        "text": "Synchronizing",
+        "desc": "This may take a while if you have many transactions or a slow internet connection"
+      },
       "readOnly": {
         "title": "Receive",
         "text": "Please be careful",

--- a/src/screens/ReceiveFunds/02-ConnectDevice.js
+++ b/src/screens/ReceiveFunds/02-ConnectDevice.js
@@ -87,7 +87,12 @@ class ConnectDevice extends Component<Props> {
   };
 
   renderReadOnly = () => <ReadOnlyWarning continue={this.onSkipDevice} />;
-  renderNotSyncedOnly = () => <NotSyncedWarning continue={this.onSkipDevice} />;
+  renderNotSyncedOnly = () => (
+    <NotSyncedWarning
+      continue={this.onSkipDevice}
+      accountId={this.props.account.id}
+    />
+  );
 
   render() {
     const { readOnlyModeEnabled, account } = this.props;

--- a/src/screens/ReceiveFunds/02-ConnectDevice.js
+++ b/src/screens/ReceiveFunds/02-ConnectDevice.js
@@ -23,6 +23,7 @@ import {
 } from "../../components/DeviceJob/steps";
 import { readOnlyModeEnabledSelector } from "../../reducers/settings";
 import ReadOnlyWarning from "./ReadOnlyWarning";
+import NotSyncedWarning from "./NotSyncedWarning";
 
 type Navigation = NavigationScreenProp<{
   params: {
@@ -86,12 +87,17 @@ class ConnectDevice extends Component<Props> {
   };
 
   renderReadOnly = () => <ReadOnlyWarning continue={this.onSkipDevice} />;
+  renderNotSyncedOnly = () => <NotSyncedWarning continue={this.onSkipDevice} />;
 
   render() {
     const { readOnlyModeEnabled, account } = this.props;
 
     if (readOnlyModeEnabled) {
       return this.renderReadOnly();
+    }
+
+    if (!account.freshAddress) {
+      return this.renderNotSyncedOnly();
     }
 
     return (

--- a/src/screens/ReceiveFunds/NotSyncedWarning.js
+++ b/src/screens/ReceiveFunds/NotSyncedWarning.js
@@ -1,0 +1,43 @@
+/* @flow */
+import React, { PureComponent } from "react";
+import { StyleSheet } from "react-native";
+import { Trans } from "react-i18next";
+import colors from "../../colors";
+import LText from "../../components/LText";
+import PendingContainer from "../PairDevices/PendingContainer";
+import { deviceNames } from "../../wording";
+
+class NotSyncedWarning extends PureComponent<{ continue: () => void }> {
+  render() {
+    return (
+      <PendingContainer>
+        <LText secondary semiBold style={styles.title}>
+          <Trans i18nKey="transfer.receive.notSynced.text" />
+        </LText>
+        <LText style={styles.subtitle}>
+          <Trans
+            i18nKey="transfer.receive.notSynced.desc"
+            values={deviceNames.nanoX}
+          />
+        </LText>
+      </PendingContainer>
+    );
+  }
+}
+
+export default NotSyncedWarning;
+
+const styles = StyleSheet.create({
+  title: {
+    marginTop: 32,
+    fontSize: 18,
+    color: colors.darkBlue,
+  },
+  subtitle: {
+    fontSize: 14,
+    marginTop: 16,
+    textAlign: "center",
+    paddingHorizontal: 24,
+    color: colors.smoke,
+  },
+});

--- a/src/screens/ReceiveFunds/NotSyncedWarning.js
+++ b/src/screens/ReceiveFunds/NotSyncedWarning.js
@@ -6,11 +6,19 @@ import colors from "../../colors";
 import LText from "../../components/LText";
 import PendingContainer from "../PairDevices/PendingContainer";
 import { deviceNames } from "../../wording";
+import SyncOneAccountOnMount from "../../bridge/SyncOneAccountOnMount";
 
-class NotSyncedWarning extends PureComponent<{ continue: () => void }> {
+class NotSyncedWarning extends PureComponent<{
+  continue: () => void,
+  accountId: string,
+}> {
   render() {
     return (
       <PendingContainer>
+        <SyncOneAccountOnMount
+          priority={100}
+          accountId={this.props.accountId}
+        />
         <LText secondary semiBold style={styles.title}>
           <Trans i18nKey="transfer.receive.notSynced.text" />
         </LText>
@@ -31,10 +39,12 @@ const styles = StyleSheet.create({
   title: {
     marginTop: 32,
     fontSize: 18,
+    lineHeight: 27,
     color: colors.darkBlue,
   },
   subtitle: {
     fontSize: 14,
+    lineHeight: 21,
     marginTop: 16,
     textAlign: "center",
     paddingHorizontal: 24,


### PR DESCRIPTION
This should only apply to accounts imported from desktop that haven't had a chance to sync with their corresponding blockchains. Moreso, it's apparently only affecting bitcoin family coins since we won't necessarily have a `freshAddress` ready in the code.

To test:
- Import accounts from desktop and make the phone unable to sync
- Go to a certain account and try to receive funds
- See this

![image](https://user-images.githubusercontent.com/4631227/52501848-9fca9300-2be1-11e9-90a5-fd9e2e8cc8d2.png)



Known issue: If you are in airplane mode and the sync _fails_ you will be left in that screen forever, you'd need to refresh on the main screen for the sync to resume. So maybe address that in a future release