### PR TITLE
Clear input button on recipient address, send flow, max cap

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,7 @@ export const SYNC_DELAY = 2500;
 export const UP_TO_DATE_THRESHOLD = SYNC_ALL_INTERVAL;
 
 export const MAX_ACCOUNT_NAME_SIZE = 50;
+export const CUSTOM_FEES_CAP = 100000;
 
 export const BLE_SCANNING_NOTHING_TIMEOUT = 30 * 1000;
 

--- a/src/families/bitcoin/ScreenEditFeePerByte/CustomFeesRow.js
+++ b/src/families/bitcoin/ScreenEditFeePerByte/CustomFeesRow.js
@@ -18,6 +18,7 @@ import LText from "../../../components/LText/index";
 
 import Check from "../../../icons/Check";
 import colors from "../../../colors";
+import { CUSTOM_FEES_CAP } from "../../../constants";
 
 const bitcoinCurrency = getCryptoCurrencyById("bitcoin");
 const satoshiUnit = bitcoinCurrency.units[bitcoinCurrency.units.length - 1];
@@ -50,6 +51,11 @@ class FeesRow extends Component<Props, State> {
   onChangeText = (text: string) => {
     const { onPress } = this.props;
     const fees = sanitizeValueString(satoshiUnit, text);
+
+    if (BigNumber(fees.value).gt(CUSTOM_FEES_CAP)) {
+      [fees.value, fees.display] = [`${CUSTOM_FEES_CAP}`, `${CUSTOM_FEES_CAP}`];
+    }
+
     this.setState({ fees: fees.display }, () => {
       if (fees.value !== "") {
         onPress(BigNumber(fees.value));

--- a/src/families/bitcoin/ScreenEditFeePerByte/CustomFeesRow.js
+++ b/src/families/bitcoin/ScreenEditFeePerByte/CustomFeesRow.js
@@ -53,7 +53,8 @@ class FeesRow extends Component<Props, State> {
     const fees = sanitizeValueString(satoshiUnit, text);
 
     if (BigNumber(fees.value).gt(CUSTOM_FEES_CAP)) {
-      [fees.value, fees.display] = [`${CUSTOM_FEES_CAP}`, `${CUSTOM_FEES_CAP}`];
+      fees.value = `${CUSTOM_FEES_CAP}`;
+      fees.display = `${CUSTOM_FEES_CAP}`;
     }
 
     this.setState({ fees: fees.display }, () => {

--- a/src/screens/SendFunds/02-SelectRecipient.js
+++ b/src/screens/SendFunds/02-SelectRecipient.js
@@ -214,6 +214,7 @@ class SendSelectRecipient extends Component<Props, State> {
                 ]}
                 onFocus={this.onRecipientFieldFocus}
                 onChangeText={this.onChangeText}
+                onInputCleared={this.clear}
                 value={address}
                 ref={this.input}
                 multiline


### PR DESCRIPTION
- fix unlinked clear button on input for the recipient address
- adds a max fee cap to custom fees for bitcoin-like coins
