### PR TITLE
feat: LL-1077 Add failsafe to the send flow when fees are too high

### DIFF
--- a/src/components/ConfirmationModal.js
+++ b/src/components/ConfirmationModal.js
@@ -4,7 +4,7 @@ import React, { PureComponent } from "react";
 import { Trans } from "react-i18next";
 import { View, StyleSheet } from "react-native";
 
-import colors from "../colors";
+import colors, { rgba } from "../colors";
 import BottomModal from "./BottomModal";
 import LText from "./LText";
 import Button from "./Button";
@@ -12,15 +12,18 @@ import Button from "./Button";
 type Props = {
   isOpened: boolean,
   onClose: () => void,
-  onConfirm: () => void,
-  confirmationTitle: React$Node,
-  confirmationDesc: React$Node,
+  onConfirm: () => *,
+  confirmationTitle?: React$Node,
+  confirmationDesc?: React$Node,
+  Icon?: React$ComponentType<*>,
+  confirmButtonText?: React$Node,
+  rejectButtonText?: React$Node,
+  alert: boolean,
 };
 
 class ConfirmationModal extends PureComponent<Props> {
   static defaultProps = {
-    confirmationTitle: "Are you sure?",
-    confirmationDesc: "Please confirm you want to close",
+    alert: false,
   };
 
   render() {
@@ -29,7 +32,11 @@ class ConfirmationModal extends PureComponent<Props> {
       onClose,
       confirmationTitle,
       confirmationDesc,
+      confirmButtonText,
+      rejectButtonText,
       onConfirm,
+      Icon,
+      alert,
       ...rest
     } = this.props;
     return (
@@ -40,16 +47,25 @@ class ConfirmationModal extends PureComponent<Props> {
         style={styles.confirmationModal}
         {...rest}
       >
-        <LText semiBold style={styles.confirmationTitle}>
-          {confirmationTitle}
-        </LText>
-        <LText style={styles.confirmationDesc}>{confirmationDesc}</LText>
+        {Icon && (
+          <View style={styles.icon}>
+            <Icon size={24} />
+          </View>
+        )}
+        {confirmationTitle && (
+          <LText semiBold style={styles.confirmationTitle}>
+            {confirmationTitle}
+          </LText>
+        )}
+        {confirmationDesc && (
+          <LText style={styles.confirmationDesc}>{confirmationDesc}</LText>
+        )}
         <View style={styles.confirmationFooter}>
           <Button
             event="ConfirmationModalCancel"
             containerStyle={styles.confirmationButton}
             type="secondary"
-            title={<Trans i18nKey="common.cancel" />}
+            title={rejectButtonText || <Trans i18nKey="common.cancel" />}
             onPress={onClose}
           />
           <Button
@@ -58,8 +74,8 @@ class ConfirmationModal extends PureComponent<Props> {
               styles.confirmationButton,
               styles.confirmationLastButton,
             ]}
-            type="primary"
-            title={<Trans i18nKey="common.confirm" />}
+            type={alert ? "alert" : "primary"}
+            title={confirmButtonText || <Trans i18nKey="common.confirm" />}
             onPress={onConfirm}
           />
         </View>
@@ -93,6 +109,15 @@ const styles = StyleSheet.create({
   },
   confirmationLastButton: {
     marginLeft: 16,
+  },
+  icon: {
+    alignSelf: "center",
+    backgroundColor: rgba(colors.alert, 0.08),
+    width: 56,
+    borderRadius: 28,
+    height: 56,
+    alignItems: "center",
+    justifyContent: "center",
   },
 });
 

--- a/src/icons/AlertTriangle.js
+++ b/src/icons/AlertTriangle.js
@@ -1,13 +1,17 @@
 // @flow
 import React from "react";
 import Svg, { Path, G } from "react-native-svg";
+import colors from "../colors";
 
 type Props = {
   size: number,
   color: string,
 };
 
-export default function AlertTriangle({ size = 16, color }: Props) {
+export default function AlertTriangle({
+  size = 16,
+  color = colors.alert,
+}: Props) {
   return (
     <Svg viewBox="0 0 16 16" width={size} height={size}>
       <G

--- a/src/icons/ExclamationCircle.js
+++ b/src/icons/ExclamationCircle.js
@@ -1,0 +1,32 @@
+// @flow
+import React from "react";
+import Svg, { Defs, Mask, Use, Path, G } from "react-native-svg";
+
+type Props = {
+  size: number,
+  color: string,
+};
+
+export default function ExclamationCircle({
+  size = 16,
+  color = "#EA2E49",
+}: Props) {
+  return (
+    <Svg viewBox="0 0 24 24" width={size} height={size}>
+      <Defs>
+        <Path
+          id="a"
+          d="M12 .375C5.58.375.375 5.582.375 12 .375 18.422 5.58 23.625 12 23.625S23.625 18.422 23.625 12C23.625 5.582 18.42.375 12 .375zm0 21A9.37 9.37 0 0 1 2.625 12 9.372 9.372 0 0 1 12 2.625 9.372 9.372 0 0 1 21.375 12 9.37 9.37 0 0 1 12 21.375zm1.969-4.875A1.971 1.971 0 0 1 12 18.469a1.971 1.971 0 0 1-1.969-1.969c0-1.086.883-1.969 1.969-1.969s1.969.883 1.969 1.969zm-3.814-9.91l.318 6.376c.015.299.262.534.562.534h1.93c.3 0 .547-.235.562-.534l.318-6.375A.562.562 0 0 0 13.284 6h-2.568a.562.562 0 0 0-.561.59z"
+        />
+      </Defs>
+      <G fill="none" fillRule="evenodd">
+        <Mask id="b" fill="#fff">
+          <Use xlinkHref="#a" />
+        </Mask>
+        <G fill={color} mask="url(#b)">
+          <Path d="M0 0h24v24H0z" />
+        </G>
+      </G>
+    </Svg>
+  );
+}

--- a/src/icons/ExclamationCircle.js
+++ b/src/icons/ExclamationCircle.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react";
 import Svg, { Defs, Mask, Use, Path, G } from "react-native-svg";
+import colors from "../colors";
 
 type Props = {
   size: number,
@@ -9,7 +10,7 @@ type Props = {
 
 export default function ExclamationCircle({
   size = 16,
-  color = "#EA2E49",
+  color = colors.alert,
 }: Props) {
   return (
     <Svg viewBox="0 0 24 24" width={size} height={size}>

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -793,6 +793,7 @@
     "loading": "Searching devices..."
   },
   "send": {
+    "highFeeModal": "Be careful, your fees represent more than <1>10%</1> of the amount. Do you want to continue?",
     "scan": {
       "title": "Scan QR code",
       "descBottom": "Please put the QR code within the square",

--- a/src/screens/ReceiveFunds/03-Confirmation.js
+++ b/src/screens/ReceiveFunds/03-Confirmation.js
@@ -125,13 +125,21 @@ class ReceiveConfirmation extends Component<Props, State> {
   verifyOnDevice = async (deviceId: string) => {
     const { account, navigation } = this.props;
 
-    this.sub = withDevice(deviceId)(transport =>
-      account.id.startsWith("mock")
-        ? of({}).pipe(delay(1000), rejectionOp())
-        :
-      from(
-        getAddress(transport, account.currency, account.freshAddressPath, true),
-      ),
+    this.sub = withDevice(deviceId)(
+      transport =>
+        account.id.startsWith("mock")
+          ? of({}).pipe(
+              delay(1000),
+              rejectionOp(),
+            )
+          : from(
+              getAddress(
+                transport,
+                account.currency,
+                account.freshAddressPath,
+                true,
+              ),
+            ),
     ).subscribe({
       complete: () => {
         this.setState({ verified: true });

--- a/src/screens/SendFunds/04-Summary.js
+++ b/src/screens/SendFunds/04-Summary.js
@@ -25,6 +25,8 @@ import SendRowsFee from "../../families/SendRowsFee";
 import SummaryTotalSection from "./SummaryTotalSection";
 import StepHeader from "../../components/StepHeader";
 import SectionSeparator from "../../components/SectionSeparator";
+import ExclamationCircle from "../../icons/ExclamationCircle";
+import ConfirmationModal from "../../components/ConfirmationModal";
 
 // TODO put this somewhere
 const similarError = (a, b) =>
@@ -45,6 +47,7 @@ class SendSummary extends Component<
   {
     totalSpent: ?BigNumber,
     error: ?Error,
+    highFeesOpen: boolean
   },
 > {
   static navigationOptions = {
@@ -62,6 +65,7 @@ class SendSummary extends Component<
   state = {
     totalSpent: null,
     error: null, // TODO use error somewhere!
+    highFeesOpen: false,
   };
 
   componentDidMount() {
@@ -89,6 +93,19 @@ class SendSummary extends Component<
     const transaction = navigation.getParam("transaction");
     const bridge = getAccountBridge(account);
     await bridge.checkValidTransaction(account, transaction);
+
+    if (bridge && account && transaction) {
+      const totalSpent = await bridge.getTotalSpent(account, transaction);
+      if (
+        totalSpent
+          .minus(transaction.amount)
+          .times(10)
+          .gt(transaction.amount)
+      ) {
+        this.setState({ highFeesOpen: true });
+        return;
+      }
+    }
     navigation.navigate("SendConnectDevice", {
       accountId: account.id,
       transaction,
@@ -134,8 +151,25 @@ class SendSummary extends Component<
     }
   };
 
+  onAcceptFees = async () => {
+    const { account, navigation } = this.props;
+    const transaction = navigation.getParam("transaction");
+    const bridge = getAccountBridge(account);
+    await bridge.checkValidTransaction(account, transaction);
+
+    navigation.navigate("SendConnectDevice", {
+      accountId: account.id,
+      transaction,
+    });
+    this.setState({ highFeesOpen: false });
+  };
+
+  onRejectFees = () => {
+    this.setState({ highFeesOpen: false });
+  };
+
   render() {
-    const { totalSpent, error } = this.state;
+    const { totalSpent, error, highFeesOpen } = this.state;
     const { account, navigation } = this.props;
     const transaction = navigation.getParam("transaction");
     const bridge = getAccountBridge(account);
@@ -180,6 +214,20 @@ class SendSummary extends Component<
             disabled={!totalSpent || !!error}
           />
         </View>
+        <ConfirmationModal
+          isOpened={highFeesOpen}
+          alert
+          onClose={this.onRejectFees}
+          onConfirm={this.onAcceptFees}
+          Icon={ExclamationCircle}
+          confirmationDesc={
+            <Trans i18nKey="send.highFeeModal">
+              {"text"}
+              <LText bold>bold text</LText>
+            </Trans>
+          }
+          confirmButtonText={<Trans i18nKey="common.continue" />}
+        />
       </SafeAreaView>
     );
   }

--- a/src/screens/SendFunds/04-Summary.js
+++ b/src/screens/SendFunds/04-Summary.js
@@ -25,7 +25,7 @@ import SendRowsFee from "../../families/SendRowsFee";
 import SummaryTotalSection from "./SummaryTotalSection";
 import StepHeader from "../../components/StepHeader";
 import SectionSeparator from "../../components/SectionSeparator";
-import ExclamationCircle from "../../icons/ExclamationCircle";
+import AlertTriangle from "../../icons/AlertTriangle";
 import ConfirmationModal from "../../components/ConfirmationModal";
 
 // TODO put this somewhere
@@ -47,7 +47,7 @@ class SendSummary extends Component<
   {
     totalSpent: ?BigNumber,
     error: ?Error,
-    highFeesOpen: boolean
+    highFeesOpen: boolean,
   },
 > {
   static navigationOptions = {
@@ -216,10 +216,9 @@ class SendSummary extends Component<
         </View>
         <ConfirmationModal
           isOpened={highFeesOpen}
-          alert
           onClose={this.onRejectFees}
           onConfirm={this.onAcceptFees}
-          Icon={ExclamationCircle}
+          Icon={AlertTriangle}
           confirmationDesc={
             <Trans i18nKey="send.highFeeModal">
               {"text"}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/55437465-3f335300-559f-11e9-9907-3739e37c2fa0.png)


### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1077

### Parts of the app affected / Test plan

The send flow, try to send an amount with fees representing more than 10% of the amount, you should be prompted with the above modal to confirm that unusual transaction. ~~The modal should not be dismissable by clicking outside~~ the user needs to either confirm and go to the next step, or cancel and remain on the first step of the flow.