### PR TITLE
LL-1021 Take into account `softmenubarheight` on account scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "react-native-config": "0.11.5",
     "react-native-crypto": "^2.1.2",
     "react-native-easy-markdown": "^1.2.0",
-    "react-native-extra-dimensions-android": "^0.22.0",
+    "react-native-extra-dimensions-android": "^1.2.1",
     "react-native-gesture-handler": "^1.0.15",
     "react-native-keychain": "^3.0.0",
     "react-native-level-fs": "^3.0.0",

--- a/src/components/CameraScreen/QRCodeBottomLayer.js
+++ b/src/components/CameraScreen/QRCodeBottomLayer.js
@@ -7,6 +7,7 @@ import colors, { rgba } from "../../colors";
 
 import LText from "../LText";
 import QrCodeProgressBar from "./QRCodeProgressBar";
+import { softMenuBarHeight } from "../../logic/getWindowDimensions";
 
 type Props = {
   progress?: number,
@@ -36,6 +37,7 @@ const styles = StyleSheet.create({
   darken: {
     backgroundColor: rgba(colors.darkBlue, 0.4),
     flexGrow: 1,
+    paddingBottom: softMenuBarHeight(),
   },
   text: {
     fontSize: 16,

--- a/src/logic/getWindowDimensions.android.js
+++ b/src/logic/getWindowDimensions.android.js
@@ -4,3 +4,6 @@ export default () => ({
   width: ExtraDimensions.get("REAL_WINDOW_WIDTH"),
   height: ExtraDimensions.get("REAL_WINDOW_HEIGHT"),
 });
+
+export const softMenuBarHeight = () =>
+  ExtraDimensions.get("SOFT_MENU_BAR_HEIGHT");

--- a/src/logic/getWindowDimensions.ios.js
+++ b/src/logic/getWindowDimensions.ios.js
@@ -5,3 +5,5 @@ export default () => {
 
   return { width, height };
 };
+
+export const softMenuBarHeight = () => 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7052,10 +7052,10 @@ react-native-easy-markdown@^1.2.0:
   dependencies:
     simple-markdown "^0.1.1"
 
-react-native-extra-dimensions-android@^0.22.0:
-  version "0.22.0"
-  resolved "https://registry.yarnpkg.com/react-native-extra-dimensions-android/-/react-native-extra-dimensions-android-0.22.0.tgz#4b09ba19f52c5181efe37965a2c34cadfa05fb61"
-  integrity sha512-92ppYjXLId5dgjji7glG96CLkGWF/uH96w/hdoM1Je6cFPMqXbVLadHNCH/Edk2i1AySY7qObZXYJD7buWnhlg==
+react-native-extra-dimensions-android@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-extra-dimensions-android/-/react-native-extra-dimensions-android-1.2.1.tgz#52ae629610f0f4b6d3a50739e0742780dc3ec216"
+  integrity sha512-AMG8qBShir1M+73tWSjV8mnud7UurFO5IsH/iYCLryM2hIhbLXFbnLH/tvrPPi4MFNWr1d7MTIhFNjb7I851sA==
 
 react-native-gesture-handler@^1.0.15, react-native-gesture-handler@~1.0.14:
   version "1.0.15"


### PR DESCRIPTION
This one was a bit trippy for me because when I looked into the library we are using for the so-called extra dimensions's [readme](https://github.com/Sunhat/react-native-extra-dimensions-android) it looks like the guy was not paying much attention to the names of the helper methods with names such as `getRealWidthHeight`, [created a pr to help](https://github.com/Sunhat/react-native-extra-dimensions-android/pull/44) 🕺. In any case, what happens is that sometimes we will have a soft menu bar on that screen and we can add padding to the styles to account for it.

On other devices without the bar shown the padding is not added.
Here's an inception photo (screen capture of a Huawei p10 looking at the emulator for a pixel XL) to illustrate.

![image](https://user-images.githubusercontent.com/4631227/53367272-f8ba5b00-3945-11e9-9bb3-98b5298874f1.png)
