### PR TITLE
Fixes display on phone using a locale not supported

### DIFF
--- a/src/components/OperationRowDate.js
+++ b/src/components/OperationRowDate.js
@@ -1,9 +1,11 @@
 // @flow
 import { Component } from "react";
 import compareDate from "../logic/compareDate";
+import { withLocale } from "../context/Locale";
 
 type Props = {
   date: Date,
+  locale: string,
 };
 
 class OperationRowDate extends Component<Props> {
@@ -14,12 +16,12 @@ class OperationRowDate extends Component<Props> {
   }
 
   render() {
-    const { date } = this.props;
-    return `at ${date.toLocaleTimeString([], {
+    const { date, locale } = this.props;
+    return `at ${date.toLocaleTimeString(locale, {
       hour: "2-digit",
       minute: "2-digit",
     })}`;
   }
 }
 
-export default OperationRowDate;
+export default withLocale(OperationRowDate);

--- a/src/context/Locale.js
+++ b/src/context/Locale.js
@@ -37,11 +37,13 @@ const i18n = i18next
     },
   });
 
-const LocaleContext = React.createContext({
+const getState = i18n => ({
   i18n,
   t: i18n.getFixedT(),
-  locale: i18n.language,
+  locale: i18n.languages[0],
 });
+
+const LocaleContext = React.createContext(getState(i18n));
 
 type State = {
   i18n: *,
@@ -55,19 +57,11 @@ export default class LocaleProvider extends React.Component<
   },
   State,
 > {
-  state = {
-    i18n,
-    t: i18n.getFixedT(),
-    locale: i18n.language,
-  };
+  state = getState(i18n);
 
   componentDidMount() {
-    i18next.on("languageChanged", locale => {
-      this.setState({
-        i18n,
-        t: i18n.getFixedT(locale),
-        locale: i18n.language,
-      });
+    i18next.on("languageChanged", () => {
+      this.setState(getState(i18n));
     });
   }
 


### PR DESCRIPTION
as the app only supports English at the moment, everything must consistently fallback to English (date and number formatters).

- using Arabic system language was creating bad rendering of our app
- using French system language does not correctly format the price (until we support French)


**before**

<img width="378" alt="Capture d’écran 2019-03-27 à 08 40 59" src="https://user-images.githubusercontent.com/211411/55058373-16c1cb00-506c-11e9-89dc-4b5f48b786a3.png">

**after**

<img width="377" alt="Capture d’écran 2019-03-27 à 08 40 42" src="https://user-images.githubusercontent.com/211411/55058372-16c1cb00-506c-11e9-9153-31bfb9c6d08d.png">


### Type

Bug

### Context

LL-1196

### Parts of the app affected / Test plan

- Arabic system language is fallbacking to English
- French system language is fallbacking to English
- English system language works like before