### PR TITLE
LL-1028 Added block to 0 fees

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     }
   },
   "dependencies": {
-    "@ledgerhq/errors": "4.38.0",
+    "@ledgerhq/errors": "4.39.0",
     "@ledgerhq/hw-app-btc": "4.38.0",
     "@ledgerhq/hw-app-eth": "4.38.0",
     "@ledgerhq/hw-app-xrp": "4.38.0",

--- a/src/families/bitcoin/ScreenEditFeePerByte/CustomFeesRow.js
+++ b/src/families/bitcoin/ScreenEditFeePerByte/CustomFeesRow.js
@@ -1,7 +1,13 @@
 // @flow
 import React, { Component } from "react";
 import { Trans } from "react-i18next";
-import { View, StyleSheet, TouchableOpacity, TextInput } from "react-native";
+import {
+  View,
+  StyleSheet,
+  TouchableOpacity,
+  TextInput,
+  Platform,
+} from "react-native";
 import { BigNumber } from "bignumber.js";
 import {
   sanitizeValueString,
@@ -9,8 +15,8 @@ import {
 } from "@ledgerhq/live-common/lib/currencies";
 
 import LText from "../../../components/LText/index";
-import Check from "../../../icons/Check";
 
+import Check from "../../../icons/Check";
 import colors from "../../../colors";
 
 const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
@@ -22,6 +28,7 @@ type Props = {
   initialValue: ?BigNumber,
   onPress: BigNumber => void,
   isSelected: boolean,
+  isValid?: boolean,
 };
 
 type State = {
@@ -31,6 +38,7 @@ type State = {
 class FeesRow extends Component<Props, State> {
   static defaultProps = {
     last: false,
+    isValid: true,
   };
 
   state = {
@@ -69,7 +77,7 @@ class FeesRow extends Component<Props, State> {
   };
 
   render() {
-    const { title, last, isSelected } = this.props;
+    const { title, last, isSelected, isValid } = this.props;
 
     return (
       <TouchableOpacity onPress={this.onPress}>
@@ -88,6 +96,9 @@ class FeesRow extends Component<Props, State> {
               style={[styles.title, isSelected ? styles.titleSelected : null]}
             >
               {title}
+            </LText>
+            <LText secondary style={isValid ? styles.warning : styles.error}>
+              <Trans i18nKey="send.fees.required" />
             </LText>
           </View>
           <View style={styles.inputContainer}>
@@ -119,7 +130,11 @@ const styles = StyleSheet.create({
     alignItems: "center",
     marginLeft: 16,
     paddingRight: 16,
-    paddingVertical: 16,
+    ...Platform.select({
+      ios: {
+        paddingVertical: 16,
+      },
+    }),
     borderBottomColor: colors.lightFog,
     borderBottomWidth: 1,
   },
@@ -128,9 +143,15 @@ const styles = StyleSheet.create({
   },
   titleContainer: {
     flex: 1,
-    flexDirection: "row",
-    alignItems: "center",
+    flexDirection: "column",
+    alignItems: "flex-start",
     marginRight: 24,
+  },
+  error: {
+    color: colors.alert,
+  },
+  warning: {
+    color: colors.grey,
   },
   title: {
     fontSize: 14,
@@ -158,9 +179,13 @@ const styles = StyleSheet.create({
   },
   textInput: {
     fontSize: 14,
-    marginRight: 6,
     color: colors.darkBlue,
     textAlign: "right",
+    ...Platform.select({
+      ios: {
+        marginRight: 6,
+      },
+    }),
   },
   textInputSelected: {
     fontWeight: "600",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -114,6 +114,9 @@
     "FeeNotLoaded": {
       "title": "Couldn’t load fee rates"
     },
+    "FeeRequired": {
+      "title": "Fees are required"
+    },
     "GenuineCheckFailed": {
       "title": "Genuine check failed",
       "description": "Something went wrong. Please try again or contact Ledger Support when in doubt."
@@ -818,7 +821,8 @@
     },
     "fees": {
       "title": "Network fees",
-      "validate": "Validate fees",
+      "validate": "Confirm",
+      "required": "Fees are required",
       "edit": {
         "title": "Choose Unit"
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,10 +760,10 @@
   dependencies:
     "@ledgerhq/errors" "^4.38.0"
 
-"@ledgerhq/errors@4.38.0", "@ledgerhq/errors@^4.32.0", "@ledgerhq/errors@^4.38.0":
-  version "4.38.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.38.0.tgz#5260118b2cb1069f706d9316bf6f2ee1f6935f43"
-  integrity sha512-ZVpwiQV4y6OqMcOhZ7xQR37xpZdYGXnZftlYtT9muzXrak/HPHc19oPpwiuqKmHAbgfio6qEVk9Lp3yWLY9bPQ==
+"@ledgerhq/errors@4.39.0", "@ledgerhq/errors@^4.32.0", "@ledgerhq/errors@^4.38.0":
+  version "4.39.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.39.0.tgz#10b9889f78df94ce36a4b34d9a3a45aac77be0e9"
+  integrity sha512-kBr2rnoYDACRCxTLtEufE4oCvYj6vx2oFWVVjwskBxYsF5LC9R8Mbg5C4GgvDweiWW4Io8HA9p9jCsOfdCDygg==
 
 "@ledgerhq/hw-app-btc@4.38.0", "@ledgerhq/hw-app-btc@^4.32.0":
   version "4.38.0"


### PR DESCRIPTION
Disabled the button and show an error when 0 fees are entered in the custom fees for bitcoin family. **Updated** with the latest design from @bscholving which always shows the warning and will turn red on invalid input, updated wording too.

![image](https://user-images.githubusercontent.com/4631227/52951226-8368ec00-3381-11e9-958b-70c0fa6be16c.png)

