### PR TITLE
Reintegrated the readonly flag for iOS

### DIFF
--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -307,6 +307,6 @@ export const hasInstalledAnyAppSelector = (state: State) =>
   state.settings.hasInstalledAnyApp;
 
 export const readOnlyModeEnabledSelector = (state: State) =>
-  Platform.OS === "android" && state.settings.readOnlyModeEnabled;
+  Platform.OS !== "android" && state.settings.readOnlyModeEnabled;
 
 export default handleActions(handlers, INITIAL_STATE);

--- a/src/screens/Manager/ReadOnlyNanoX.js
+++ b/src/screens/Manager/ReadOnlyNanoX.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React, { PureComponent } from "react";
-import { StyleSheet, View, Image, Linking } from "react-native";
+import { StyleSheet, View, Linking } from "react-native";
 import { Trans } from "react-i18next";
 import colors from "../../colors";
 import TrackScreen from "../../analytics/TrackScreen";
@@ -11,6 +11,8 @@ import Button from "../../components/Button";
 import { urls } from "../../config/urls";
 import { withOnboardingContext } from "../Onboarding/onboardingContext";
 import type { OnboardingStepProps } from "../Onboarding/types";
+import DeviceNanoAction from "../../components/DeviceNanoAction";
+import getWindowDimensions from "../../logic/getWindowDimensions";
 
 const hitSlop = {
   top: 16,
@@ -18,6 +20,8 @@ const hitSlop = {
   right: 16,
   bottom: 16,
 };
+
+const { width } = getWindowDimensions();
 
 class ReadOnlyNanoX extends PureComponent<OnboardingStepProps> {
   buy = () => Linking.openURL(urls.buyNanoX);
@@ -35,8 +39,9 @@ class ReadOnlyNanoX extends PureComponent<OnboardingStepProps> {
       <View style={styles.root}>
         <TrackScreen category="Manager" name="ReadOnlyNanoX" />
         <View style={styles.image}>
-          <Image source={require("../../images/nanoXHorizontalBig.png")} />
+          <DeviceNanoAction screen="empty" width={width * 0.8} />
         </View>
+
         <LText secondary semiBold style={styles.title}>
           <Trans i18nKey="manager.readOnly.question" />
         </LText>
@@ -112,7 +117,6 @@ const styles = StyleSheet.create({
   image: {
     marginBottom: 32,
     marginHorizontal: 7,
-    justifyContent: "center",
   },
   subText: {
     fontSize: 14,

--- a/src/screens/Manager/index.js
+++ b/src/screens/Manager/index.js
@@ -8,6 +8,7 @@ import { Trans, translate } from "react-i18next";
 import i18next from "i18next";
 import { compose } from "redux";
 import manager from "@ledgerhq/live-common/lib/manager";
+import { createStructuredSelector } from "reselect";
 import { removeKnownDevice } from "../../actions/ble";
 import {
   connectingStep,
@@ -26,6 +27,8 @@ import type { DeviceLike } from "../../reducers/ble";
 import Trash from "../../icons/Trash";
 import BottomModal from "../../components/BottomModal";
 import ModalBottomAction from "../../components/ModalBottomAction";
+import ReadOnlyNanoX from "./ReadOnlyNanoX";
+import { readOnlyModeEnabledSelector } from "../../reducers/settings";
 
 const UnpairDeviceModal = ({
   onHideMenu,
@@ -56,6 +59,10 @@ const UnpairDeviceModal = ({
     />
   </BottomModal>
 );
+
+const mapStateToProps = createStructuredSelector({
+  readOnlyModeEnabled: readOnlyModeEnabledSelector,
+});
 
 class ChooseDevice extends Component<
   {
@@ -149,10 +156,14 @@ class ChooseDevice extends Component<
   }
 
   render() {
-    const { isFocused } = this.props;
+    const { isFocused, readOnlyModeEnabled } = this.props;
     const { showMenu } = this.state;
 
     if (!isFocused) return null;
+
+    if (readOnlyModeEnabled) {
+      return <ReadOnlyNanoX navigation={this.props.navigation} />;
+    }
 
     return (
       <ScrollView style={styles.root}>
@@ -229,7 +240,7 @@ const styles = StyleSheet.create({
 export default compose(
   translate(),
   connect(
-    null,
+    mapStateToProps,
     { removeKnownDevice },
   ),
 )(withNavigationFocus(ChooseDevice));


### PR DESCRIPTION
Integrated back the readonlymode flag, for iOS.
Should show the pitch nanoX screen for iOS devices until we pair one, should be transparent for Android.