### PR TITLE
LL-1051 Created SkipLock component to disable auto-lock in certain processes

### DIFF
--- a/src/components/Installing.js
+++ b/src/components/Installing.js
@@ -9,6 +9,7 @@ import LiveLogo from "../icons/LiveLogoIcon";
 import Spinning from "./Spinning";
 import LText from "./LText";
 import FirmwareProgress from "./FirmwareProgress";
+import SkipLock from "./behaviour/SkipLock";
 
 class Installing extends PureComponent<{
   progress: number,
@@ -19,6 +20,7 @@ class Installing extends PureComponent<{
     const { progress, installing, t } = this.props;
     return (
       <View style={styles.root}>
+        <SkipLock />
         {progress === 0 ? (
           <View style={{ padding: 10 }}>
             <Spinning>

--- a/src/components/behaviour/SkipLock.js
+++ b/src/components/behaviour/SkipLock.js
@@ -1,0 +1,52 @@
+// @flow
+import React, { PureComponent } from "react";
+import { withNavigationFocus } from "react-navigation";
+
+export const SkipLockContext = React.createContext({
+  skipLockCount: 0,
+  setEnabled: (_: boolean) => {},
+});
+
+class SkipLock extends PureComponent<*> {
+  render() {
+    return (
+      <SkipLockContext.Consumer>
+        {context => (
+          <SkipLockInner setEnabled={context.setEnabled} {...this.props} />
+        )}
+      </SkipLockContext.Consumer>
+    );
+  }
+}
+
+class SkipLockInner extends PureComponent<{
+  setEnabled: (enabled: boolean) => void,
+  isFocused: boolean,
+}> {
+  lastValue = false;
+
+  componentDidMount() {
+    this.report(true);
+  }
+
+  componentDidUpdate() {
+    this.report(this.props.isFocused);
+  }
+
+  componentWillUnmount() {
+    this.report(false);
+  }
+
+  report = enabled => {
+    if (this.lastValue !== enabled) {
+      this.props.setEnabled(enabled);
+      this.lastValue = enabled;
+    }
+  };
+
+  render() {
+    return null;
+  }
+}
+
+export default withNavigationFocus(SkipLock);

--- a/src/components/behaviour/SkipLock.js
+++ b/src/components/behaviour/SkipLock.js
@@ -2,17 +2,14 @@
 import React, { PureComponent } from "react";
 import { withNavigationFocus } from "react-navigation";
 
-export const SkipLockContext = React.createContext({
-  skipLockCount: 0,
-  setEnabled: (_: boolean) => {},
-});
+export const SkipLockContext = React.createContext((_: boolean) => {});
 
 class SkipLock extends PureComponent<*> {
   render() {
     return (
       <SkipLockContext.Consumer>
-        {context => (
-          <SkipLockInner setEnabled={context.setEnabled} {...this.props} />
+        {setEnabled => (
+          <SkipLockInner setEnabled={setEnabled} {...this.props} />
         )}
       </SkipLockContext.Consumer>
     );
@@ -26,7 +23,7 @@ class SkipLockInner extends PureComponent<{
   lastValue = false;
 
   componentDidMount() {
-    this.report(true);
+    this.report(this.props.isFocused);
   }
 
   componentDidUpdate() {

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ export const GENUINE_CHECK_TIMEOUT = 120 * 1000;
 export const GET_CALLS_RETRY = 3;
 export const GET_CALLS_TIMEOUT = 60000;
 
-export const AUTOLOCK_TIMEOUT = 60000;
+export const AUTOLOCK_TIMEOUT = 6000;
 
 export const LEDGER_REST_API_BASE = "https://explorers.api.live.ledger.com";
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,7 @@ export const GENUINE_CHECK_TIMEOUT = 120 * 1000;
 export const GET_CALLS_RETRY = 3;
 export const GET_CALLS_TIMEOUT = 60000;
 
-export const AUTOLOCK_TIMEOUT = 6000;
+export const AUTOLOCK_TIMEOUT = 60000;
 
 export const LEDGER_REST_API_BASE = "https://explorers.api.live.ledger.com";
 

--- a/src/context/AuthPass/index.js
+++ b/src/context/AuthPass/index.js
@@ -71,7 +71,10 @@ class AuthPass extends PureComponent<Props, State> {
     ) {
       this.lock();
       this.appInBg = Date.now();
-    } else if (nextAppState === "background") {
+    } else if (
+      nextAppState === "background" ||
+      this.state.appState === "active"
+    ) {
       this.appInBg = Date.now();
     }
     this.setState({ appState: nextAppState });

--- a/src/context/AuthPass/index.js
+++ b/src/context/AuthPass/index.js
@@ -5,8 +5,8 @@ import { connect } from "react-redux";
 import { translate } from "react-i18next";
 import { createStructuredSelector } from "reselect";
 import { privacySelector } from "../../reducers/settings";
+import { SkipLockContext } from "../../components/behaviour/SkipLock";
 import { AUTOLOCK_TIMEOUT } from "../../constants";
-
 import auth from "./auth";
 import type { Privacy } from "../../reducers/settings";
 import AuthScreen from "./AuthScreen";
@@ -19,6 +19,8 @@ type State = {
   isLocked: boolean,
   biometricsError: ?Error,
   appState: string,
+  skipLockCount: number,
+  setEnabled: (enabled: boolean) => void,
 };
 
 type Props = {
@@ -32,10 +34,19 @@ type Props = {
 let wasUnlocked = false;
 
 class AuthPass extends PureComponent<Props, State> {
+  setEnabled = (enabled: boolean) => {
+    this.setState(prevState => ({
+      skipLockCount: prevState.skipLockCount + (enabled ? 1 : -1),
+    }));
+  };
+
   state = {
     isLocked: !!this.props.privacy && !wasUnlocked,
     biometricsError: null,
     appState: AppState.currentState || "",
+
+    skipLockCount: 0,
+    setEnabled: this.setEnabled,
   };
 
   static getDerivedStateFromProps({ privacy }, { isLocked }) {
@@ -90,7 +101,8 @@ class AuthPass extends PureComponent<Props, State> {
 
   // lock the app
   lock = () => {
-    if (!this.props.privacy) return;
+    if (!this.props.privacy || this.state.skipLockCount) return;
+
     wasUnlocked = false;
     this.setState(
       {
@@ -112,7 +124,7 @@ class AuthPass extends PureComponent<Props, State> {
 
   render() {
     const { children, privacy } = this.props;
-    const { isLocked, biometricsError } = this.state;
+    const { isLocked, biometricsError, skipLockCount, setEnabled } = this.state;
     if (isLocked && privacy) {
       return (
         <AuthScreen
@@ -123,7 +135,12 @@ class AuthPass extends PureComponent<Props, State> {
         />
       );
     }
-    return children;
+    const contextValue = { skipLockCount, setEnabled };
+    return (
+      <SkipLockContext.Provider value={contextValue}>
+        {children}
+      </SkipLockContext.Provider>
+    );
   }
 }
 

--- a/src/context/AuthPass/index.js
+++ b/src/context/AuthPass/index.js
@@ -124,7 +124,7 @@ class AuthPass extends PureComponent<Props, State> {
 
   render() {
     const { children, privacy } = this.props;
-    const { isLocked, biometricsError, skipLockCount, setEnabled } = this.state;
+    const { isLocked, biometricsError, setEnabled } = this.state;
     if (isLocked && privacy) {
       return (
         <AuthScreen
@@ -135,9 +135,8 @@ class AuthPass extends PureComponent<Props, State> {
         />
       );
     }
-    const contextValue = { skipLockCount, setEnabled };
     return (
-      <SkipLockContext.Provider value={contextValue}>
+      <SkipLockContext.Provider value={setEnabled}>
         {children}
       </SkipLockContext.Provider>
     );

--- a/src/screens/Manager/AppAction.js
+++ b/src/screens/Manager/AppAction.js
@@ -27,6 +27,7 @@ import colors from "../../colors";
 import AppIcon from "./AppIcon";
 import { installAppFirstTime } from "../../actions/settings";
 import { hasInstalledAnyAppSelector } from "../../reducers/settings";
+import SkipLock from "../../components/behaviour/SkipLock";
 
 class PendingProgress extends PureComponent<{
   progress: number,
@@ -196,6 +197,7 @@ class AppAction extends PureComponent<
             <View style={styles.headIcon}>
               {icon}
               <View style={styles.loaderWrapper}>
+                {pending && <SkipLock />}
                 {pending ? (
                   progress ? (
                     <PendingProgress progress={progress} />

--- a/src/screens/ReceiveFunds/03-Confirmation.js
+++ b/src/screens/ReceiveFunds/03-Confirmation.js
@@ -35,6 +35,7 @@ import CopyLink from "../../components/CopyLink";
 import ShareLink from "../../components/ShareLink";
 import { urls } from "../../config/urls";
 import { readOnlyModeEnabledSelector } from "../../reducers/settings";
+import SkipLock from "../../components/behaviour/SkipLock";
 
 type Navigation = NavigationScreenProp<{
   params: {
@@ -179,7 +180,12 @@ class ReceiveConfirmation extends Component<Props, State> {
           unsafe={unsafe}
           verified={verified}
         />
-        {allowNavigation ? null : <PreventNativeBack />}
+        {allowNavigation ? null : (
+          <>
+            <PreventNativeBack />
+            <SkipLock />
+          </>
+        )}
         <ScrollView style={{ flex: 1 }} contentContainerStyle={styles.root}>
           <View style={styles.container}>
             <Touchable event="QRZoom" onPress={this.onZoom}>

--- a/src/screens/SendFunds/06-Validation.js
+++ b/src/screens/SendFunds/06-Validation.js
@@ -17,6 +17,7 @@ import colors from "../../colors";
 import StepHeader from "../../components/StepHeader";
 import PreventNativeBack from "../../components/PreventNativeBack";
 import ValidateOnDevice from "./ValidateOnDevice";
+import SkipLock from "../../components/behaviour/SkipLock";
 
 type Props = {
   account: Account,
@@ -125,7 +126,13 @@ class Validation extends Component<Props, State> {
     return (
       <SafeAreaView style={styles.root}>
         <TrackScreen category="SendFunds" name="Validation" signed={signed} />
-        {signing && <PreventNativeBack />}
+        {signing && (
+          <>
+            <PreventNativeBack />
+            <SkipLock />
+          </>
+        )}
+
         {signed ? (
           <View style={styles.center}>
             <ActivityIndicator size="large" />

--- a/src/screens/Settings/Debug/index.js
+++ b/src/screens/Settings/Debug/index.js
@@ -21,6 +21,7 @@ import OpenDebugIcons from "./OpenDebugIcons";
 import ReadOnlyModeRow from "../General/ReadOnlyModeRow";
 import OpenDebugStore from "./OpenDebugStore";
 import OpenLottie from "./OpenDebugLottie";
+import SkipLock from "../../../components/behaviour/SkipLock";
 
 class DebugMocks_ extends PureComponent<{
   accounts: *,
@@ -49,6 +50,7 @@ class DebugMocks_ extends PureComponent<{
         <OpenDebugIcons />
         <OpenLottie />
         <ReadOnlyModeRow />
+        <SkipLock />
       </ScrollView>
     );
   }


### PR DESCRIPTION
Created a `<SkipLock/>` component that will allow us to disable the autolock behaviour in certain parts of the application to avoid breaking a flow or disturbing a process that requires the app to be inactive (pairing for example could also get this if wanted).

To use it simply render the component in the screen you want to disable autolock for.

### How to test?
Autolock should be disabled while installing an app, updating firmware, or validating data on the device. To test, simply navigate out of the app while on one of those screens, wait 1 minute (or modify the environmental variable to a lower setting) and come back to the app.