### PR TITLE
LL-1123 Upgrade react-native-keychain to fix null exception + settings intent crash + wrong redirect

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,11 +2,11 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "27.0.3"
+        buildToolsVersion = "28.0.3"
         minSdkVersion = 24
-        compileSdkVersion = 27
+        compileSdkVersion = 28
         targetSdkVersion = 26
-        supportLibVersion = "27.1.1"
+        supportLibVersion = "28.0.3"
     }
     repositories {
         jcenter()
@@ -48,8 +48,8 @@ subprojects {
     afterEvaluate {project ->
         if (project.hasProperty("android")) {
             android {
-                compileSdkVersion 27
-                buildToolsVersion '27.0.3'
+                compileSdkVersion 28
+                buildToolsVersion '28.0.3'
 
                 compileOptions {
                     sourceCompatibility 1.8

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Mar 13 13:34:38 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "react-native-easy-markdown": "^1.2.0",
     "react-native-extra-dimensions-android": "^1.2.1",
     "react-native-gesture-handler": "^1.0.15",
-    "react-native-keychain": "^3.0.0",
+    "react-native-keychain": "^3.1.1",
     "react-native-level-fs": "^3.0.0",
     "react-native-locale": "0.0.19",
     "react-native-modal": "^7.0.1",

--- a/src/components/CameraScreen/QRCodeBottomLayer.js
+++ b/src/components/CameraScreen/QRCodeBottomLayer.js
@@ -16,7 +16,6 @@ type Props = {
 };
 
 class QrCodeBottomLayer extends PureComponent<Props> {
-
   render() {
     const { progress, viewFinderSize, liveQrCode } = this.props;
     return (

--- a/src/components/CameraScreen/index.js
+++ b/src/components/CameraScreen/index.js
@@ -14,7 +14,7 @@ type Props = {
   width: number,
   height: number,
   progress?: number,
-  liveQrCode?: boolean
+  liveQrCode?: boolean,
 };
 
 class CameraScreen extends PureComponent<Props> {

--- a/src/navigators.js
+++ b/src/navigators.js
@@ -106,7 +106,7 @@ import DebugStore from "./screens/DebugStore";
 import DebugWSImport from "./screens/DebugWSImport";
 import ScanAccounts from "./screens/ImportAccounts/Scan";
 import DisplayResult from "./screens/ImportAccounts/DisplayResult";
-import FallBackCameraScreen from "./screens/ImportAccounts/FallBackCameraScreen.ios";
+import FallBackCameraScreen from "./screens/ImportAccounts/FallBackCameraScreen";
 import OnboardingOrNavigator from "./screens/OnboardingOrNavigator";
 import AdvancedLogs from "./screens/AccountSettings/AdvancedLogs";
 

--- a/src/screens/ImportAccounts/Scan.js
+++ b/src/screens/ImportAccounts/Scan.js
@@ -132,7 +132,12 @@ class Scan extends PureComponent<
           style={[styles.camera, cameraDimensions]}
           notAuthorizedView={<FallBackCamera navigation={navigation} />}
         >
-          <CameraScreen liveQrCode width={width} height={height} progress={progress} />
+          <CameraScreen
+            liveQrCode
+            width={width}
+            height={height}
+            progress={progress}
+          />
         </RNCamera>
         <GenericErrorBottomModal error={error} onClose={this.onCloseError} />
       </View>

--- a/src/screens/SendFunds/FallbackCamera/FallbackCameraSend.android.js
+++ b/src/screens/SendFunds/FallbackCamera/FallbackCameraSend.android.js
@@ -43,7 +43,7 @@ class FallBackCameraScreen extends PureComponent<Props, State> {
       nextAppState === "active" &&
       openSettingsPressed
     ) {
-      navigation.replace("SendFundsMain");
+      navigation.replace("SendFunds");
     }
     this.setState({ appState: nextAppState });
   };

--- a/src/screens/Settings/General/ConfirmPassword.js
+++ b/src/screens/Settings/General/ConfirmPassword.js
@@ -37,7 +37,7 @@ class ConfirmPassword extends PureComponent<Props, State> {
 
   componentDidMount() {
     Keychain.getSupportedBiometryType().then(biometricsType => {
-      this.setState({ biometricsType });
+      if(biometricsType) this.setState({ biometricsType });
     });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7107,10 +7107,10 @@ react-native-gesture-handler@^1.0.15, react-native-gesture-handler@~1.0.14:
     invariant "^2.2.2"
     prop-types "^15.5.10"
 
-react-native-keychain@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-3.0.0.tgz#29da1dfa43c2581f76bf9420914fd38a1558cf18"
-  integrity sha512-0incABt1+aXsZvG34mDV57KKanSB+iMHmxvWv+N6lgpNLaSoqrCxazjbZdeqD4qJ7Z+Etp5CLf/4v1aI+sNLBw==
+react-native-keychain@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-3.1.1.tgz#119cbf734d8dceaf80de82ee979a4db268fbc380"
+  integrity sha512-+qZn6uRevd/rdyzuh4YBBhjhv/hxj+N408+vD8/otnsZ+c3mcc2FmRw3n+n2g0Z6tfgfT30jVETe6ZhfcER7yQ==
 
 react-native-level-fs@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Had to upgrade the build tools version to allow the new version of `react-native-keychain`, this ideally should fix LL-1123 or at least the part of it pertaining to the fingerprint scanner crashes. ~The camera intent still remains a mystery.~ The camera intent crash was caused by an incorrect import of the fallback camera screen where we were specifying the ios import, hence calling the settings intent with react native's `Linking` instead of the specific android library we use.

Also changed the replace route for the fallback camera screen, apparently we can't replace to a route that's not in the same `StackNavigator` unless it's in `BaseNavigator`