### PR TITLE
Refactored languages, added whitelist

### DIFF
--- a/src/context/Locale.js
+++ b/src/context/Locale.js
@@ -29,6 +29,7 @@ const i18n = i18next
   .init({
     fallbackLng: "en",
     resources: locales,
+    whitelist: Object.keys(locales),
     ns: ["common"],
     defaultNS: "common",
     interpolation: {

--- a/src/languages.js
+++ b/src/languages.js
@@ -2,14 +2,11 @@
 import Config from "react-native-config";
 import allLocales from "./locales";
 
-const prodStableLanguages = ["en"];
-
-const l = {};
 export const localeIds: string[] = Object.keys(allLocales);
-localeIds.forEach(key => {
-  if (Config.LEDGER_DEBUG_ALL_LANGS || prodStableLanguages.includes(key)) {
-    l[key] = allLocales[key];
-  }
-});
-
-export const locales = l;
+export const locales = (Config.LEDGER_DEBUG_ALL_LANGS
+  ? localeIds
+  : ["en"]
+).reduce((obj, key) => {
+  obj[key] = allLocales[key]; // eslint-disable-line no-param-reassign
+  return obj;
+}, {});


### PR DESCRIPTION
Somehow the locales were leaking regardless of the allowed languages, I refactored the languages file and added the `whitelist` param to the init of i18next. This seems to remove the Oui.

![image](https://user-images.githubusercontent.com/4631227/53988559-0c26ac80-4124-11e9-99a9-5ac43fa4ab91.png)
