### PR TITLE
LL-1046 Override detected language if it's RTL

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,6 +23,7 @@
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"
+      android:supportsRtl="false" tools:replace="android:supportsRtl"
       android:allowBackup="true"
       android:theme="@style/AppTheme">
       <activity

--- a/android/app/src/main/java/com/ledger/live/MainActivity.java
+++ b/android/app/src/main/java/com/ledger/live/MainActivity.java
@@ -3,15 +3,20 @@ package com.ledger.live;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.os.Bundle;
+import android.view.View;
 import android.view.WindowManager;
 
 import com.facebook.react.ReactFragmentActivity;
 
 import org.devio.rn.splashscreen.SplashScreen;
+
 import com.facebook.react.ReactActivityDelegate;
 import com.facebook.react.ReactRootView;
 import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+
+import java.util.Locale;
 
 
 public class MainActivity extends ReactFragmentActivity {
@@ -38,11 +43,12 @@ public class MainActivity extends ReactFragmentActivity {
          * text.
          */
         final ClipboardManager clipboard = (ClipboardManager) this.getSystemService(Context.CLIPBOARD_SERVICE);
-        if(clipboard != null){
-            clipboard.addPrimaryClipChangedListener( new ClipboardManager.OnPrimaryClipChangedListener() {
+        if (clipboard != null) {
+            clipboard.addPrimaryClipChangedListener(new ClipboardManager.OnPrimaryClipChangedListener() {
                 boolean breakLoop = false;
+
                 public void onPrimaryClipChanged() {
-                    if(breakLoop){
+                    if (breakLoop) {
                         breakLoop = false;
                         return;
                     }
@@ -60,15 +66,28 @@ public class MainActivity extends ReactFragmentActivity {
     }
 
     @Override
-    protected void onPause(){
+    protected void onPause() {
         super.onPause();
-        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE,WindowManager.LayoutParams.FLAG_SECURE);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_SECURE, WindowManager.LayoutParams.FLAG_SECURE);
     }
 
     @Override
-    protected void onResume(){
+    protected void onResume() {
         super.onResume();
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+
+        /*
+         * Override the detected language to english if it's a RTL language.
+         * TODO if we ever support a RTL language we'd have to take it into account here.
+         */
+        Configuration config = getBaseContext().getResources().getConfiguration();
+        if (config.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL) {
+            Locale locale = new Locale("en");
+            Locale.setDefault(locale);
+            config.setLocale(locale);
+            getBaseContext().getResources().updateConfiguration(config, getBaseContext().getResources().getDisplayMetrics());
+        }
+
     }
 
     @Override

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -2,7 +2,7 @@
 
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
-        <!-- Customize your theme here. -->
+        <item name="android:layoutDirection">ltr</item>
     </style>
 
 </resources>

--- a/src/languages.js
+++ b/src/languages.js
@@ -5,7 +5,8 @@ import allLocales from "./locales";
 const prodStableLanguages = ["en"];
 
 const l = {};
-Object.keys(allLocales).forEach(key => {
+export const localeIds: string[] = Object.keys(allLocales);
+localeIds.forEach(key => {
   if (Config.LEDGER_DEBUG_ALL_LANGS || prodStableLanguages.includes(key)) {
     l[key] = allLocales[key];
   }

--- a/src/screens/OperationDetails/Content.js
+++ b/src/screens/OperationDetails/Content.js
@@ -8,6 +8,7 @@ import uniq from "lodash/uniq";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";
 import { Trans } from "react-i18next";
+import { localeIds } from "../../languages";
 import LText from "../../components/LText";
 import OperationIcon from "../../components/OperationIcon";
 import CurrencyUnitValue from "../../components/CurrencyUnitValue";
@@ -107,7 +108,7 @@ class Content extends PureComponent<Props, *> {
             <Trans i18nKey="operationDetails.date" />
           </LText>
           <LText semiBold>
-            {operation.date.toLocaleDateString([], {
+            {operation.date.toLocaleDateString(localeIds, {
               year: "numeric",
               month: "long",
               day: "numeric",


### PR DESCRIPTION
### Issue
On devices (Android) using a right-to-left language such as Arabic or Hebrew, Android enforces a conversion of the layout that breaks the app making it look terrible. 

### Proposed solution
Common solutions proposed online to disable the rtl conversion seem to not currently work, as a workaround we will detect the locale of the device `onResume` at the native level and enforce the use of `en` instead for rtl languages. iOS seems to not be affected by this and respects the original app's layout instead of enforcing a conversion (kudos apple)

### Caveats
I left a `TODO` in the code for this, but if we ever support a rtl language we'd have to add the exception to the code in order for the translations to actually work, otherwise it will use this and end up with english. 

### Demo
![image](https://user-images.githubusercontent.com/4631227/53006867-68a47f00-3436-11e9-99a7-22532c634b9b.png)
