### PR TITLE
Fixed a regression in SettingsRow

### DIFF
--- a/src/components/SettingsRow.js
+++ b/src/components/SettingsRow.js
@@ -120,6 +120,7 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
   },
   textBlock: {
+    marginRight: "auto",
     paddingRight: 16,
     flexShrink: 1,
   },

--- a/src/components/SettingsRow.js
+++ b/src/components/SettingsRow.js
@@ -76,7 +76,7 @@ export default class SettingsRow extends Component<{
         eventProperties={eventProperties}
       >
         {iconLeft && <View style={styles.iconLeft}>{iconLeft}</View>}
-        <View style={styles.textBlock}>
+        <View style={[styles.textBlock, { marginLeft: iconLeft ? 0 : 16 }]}>
           {title$}
           {desc &&
             !noTextDesc && <LText style={styles.description}>{desc}</LText>}
@@ -105,11 +105,10 @@ const styles = StyleSheet.create({
   root: {
     minHeight: 50,
     flexDirection: "row",
-    alignItems: "center",
-    paddingHorizontal: 16,
     paddingVertical: 24,
     backgroundColor: "white",
     marginBottom: 2,
+    justifyContent: "space-between",
   },
   rootAlignedTop: {
     alignItems: "flex-start",
@@ -122,13 +121,15 @@ const styles = StyleSheet.create({
   },
   textBlock: {
     paddingRight: 16,
-    flexGrow: 1,
-    flexShrink: 0,
+    flexShrink: 1,
   },
   rightBlock: {
-    flexShrink: 1,
     flexDirection: "row",
     alignItems: "center",
+    justifyContent: "flex-end",
+    flexShrink: 0,
+    maxWidth: "50%",
+    marginRight: 16,
   },
   titleContainer: {
     flexDirection: "row",
@@ -152,6 +153,7 @@ const styles = StyleSheet.create({
   },
   iconLeft: {
     paddingRight: 16,
+    marginLeft: 16,
   },
   iconLeftContainer: {
     marginRight: 8,

--- a/src/screens/AccountSettings/AccountNameRow.js
+++ b/src/screens/AccountSettings/AccountNameRow.js
@@ -33,7 +33,7 @@ class AccountNameRow extends PureComponent<Props> {
         <LText
           semiBold
           numberOfLines={1}
-          ellipsizeMode="tail"
+          ellipsizeMode="middle"
           style={styles.accountName}
         >
           {account.name}


### PR DESCRIPTION
A past fix for Account name length brought in a regression into all settings row (Settings/General for example). The solution is to not center the elements of the row inside but rather space them, and a few more tweaks. This limits the right content to a max of 50% too, so it never squeezes the left either.


![image](https://user-images.githubusercontent.com/4631227/52848510-2fef6780-310f-11e9-8fd3-2bcb017b7eee.png)
