### PR TITLE
LL-1086 Handle new react-native-hid logic changes

### DIFF
--- a/src/components/SelectDevice/index.js
+++ b/src/components/SelectDevice/index.js
@@ -92,7 +92,9 @@ class SelectDevice extends Component<Props, State> {
                   name: e.name,
                   family: e.family,
                 })
-              : devices.filter(d => d.id !== e.id),
+              : e.type === "reset"
+                ? []
+                : devices.filter(d => d.id !== e.id),
         })),
     });
   }


### PR DESCRIPTION
Linked to https://github.com/LedgerHQ/ledgerjs/pull/303 , ~once merged react-native-hid will broadcast a `reset` event that we need to handle on the mobile end to clear the device list. This is that handling.~ What do we do about the unsubscribe logic that was unnecessary after the changes, do we remove it from here?