### PR TITLE
Center ctas on receive screen

### DIFF
--- a/src/screens/ReceiveFunds/03-Confirmation.js
+++ b/src/screens/ReceiveFunds/03-Confirmation.js
@@ -230,14 +230,17 @@ class ReceiveConfirmation extends Component<Props, State> {
             </View>
             <View style={styles.copyLink}>
               <CopyLink
+                style={styles.copyShare}
                 string={account.freshAddress}
                 replacement={<Trans i18nKey="transfer.receive.addressCopied" />}
               >
                 <Trans i18nKey="transfer.receive.copyAddress" />
               </CopyLink>
-              <ShareLink value={account.freshAddress}>
-                <Trans i18nKey="transfer.receive.shareAddress" />
-              </ShareLink>
+              <View style={styles.copyShare}>
+                <ShareLink value={account.freshAddress}>
+                  <Trans i18nKey="transfer.receive.shareAddress" />
+                </ShareLink>
+              </View>
             </View>
           </View>
           <View style={styles.bottomContainer}>
@@ -424,8 +427,11 @@ const styles = StyleSheet.create({
   copyLink: {
     paddingTop: 24,
     flexDirection: "row",
-    justifyContent: "space-between",
+    justifyContent: "center",
     alignSelf: "stretch",
+  },
+  copyShare: {
+    paddingHorizontal: 12,
   },
   modal: {
     flexDirection: "column",


### PR DESCRIPTION
Small design change for the receive confirmation screen, moving the two ctas for copy/share to be center aligned instead of spread.
![image](https://user-images.githubusercontent.com/4631227/54692534-70cf0780-4b25-11e9-967b-5fab69b14e91.png)
