### PR TITLE
bugfix: Disable device selection for already paired devices

### DIFF
--- a/src/components/DeviceItem.js
+++ b/src/components/DeviceItem.js
@@ -55,7 +55,10 @@ export default class DeviceItem extends PureComponent<Props> {
     return (
       <View style={styles.outer}>
         <View style={styles.inner}>
-          <Touchable event="DeviceItemEnter" onPress={this.onPress}>
+          <Touchable
+            event="DeviceItemEnter"
+            onPress={disabled ? undefined : this.onPress}
+          >
             <View style={[styles.root, disabled && styles.rootDisabled]}>
               <View style={styles.iconWrapper}>
                 {CustomIcon ? (


### PR DESCRIPTION
![Apr-08-2019 16-04-30](https://user-images.githubusercontent.com/4631227/55730345-3d8ee280-5a18-11e9-8c7c-be48716d7540.gif)

### Type

Bug fix, refression on paired devices

### Context

Pairing devices bluetooth