### PR TITLE
LL-954 Modified copy for Readonlymode confirmation, adjusted styles for account titles

### DIFF
--- a/src/components/StepHeader.js
+++ b/src/components/StepHeader.js
@@ -44,12 +44,12 @@ class StepHeader extends PureComponent<Props> {
 const styles = StyleSheet.create({
   root: {
     flexDirection: "column",
-    flex:1,
+    flex: 1,
     paddingVertical: 5,
   },
   title: {
     textAlign: "center",
-    flexGrow:1,
+    flexGrow: 1,
     color: colors.darkBlue,
     fontSize: 16,
   },

--- a/src/components/StepHeader.js
+++ b/src/components/StepHeader.js
@@ -26,7 +26,13 @@ class StepHeader extends PureComponent<Props> {
       <TouchableWithoutFeedback onPress={this.onPress}>
         <View style={styles.root}>
           <LText style={styles.subtitle}>{subtitle}</LText>
-          <LText secondary semiBold style={styles.title}>
+          <LText
+            semiBold
+            secondary
+            numberOfLines={1}
+            ellipsizeMode="tail"
+            style={styles.title}
+          >
             {title}
           </LText>
         </View>
@@ -37,10 +43,13 @@ class StepHeader extends PureComponent<Props> {
 
 const styles = StyleSheet.create({
   root: {
-    flex: 1,
+    flexDirection: "column",
+    flex:1,
+    paddingVertical: 5,
   },
   title: {
     textAlign: "center",
+    flexGrow:1,
     color: colors.darkBlue,
     fontSize: 16,
   },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -724,7 +724,7 @@
     },
     "receive": {
       "title": "Receive",
-      "titleReadOnly": "Are you completely sure?",
+      "titleReadOnly": "Unverified address",
       "headerTitle": "Crypto asset",
       "titleDevice": "Connect device",
       "verifySkipped": "Your receive address has not been confirmed on your Ledger device. Please verify your {{accountType}} address for optimal security",

--- a/src/screens/Account/AccountHeaderTitle.js
+++ b/src/screens/Account/AccountHeaderTitle.js
@@ -55,7 +55,6 @@ const styles = StyleSheet.create({
   headerContainer: {
     flexDirection: "row",
     marginHorizontal: 24,
-    paddingHorizontal: 50,
     paddingVertical: 5,
   },
   iconContainer: {


### PR DESCRIPTION
Updated the copy for readonly mode account confirmation, with a new text from @dasilvarosa and some styling for the account titles that were getting chopped on iPhone SE. Hopefully, this makes it better.

![image](https://user-images.githubusercontent.com/4631227/52640826-b28de200-2ed7-11e9-837e-65c2c6ac03b8.png)
