### PR TITLE
feat: LL-1004 Use estimage-gas-limit to prefill gas

### DIFF
--- a/src/screens/ReceiveFunds/03-Confirmation.js
+++ b/src/screens/ReceiveFunds/03-Confirmation.js
@@ -125,13 +125,21 @@ class ReceiveConfirmation extends Component<Props, State> {
   verifyOnDevice = async (deviceId: string) => {
     const { account, navigation } = this.props;
 
-    this.sub = withDevice(deviceId)(transport =>
-      account.id.startsWith("mock")
-        ? of({}).pipe(delay(1000), rejectionOp())
-        :
-      from(
-        getAddress(transport, account.currency, account.freshAddressPath, true),
-      ),
+    this.sub = withDevice(deviceId)(
+      transport =>
+        account.id.startsWith("mock")
+          ? of({}).pipe(
+              delay(1000),
+              rejectionOp(),
+            )
+          : from(
+              getAddress(
+                transport,
+                account.currency,
+                account.freshAddressPath,
+                true,
+              ),
+            ),
     ).subscribe({
       complete: () => {
         this.setState({ verified: true });

--- a/src/screens/SendFunds/02-SelectRecipient.js
+++ b/src/screens/SendFunds/02-SelectRecipient.js
@@ -10,10 +10,10 @@ import i18next from "i18next";
 import { translate, Trans } from "react-i18next";
 import type { Account } from "@ledgerhq/live-common/lib/types";
 import throttle from "lodash/throttle";
+import { BigNumber } from "bignumber.js";
 import Icon from "react-native-vector-icons/dist/FontAwesome";
 
 import type { T } from "../../types/common";
-
 import { accountScreenSelector } from "../../reducers/accounts";
 import { getAccountBridge } from "../../bridge";
 import { track, TrackScreen } from "../../analytics";
@@ -150,6 +150,7 @@ class SendSelectRecipient extends Component<Props, State> {
     const { account, navigation } = this.props;
     const { address } = this.state;
     const bridge = getAccountBridge(account);
+
     let transaction =
       navigation.getParam("transaction") || bridge.createTransaction(account);
 
@@ -164,6 +165,17 @@ class SendSelectRecipient extends Component<Props, State> {
         account,
         transaction,
         this.preloadedNetworkInfo,
+      );
+    }
+
+    // $FlowFixMe
+    if (bridge.estimateGasLimit) {
+      const gasLimit = await bridge.estimateGasLimit(account, address);
+      transaction = bridge.editTransactionExtra(
+        account,
+        transaction,
+        "gasLimit",
+        BigNumber(gasLimit),
       );
     }
 


### PR DESCRIPTION
When using the v3 explorer for Ethereum get the estimated gas limit from the servers instead of using the hardcoded 21k. This will graciously fallback to the 21k for v2. Note that we will need to set the `USE_EXPERIMENTAL_EXPLORERS` flag programmatically for this to work, or flick the switch in the experimental features screen once it's available.

### Type

Feature

### Blocked by

https://github.com/LedgerHQ/ledger-live-common/pull/191

Needs to have `live-common` bumped with the code from that pr

### Parts of the app affected / Test plan

Send flow, for Ethereum, try using a contract vs non-contract address, see if the gas limit changes.