### PR TITLE
fix account name length + ui fixes

### DIFF
--- a/src/components/SettingsRow.js
+++ b/src/components/SettingsRow.js
@@ -123,9 +123,10 @@ const styles = StyleSheet.create({
   textBlock: {
     paddingRight: 16,
     flexGrow: 1,
-    flexShrink: 1,
+    flexShrink: 0,
   },
   rightBlock: {
+    flexShrink: 1,
     flexDirection: "row",
     alignItems: "center",
   },

--- a/src/screens/Account/index.js
+++ b/src/screens/Account/index.js
@@ -3,7 +3,6 @@
 import React, { PureComponent } from "react";
 import { compose } from "redux";
 import { StyleSheet, View, Animated } from "react-native";
-// $FlowFixMe
 import { SectionList } from "react-navigation";
 import type { SectionBase } from "react-native/Libraries/Lists/SectionList";
 import { connect } from "react-redux";

--- a/src/screens/AccountSettings/EditAccountName.js
+++ b/src/screens/AccountSettings/EditAccountName.js
@@ -19,6 +19,8 @@ import { getFontStyle } from "../../components/LText";
 
 import colors from "../../colors";
 
+export const MAX_ACCOUNT_NAME_LENGHT = 50;
+
 type Props = {
   navigation: NavigationScreenProp<{
     accountId: string,
@@ -77,7 +79,7 @@ class EditAccountName extends PureComponent<Props, State> {
               style={styles.textInputAS}
               defaultValue={account.name}
               returnKeyType="done"
-              maxLength={20}
+              maxLength={MAX_ACCOUNT_NAME_LENGHT}
               onChangeText={accountName => this.setState({ accountName })}
               onSubmitEditing={this.onNameEndEditing}
               clearButtonMode="while-editing"

--- a/src/screens/Accounts/AccountRow.js
+++ b/src/screens/Accounts/AccountRow.js
@@ -52,7 +52,12 @@ class AccountRow extends PureComponent<Props> {
         >
           <CurrencyIcon size={24} currency={account.currency} />
           <View style={styles.inner}>
-            <LText semiBold numberOfLines={1} style={styles.accountNameText}>
+            <LText
+              semiBold
+              numberOfLines={1}
+              ellipsizeMode="middle"
+              style={styles.accountNameText}
+            >
               {account.name}
             </LText>
             <AccountSyncStatus

--- a/src/screens/Accounts/index.js
+++ b/src/screens/Accounts/index.js
@@ -2,7 +2,6 @@
 
 import React, { Component, Fragment } from "react";
 import { StyleSheet } from "react-native";
-// $FlowFixMe
 import { FlatList } from "react-navigation";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";


### PR DESCRIPTION
Augment the max number of character for the account name to 50 (to be iso with desktop) and fixed SettingsRow to accept longer name

### Type

feat + fix

### Context

LL-951 LL-952

### Parts of the app affected / Test plan

EditAccountName, Accounts page