### PR TITLE
LL-1072 Disable input of non ascii character for device name

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
     "lines-between-class-members": 0,
     "flowtype/space-after-type-colon": 0,
     "no-continue": 0,
+    "no-control-regex": 0,
     "no-return-assign": 0,
     "no-shadow": 0,
     "prefer-template": 0,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     }
   },
   "dependencies": {
-    "@ledgerhq/errors": "4.39.0",
+    "@ledgerhq/errors": "4.41.1",
     "@ledgerhq/hw-app-btc": "4.38.0",
     "@ledgerhq/hw-app-eth": "4.38.0",
     "@ledgerhq/hw-app-xrp": "4.38.0",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -68,6 +68,9 @@
       "title": "Possibly not genuine",
       "description": "Request Ledger Support assistance."
     },
+    "DeviceNameInvalid": {
+      "title": "Please choose a device name without '{{invalidCharacters}}'"
+    },
     "DeviceOnDashboardExpected": {
       "title": "Return to Dashboard",
       "description": "Please navigate back to Dashboard on your device"

--- a/src/screens/EditDeviceName.js
+++ b/src/screens/EditDeviceName.js
@@ -90,7 +90,14 @@ class EditDeviceName extends PureComponent<
     const { name } = this.state;
     if (this.initialName !== name) {
       Keyboard.dismiss();
-      setTimeout(() => this.setState({ connecting: true }), 800);
+      setTimeout(
+        () =>
+          this.setState(prevState => ({
+            name: prevState.name.trim(),
+            connecting: true,
+          })),
+        800,
+      );
     } else {
       this.props.navigation.goBack();
     }

--- a/src/screens/EditDeviceName.js
+++ b/src/screens/EditDeviceName.js
@@ -9,6 +9,7 @@ import i18next from "i18next";
 import Icon from "react-native-vector-icons/dist/Feather";
 import { compose } from "redux";
 import { connect } from "react-redux";
+import { DeviceNameInvalid } from "@ledgerhq/errors";
 import colors from "../colors";
 import { TrackScreen } from "../analytics";
 import Button from "../components/Button";
@@ -66,14 +67,24 @@ class EditDeviceName extends PureComponent<
     error: null,
     connecting: false,
   };
-  invalidCharacters = /[^\x00-\x7F]/g;
 
   onChangeText = (name: string) => {
-    this.setState({ name: name.replace(this.invalidCharacters, "") });
+    this.setState({ name }, this.validate);
   };
 
   onInputCleared = () => {
     this.setState({ name: "" });
+  };
+
+  validate = () => {
+    this.setState(prevState => {
+      const invalidCharacters = prevState.name.replace(/[\x00-\x7F]*/g, "");
+      return {
+        error: invalidCharacters
+          ? new DeviceNameInvalid("", { invalidCharacters })
+          : undefined,
+      };
+    });
   };
 
   onSubmit = async () => {
@@ -132,7 +143,7 @@ class EditDeviceName extends PureComponent<
               type="primary"
               title={<Trans i18nKey="EditDeviceName.action" />}
               onPress={this.onSubmit}
-              disabled={!name}
+              disabled={!name || error}
             />
           </View>
 

--- a/src/screens/EditDeviceName.js
+++ b/src/screens/EditDeviceName.js
@@ -66,9 +66,10 @@ class EditDeviceName extends PureComponent<
     error: null,
     connecting: false,
   };
+  invalidCharacters = /[^\x00-\x7F]/g;
 
   onChangeText = (name: string) => {
-    this.setState({ name });
+    this.setState({ name: name.replace(this.invalidCharacters, "") });
   };
 
   onInputCleared = () => {

--- a/src/screens/EditDeviceName.js
+++ b/src/screens/EditDeviceName.js
@@ -149,7 +149,7 @@ class EditDeviceName extends PureComponent<
               type="primary"
               title={<Trans i18nKey="EditDeviceName.action" />}
               onPress={this.onSubmit}
-              disabled={!name || !!error}
+              disabled={!name.trim() || !!error}
             />
           </View>
 

--- a/src/screens/EditDeviceName.js
+++ b/src/screens/EditDeviceName.js
@@ -111,7 +111,7 @@ class EditDeviceName extends PureComponent<
     const { name, error, connecting } = this.state;
     const { navigation } = this.props;
     const deviceId = navigation.getParam("deviceId");
-    const remainingCount = MAX_DEVICE_NAME - Buffer.from(name).length;
+    const remainingCount = MAX_DEVICE_NAME - name.length;
     return (
       <SafeAreaView style={styles.safearea}>
         <TrackScreen category="EditDeviceName" />

--- a/src/screens/EditDeviceName.js
+++ b/src/screens/EditDeviceName.js
@@ -1,7 +1,6 @@
 // @flow
 
 import React, { PureComponent } from "react";
-import { Buffer } from "buffer";
 import { Keyboard, View, StyleSheet, SafeAreaView } from "react-native";
 import type { NavigationScreenProp } from "react-navigation";
 import { translate, Trans } from "react-i18next";
@@ -143,7 +142,7 @@ class EditDeviceName extends PureComponent<
               type="primary"
               title={<Trans i18nKey="EditDeviceName.action" />}
               onPress={this.onSubmit}
-              disabled={!name || error}
+              disabled={!name || !!error}
             />
           </View>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,10 +760,10 @@
   dependencies:
     "@ledgerhq/errors" "^4.38.0"
 
-"@ledgerhq/errors@4.39.0", "@ledgerhq/errors@^4.32.0", "@ledgerhq/errors@^4.38.0":
-  version "4.39.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.39.0.tgz#10b9889f78df94ce36a4b34d9a3a45aac77be0e9"
-  integrity sha512-kBr2rnoYDACRCxTLtEufE4oCvYj6vx2oFWVVjwskBxYsF5LC9R8Mbg5C4GgvDweiWW4Io8HA9p9jCsOfdCDygg==
+"@ledgerhq/errors@4.41.1", "@ledgerhq/errors@^4.32.0", "@ledgerhq/errors@^4.38.0":
+  version "4.41.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.41.1.tgz#8047464bf81c755dc7239b0ffb73fbf17a1c97aa"
+  integrity sha512-MKYzYNT5AKKZu2Ss0QrMXUS7Zri1F0HpNI3yKGjnhXEVxtr2fvxFXKgqdw7sdo+cLtkbNTJhiclemt0e0HtL0Q==
 
 "@ledgerhq/hw-app-btc@4.38.0", "@ledgerhq/hw-app-btc@^4.32.0":
   version "4.38.0"


### PR DESCRIPTION
To prevent characters that can't be displayed on the NanoX screen this adds a filter of non-ASCII characters to the edit device name screen. The behavior is a bit glitchy on Android where it will allow you to enter the character but clean-up only after another character is entered or we try to save. This is an issue with the events triggered on Android, works well on iOS.

Content is sanitized on both platforms. Try entering non-ASCII characters.