### PR TITLE
Fixes app to crash with import accounts

### DIFF
--- a/src/implement-react-native-libcore/loadCoreImpl.js
+++ b/src/implement-react-native-libcore/loadCoreImpl.js
@@ -405,9 +405,7 @@ export async function loadCore(): Promise<Core> {
       },
     },
     methods: {
-      getIndex: {
-        returns: "ExtendedKeyAccountCreationInfo",
-      },
+      getIndex: {},
       getExtendedKeys: {},
       getOwners: {},
       getDerivations: {},


### PR DESCRIPTION
### Type

Bug Fix

### Context
After import, apps were crashing due to an incorrect declaration of the getIndex method. 