### PR TITLE
LL-1022 [Android] Fix retry crash after rejected permissions

### DIFF
--- a/src/components/RequiresBLE/RequiresLocationOnAndroid.android.js
+++ b/src/components/RequiresBLE/RequiresLocationOnAndroid.android.js
@@ -4,12 +4,11 @@
 
 import React, { Component } from "react";
 import { PermissionsAndroid } from "react-native";
-import { Trans } from "react-i18next";
 import LocationRequired from "../../screens/LocationRequired";
 
 const permission = PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION;
 
-export default class RequiresBLE extends Component<
+class RequiresBLE extends Component<
   {
     children: *,
   },
@@ -26,10 +25,7 @@ export default class RequiresBLE extends Component<
   }
 
   request = async () => {
-    const result = await PermissionsAndroid.request(permission, {
-      title: <Trans i18nKey="bluetooth.locationRequiredTitle" />,
-      message: <Trans i18nKey="bluetooth.locationRequiredMessage" />,
-    });
+    const result = await PermissionsAndroid.request(permission);
 
     this.setState({ granted: result === PermissionsAndroid.RESULTS.GRANTED });
   };
@@ -51,3 +47,5 @@ export default class RequiresBLE extends Component<
     return <LocationRequired errorType="unauthorized" onRetry={this.retry} />;
   }
 }
+
+export default RequiresBLE;


### PR DESCRIPTION
On Android, after being prompted to allow the location permission **and rejecting it** the app will insta-crash when clicking on _Pair new device_, the reasoning for this is that after an initial permission request that we reject, the app tries to use the `rationale`.

The `rationale` we provide is a title and a message that we were passing as jsx, and that was chocking the `PermissionsAndroid` logic. Throwing a seemingly unrelated error for `nativeFlushQueueImmediate` at the c++ level but that I guess was triggered when the `request` method was passing that stuff around.

I removed the rationale from our code since it was showing an ugly dialog (no styles, no dismiss) that shows the same information that our specific screen for "Location Required". Without that, since we aren't passing the wrong parameters anymore, it's fixed.

https://developer.android.com/training/permissions/requesting#explain
https://facebook.github.io/react-native/docs/permissionsandroid#request

### How to replicate the error before this pr / test after it
On Android, with location and bluetooth disabled, on a fresh install.

- Try to pair a new device, you will be prompted to allow permission for location, reject it.
- Go back to the previous screen and click on "Pair new device" again.
- Insta crash.