### PR TITLE
Added a centeredIcon flag for SettingRow icons

### DIFF
--- a/src/components/SettingsRow.js
+++ b/src/components/SettingsRow.js
@@ -16,6 +16,7 @@ export default class SettingsRow extends Component<{
   selected?: boolean,
   arrowRight?: boolean,
   iconLeft?: *,
+  centeredIcon?: boolean,
   alignedTop?: boolean,
   compact?: boolean,
   children: React$Node,
@@ -34,6 +35,7 @@ export default class SettingsRow extends Component<{
       desc,
       arrowRight,
       iconLeft,
+      centeredIcon,
       alignedTop,
       compact,
       selected,
@@ -75,7 +77,11 @@ export default class SettingsRow extends Component<{
         event={event}
         eventProperties={eventProperties}
       >
-        {iconLeft && <View style={styles.iconLeft}>{iconLeft}</View>}
+        {iconLeft && (
+          <View style={[styles.iconLeft, centeredIcon && styles.centeredIcon]}>
+            {iconLeft}
+          </View>
+        )}
         <View style={[styles.textBlock, { marginLeft: iconLeft ? 0 : 16 }]}>
           {title$}
           {desc &&
@@ -155,6 +161,9 @@ const styles = StyleSheet.create({
   iconLeft: {
     paddingRight: 16,
     marginLeft: 16,
+  },
+  centeredIcon: {
+    justifyContent: "center",
   },
   iconLeftContainer: {
     marginRight: 8,

--- a/src/screens/Settings/General/BiometricsRow.js
+++ b/src/screens/Settings/General/BiometricsRow.js
@@ -69,6 +69,7 @@ class BiometricsRow extends Component<Props, State> {
           <SettingsRow
             event="BiometricsRow"
             iconLeft={iconLeft}
+            centeredIcon
             title={
               <Trans
                 i18nKey="auth.enableBiometrics.title"


### PR DESCRIPTION
The biometric icon should be centered regarding the title and description according to design. Note that the text doesn't match because I had to mock the biometric type but the center should still work regardless of the type.

<img width="691" alt="Screenshot 2019-03-25 at 17 42 31" src="https://user-images.githubusercontent.com/4631227/54937997-d0faea80-4f25-11e9-926b-ae4bfb0e397b.png">
