### PR TITLE
LL-968 Allow user to finish onboarding with an empty import

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -33,7 +33,8 @@
     "upToDate": "Up to date",
     "outdated": "Outdated",
     "satPerByte": "sat/bytes",
-    "notAvailable": "Not available"
+    "notAvailable": "Not available",
+    "import": "Import"
   },
   "errors": {
     "AccountNameRequired": {
@@ -594,7 +595,7 @@
         "descBottom": "Please put the LiveQR code within the square"
       },
       "result": {
-        "title": "Select accounts",
+        "title": "Import accounts",
         "newAccounts": "New accounts",
         "updatedAccounts": "Updated accounts",
         "empty": "Add a new account",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -597,6 +597,8 @@
         "title": "Select accounts",
         "newAccounts": "New accounts",
         "updatedAccounts": "Updated accounts",
+        "empty": "Add a new account",
+        "descEmpty": "<0><0>No accounts</0></0> were found. Please try again or go back to the onboarding",
         "alreadyImported": "Already imported",
         "noAccounts": "Nothing to import",
         "unsupported": "Unsupported",

--- a/src/screens/ImportAccounts/DisplayResult.js
+++ b/src/screens/ImportAccounts/DisplayResult.js
@@ -1,8 +1,9 @@
 // @flow
 import React, { Component, Fragment } from "react";
 import { View, StyleSheet } from "react-native";
+
 // $FlowFixMe
-import { SectionList } from "react-navigation";
+import { HeaderBackButton, SectionList } from "react-navigation";
 import groupBy from "lodash/groupBy";
 import concat from "lodash/concat";
 import { connect } from "react-redux";
@@ -26,6 +27,7 @@ import StyledStatusBar from "../../components/StyledStatusBar";
 import DisplayResultItem from "./DisplayResultItem";
 import DisplayResultSettingsSection from "./DisplayResultSettingsSection";
 import ResultSection from "./ResultSection";
+import HeaderBackImage from "../../components/HeaderBackImage";
 
 type Item = {
   // current account, might be partially completed as sync happen in background
@@ -64,6 +66,15 @@ const itemModeDisplaySort = {
   unsupported: 4,
 };
 
+const BackButton = ({ navigation }: { navigation: NavigationScreenProp }) => (
+  <HeaderBackButton
+    tintColor={colors.grey}
+    onPress={() => navigation.replace("ScanAccounts")}
+  >
+    <HeaderBackImage />
+  </HeaderBackButton>
+);
+
 class DisplayResult extends Component<Props, State> {
   state = {
     selectedAccounts: [],
@@ -78,9 +89,14 @@ class DisplayResult extends Component<Props, State> {
     this.unmounted = true;
   }
 
-  static navigationOptions = {
+  static navigationOptions = ({ navigation }) => ({
     title: i18next.t("account.import.result.title"),
-    headerLeft: null,
+    headerLeft: <BackButton navigation={navigation} />,
+  });
+
+  onRetry = () => {
+    const { navigation } = this.props;
+    navigation.replace("ScanAccounts");
   };
 
   static getDerivedStateFromProps(nextProps: Props, prevState: State) {
@@ -143,7 +159,6 @@ class DisplayResult extends Component<Props, State> {
 
   close = () => {
     const { navigation } = this.props;
-
     // $FlowFixMe
     navigation.dismiss();
   };
@@ -222,10 +237,10 @@ class DisplayResult extends Component<Props, State> {
       <ResultSection mode="empty" />
       <LText style={styles.emptyNotice}>
         <Trans i18nKey="account.import.result.descEmpty">
-          <LText semiBold>
-            {"No accounts"}
-          </LText>
-          {"found on your desktop app, please try again or continue the onboarding."}
+          <LText semiBold>No accounts</LText>
+          {
+            "found on your desktop app, please try again or continue the onboarding."
+          }
         </Trans>
       </LText>
     </View>
@@ -242,29 +257,37 @@ class DisplayResult extends Component<Props, State> {
       <View style={styles.root}>
         <TrackScreen category="ImportAccounts" name="DisplayResult" />
         <StyledStatusBar />
-          <Fragment>
-            <SectionList
-              style={styles.body}
-              contentContainerStyle={styles.list}
-              renderItem={this.renderItem}
-              renderSectionHeader={this.renderSectionHeader}
-              ListFooterComponent={this.ListFooterComponent}
-              ListEmptyComponent={this.ListEmptyComponent}
-              keyExtractor={this.keyExtractor}
-              sections={Object.keys(itemsGroupedByMode).map(mode => ({
-                mode,
-                data: itemsGroupedByMode[mode],
-              }))}
+        <Fragment>
+          <SectionList
+            style={styles.body}
+            contentContainerStyle={styles.list}
+            renderItem={this.renderItem}
+            renderSectionHeader={this.renderSectionHeader}
+            ListFooterComponent={this.ListFooterComponent}
+            ListEmptyComponent={this.ListEmptyComponent}
+            keyExtractor={this.keyExtractor}
+            sections={Object.keys(itemsGroupedByMode).map(mode => ({
+              mode,
+              data: itemsGroupedByMode[mode],
+            }))}
+          />
+          <View style={styles.footer}>
+            <Button
+              event="ImportAccountsRetry"
+              containerStyle={[styles.button, styles.retry]}
+              type="secondary"
+              title={<Trans i18nKey="common.retry" />}
+              onPress={this.onRetry}
             />
-            <View style={styles.footer}>
-              <Button
-                event="ImportAccountsContinue"
-                type="primary"
-                title={<Trans i18nKey="common.import" />}
-                onPress={this.onImport}
-              />
-            </View>
-          </Fragment>
+            <Button
+              event="ImportAccountsContinue"
+              containerStyle={styles.button}
+              type="primary"
+              title={<Trans i18nKey="common.import" />}
+              onPress={this.onImport}
+            />
+          </View>
+        </Fragment>
       </View>
     );
   }
@@ -296,6 +319,13 @@ const styles = StyleSheet.create({
   },
   footer: {
     padding: 20,
+    flexDirection: "row",
+  },
+  button: {
+    flex: 1,
+  },
+  retry: {
+    marginRight: 8,
   },
   list: {
     paddingBottom: 40,

--- a/src/screens/ImportAccounts/DisplayResult.js
+++ b/src/screens/ImportAccounts/DisplayResult.js
@@ -217,6 +217,20 @@ class DisplayResult extends Component<Props, State> {
     />
   );
 
+  ListEmptyComponent = () => (
+    <View>
+      <ResultSection mode="empty" />
+      <LText>
+        <Trans i18nKey="account.import.result.descEmpty">
+          <LText semiBold>
+            {"No accounts"}
+          </LText>
+          {"found on your desktop app, please try again or continue the onboarding."}
+        </Trans>
+      </LText>
+    </View>
+  );
+
   keyExtractor = item => item.account.id;
 
   render() {
@@ -228,7 +242,6 @@ class DisplayResult extends Component<Props, State> {
       <View style={styles.root}>
         <TrackScreen category="ImportAccounts" name="DisplayResult" />
         <StyledStatusBar />
-        {items.length ? (
           <Fragment>
             <SectionList
               style={styles.body}
@@ -236,6 +249,7 @@ class DisplayResult extends Component<Props, State> {
               renderItem={this.renderItem}
               renderSectionHeader={this.renderSectionHeader}
               ListFooterComponent={this.ListFooterComponent}
+              ListEmptyComponent={this.ListEmptyComponent}
               keyExtractor={this.keyExtractor}
               sections={Object.keys(itemsGroupedByMode).map(mode => ({
                 mode,
@@ -251,23 +265,6 @@ class DisplayResult extends Component<Props, State> {
               />
             </View>
           </Fragment>
-        ) : (
-          <Fragment>
-            <View style={styles.body}>
-              <LText bold style={styles.noAccountText}>
-                <Trans i18nKey="account.import.result.noAccounts" />
-              </LText>
-            </View>
-            <View style={styles.footer}>
-              <Button
-                event="ImportAccountsDone"
-                type="primary"
-                title={<Trans i18nKey="common.done" />}
-                onPress={this.close}
-              />
-            </View>
-          </Fragment>
-        )}
       </View>
     );
   }

--- a/src/screens/ImportAccounts/DisplayResult.js
+++ b/src/screens/ImportAccounts/DisplayResult.js
@@ -220,7 +220,7 @@ class DisplayResult extends Component<Props, State> {
   ListEmptyComponent = () => (
     <View>
       <ResultSection mode="empty" />
-      <LText>
+      <LText style={styles.emptyNotice}>
         <Trans i18nKey="account.import.result.descEmpty">
           <LText semiBold>
             {"No accounts"}
@@ -260,7 +260,7 @@ class DisplayResult extends Component<Props, State> {
               <Button
                 event="ImportAccountsContinue"
                 type="primary"
-                title={<Trans i18nKey="common.continue" />}
+                title={<Trans i18nKey="common.import" />}
                 onPress={this.onImport}
               />
             </View>
@@ -291,7 +291,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
   },
   body: {
-    paddingHorizontal: 20,
+    paddingHorizontal: 12,
     flex: 1,
   },
   footer: {
@@ -306,6 +306,9 @@ const styles = StyleSheet.create({
     fontSize: 14,
     paddingTop: 10,
     paddingBottom: 10,
+  },
+  emptyNotice: {
+    marginLeft: 8,
   },
   noAccountText: {
     flex: 1,

--- a/src/screens/ImportAccounts/DisplayResultItem.js
+++ b/src/screens/ImportAccounts/DisplayResultItem.js
@@ -28,7 +28,7 @@ export default class DisplayResultItem extends Component<{
         onPress={importing ? undefined : this.onSwitch}
         style={[styles.root, { opacity: selectable ? 1 : 0.5 }]}
       >
-        <AccountCard account={account} />
+        <AccountCard account={account} style={styles.card}/>
         {!selectable ? null : (
           <CheckBox isChecked={checked} style={styles.marginLeft} />
         )}
@@ -42,5 +42,8 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
   },
-  marginLeft: { marginLeft: 16 },
+  card: {
+    marginLeft:8
+  },
+  marginLeft: { marginLeft: 24 },
 });

--- a/src/screens/ImportAccounts/DisplayResultItem.js
+++ b/src/screens/ImportAccounts/DisplayResultItem.js
@@ -28,7 +28,7 @@ export default class DisplayResultItem extends Component<{
         onPress={importing ? undefined : this.onSwitch}
         style={[styles.root, { opacity: selectable ? 1 : 0.5 }]}
       >
-        <AccountCard account={account} style={styles.card}/>
+        <AccountCard account={account} style={styles.card} />
         {!selectable ? null : (
           <CheckBox isChecked={checked} style={styles.marginLeft} />
         )}
@@ -43,7 +43,7 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   card: {
-    marginLeft:8
+    marginLeft: 8,
   },
   marginLeft: { marginLeft: 24 },
 });

--- a/src/screens/ImportAccounts/DisplayResultSettingsSection.js
+++ b/src/screens/ImportAccounts/DisplayResultSettingsSection.js
@@ -31,6 +31,10 @@ class DisplayResultSettingsSection extends PureComponent<{
 const styles = StyleSheet.create({
   root: {},
   row: {
+    backgroundColor: colors.lightGrey,
+    borderRadius: 4,
+    paddingHorizontal: 8,
+
     paddingVertical: 10,
     flexDirection: "row",
     alignItems: "center",

--- a/src/screens/ImportAccounts/ResultSection.js
+++ b/src/screens/ImportAccounts/ResultSection.js
@@ -46,6 +46,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     paddingTop: 24,
     paddingBottom: 16,
+    marginLeft: 8
   },
 });
 

--- a/src/screens/ImportAccounts/ResultSection.js
+++ b/src/screens/ImportAccounts/ResultSection.js
@@ -16,6 +16,9 @@ class ResultSection extends PureComponent<{ mode: string }> {
       case "patch":
         text = <Trans i18nKey="account.import.result.updatedAccounts" />;
         break;
+      case "empty":
+        text = <Trans i18nKey="account.import.result.empty" />;
+        break
       case "id":
         text = <Trans i18nKey="account.import.result.alreadyImported" />;
         break;

--- a/src/screens/ImportAccounts/ResultSection.js
+++ b/src/screens/ImportAccounts/ResultSection.js
@@ -18,7 +18,7 @@ class ResultSection extends PureComponent<{ mode: string }> {
         break;
       case "empty":
         text = <Trans i18nKey="account.import.result.empty" />;
-        break
+        break;
       case "id":
         text = <Trans i18nKey="account.import.result.alreadyImported" />;
         break;
@@ -46,7 +46,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     paddingTop: 24,
     paddingBottom: 16,
-    marginLeft: 8
+    marginLeft: 8,
   },
 });
 


### PR DESCRIPTION
This ads the posibility to retry after scanning the LiveQR Code from desktop or to import simply the settings in the case of not having accounts to import. It initially didn't have the retry cta, hence the comments below mentioning the need to reword.


![image](https://user-images.githubusercontent.com/4631227/52801569-75b01f80-307e-11e9-9387-405ed7218c1e.png)

