### PR TITLE
Add more lazy implementation of genuineCheck (done in live-common)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@ledgerhq/hw-app-xrp": "4.43.0",
     "@ledgerhq/hw-transport": "4.43.0",
     "@ledgerhq/hw-transport-http": "4.43.0",
-    "@ledgerhq/live-common": "4.23.0",
+    "@ledgerhq/live-common": "4.25.0",
     "@ledgerhq/react-native-hid": "4.43.0",
     "@ledgerhq/react-native-hw-transport-ble": "4.43.0",
     "@ledgerhq/react-native-ledger-core": "^0.3.45",

--- a/src/components/DeviceJob/index.js
+++ b/src/components/DeviceJob/index.js
@@ -114,7 +114,7 @@ class DeviceJob extends Component<
 
   debouncedSetStepIndex = debounce(stepIndex => {
     this.setState({ stepIndex });
-  }, 500);
+  }, 1000);
 
   onStepDone = () => {
     this.onDoneSubject.next(this.state.stepIndex);

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,10 +800,10 @@
     "@ledgerhq/errors" "^4.43.0"
     events "^3.0.0"
 
-"@ledgerhq/live-common@4.23.0":
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-4.23.0.tgz#ddf214f960c4d15d3e455d30f1c4b90e72408cd7"
-  integrity sha512-+aDfbqa48E9L3XGfRFRlbMOm2169H4tpy2XN3B+04B2XHdQ7vNqbN7V5jtSLaM4AoCPV3x5BCiT/jEpmjSX15g==
+"@ledgerhq/live-common@4.25.0":
+  version "4.25.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-4.25.0.tgz#0db502a5f4e227dcd1b9b0a9b95b92a2f079db56"
+  integrity sha512-GP7QCBPmLQiwzIsqws4VOLsAlvHp4Gl9Y8j7vprpmsypiOu8A0aITZ4kDxq5lrVHIllt6frdCsqw5IilmoosPQ==
   dependencies:
     "@ledgerhq/errors" "^4.43.0"
     "@ledgerhq/hw-app-btc" "^4.43.0"


### PR DESCRIPTION
as soon as the genuine check was done once, it's no longer needed to do again. This is solved by using a flag that the device tell us and not doing genuine check if allow manager was done in the past on that specific device.

also increase the debounce to see less blinks during the steps.

### Type

better performance of opening manager & better UX 

### Context

https://github.com/LedgerHQ/ledger-live-common/pull/169

### Parts of the app affected / Test plan

manager / genuine check