### PR TITLE
LL-1115 Fixed wording for camera import/scan recipient

### DIFF
--- a/src/components/CameraScreen/QRCodeBottomLayer.js
+++ b/src/components/CameraScreen/QRCodeBottomLayer.js
@@ -12,16 +12,24 @@ import { softMenuBarHeight } from "../../logic/getWindowDimensions";
 type Props = {
   progress?: number,
   viewFinderSize: number,
+  liveQrCode?: boolean,
 };
 
 class QrCodeBottomLayer extends PureComponent<Props> {
+
   render() {
-    const { progress, viewFinderSize } = this.props;
+    const { progress, viewFinderSize, liveQrCode } = this.props;
     return (
       <View style={[styles.darken, styles.centered]}>
         <View style={styles.centered}>
           <LText semibold style={styles.text}>
-            <Trans i18nKey="account.import.scan.descBottom" />
+            <Trans
+              i18nKey={
+                liveQrCode
+                  ? "account.import.scan.descBottom"
+                  : "send.scan.descBottom"
+              }
+            />
           </LText>
         </View>
         <QrCodeProgressBar

--- a/src/components/CameraScreen/index.js
+++ b/src/components/CameraScreen/index.js
@@ -14,11 +14,12 @@ type Props = {
   width: number,
   height: number,
   progress?: number,
+  liveQrCode?: boolean
 };
 
 class CameraScreen extends PureComponent<Props> {
   render() {
-    const { width, height, progress } = this.props;
+    const { width, height, progress, liveQrCode } = this.props;
 
     // Make the viewfinder borders 2/3 of the screen shortest border
     const viewFinderSize = (width > height ? height : width) * (2 / 3);
@@ -36,6 +37,7 @@ class CameraScreen extends PureComponent<Props> {
         <QRCodeBottomLayer
           viewFinderSize={viewFinderSize}
           progress={progress}
+          liveQrCode={liveQrCode}
         />
         <LText style={styles.version}>{liveCommonPkg.version}</LText>
       </View>

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -781,6 +781,8 @@
   },
   "send": {
     "scan": {
+      "title": "Scan QR code",
+      "descBottom": "Please put the QR code within the square",
       "fallback": {
         "header": "Scan QR code",
         "title": "Enable camera",

--- a/src/screens/ImportAccounts/Scan.js
+++ b/src/screens/ImportAccounts/Scan.js
@@ -132,7 +132,7 @@ class Scan extends PureComponent<
           style={[styles.camera, cameraDimensions]}
           notAuthorizedView={<FallBackCamera navigation={navigation} />}
         >
-          <CameraScreen width={width} height={height} progress={progress} />
+          <CameraScreen liveQrCode width={width} height={height} progress={progress} />
         </RNCamera>
         <GenericErrorBottomModal error={error} onClose={this.onCloseError} />
       </View>

--- a/src/screens/SendFunds/ScanRecipient.js
+++ b/src/screens/SendFunds/ScanRecipient.js
@@ -37,7 +37,7 @@ class ScanRecipient extends PureComponent<Props, State> {
   }: {
     navigation: NavigationScreenProp<*>,
   }) => ({
-    title: i18next.t("account.import.scan.title"),
+    title: i18next.t("send.scan.title"),
     headerRight: (
       <HeaderRightClose
         navigation={navigation}


### PR DESCRIPTION
Refactored the camera component a bit to allow for both `liveqr` and `normalqr` wording.
![image](https://user-images.githubusercontent.com/4631227/54200216-287f6c00-44cb-11e9-9de6-78efa771372e.png)
