### PR TITLE
feat: LL-593 Allow user to edit account name when importing

### DIFF
--- a/src/components/CheckBox.js
+++ b/src/components/CheckBox.js
@@ -11,7 +11,7 @@ type Props = {
   isChecked: boolean,
   onChange?: boolean => void,
   disabled?: boolean,
-  style: *,
+  style?: *,
 };
 
 export default class CheckBox extends PureComponent<Props> {
@@ -49,11 +49,11 @@ export default class CheckBox extends PureComponent<Props> {
 
 const styles = StyleSheet.create({
   root: {
-    width: 32,
-    height: 32,
+    width: 24,
+    height: 24,
     alignItems: "center",
     justifyContent: "center",
-    borderWidth: 2,
+    borderWidth: 1,
     borderColor: colors.fog,
     borderRadius: 24,
   },

--- a/src/components/TouchHintCircle.js
+++ b/src/components/TouchHintCircle.js
@@ -1,0 +1,102 @@
+// @flow
+
+import React, { Component } from "react";
+import {
+  InteractionManager,
+  Animated,
+  View,
+  StyleSheet,
+  Easing,
+} from "react-native";
+import colors from "../colors";
+
+class TouchHintCircle extends Component<*> {
+  leftAnimated = new Animated.Value(0);
+  opacityAnimated = new Animated.Value(1);
+
+  componentDidMount() {
+    Animated.spring(this.opacityAnimated, {
+      toValue: 0,
+      delay: 200,
+      duration: 600,
+      useNativeDriver: true,
+    }).start();
+
+    Animated.loop(
+      Animated.timing(this.leftAnimated, {
+        toValue: 1,
+        duration: 1000,
+        easing: Easing.elastic(1),
+        useNativeDriver: true,
+      }),
+      {
+        delay: 800,
+        iterations: 3,
+      },
+    ).start();
+
+    Animated.spring(this.opacityAnimated, {
+      toValue: 0,
+      delay: 3000,
+      duration: 1200,
+      useNativeDriver: true,
+    }).start();
+  }
+
+  render() {
+    const translateX = this.leftAnimated.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, 80],
+    });
+
+    const opacity = this.opacityAnimated.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, 1],
+    });
+
+    return (
+      <Animated.View
+        style={[
+          this.props.style,
+          styles.wrap,
+          {
+            opacity,
+            transform: [
+              {
+                translateX,
+              },
+            ],
+          },
+        ]}
+      >
+        <View style={styles.root}>
+          <View style={styles.ball} />
+        </View>
+      </Animated.View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    alignItems: "center",
+    justifyContent: "center",
+    opacity: 0.7,
+  },
+  root: {
+    height: 40,
+    width: 40,
+    borderRadius: 40,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.lightLive,
+  },
+  ball: {
+    height: 20,
+    width: 20,
+    borderRadius: 20,
+    backgroundColor: colors.live,
+  },
+});
+
+export default TouchHintCircle;

--- a/src/navigators.js
+++ b/src/navigators.js
@@ -371,6 +371,7 @@ const ImportAccounts = createStackNavigator(
     },
     DisplayResult,
     FallBackCameraScreen,
+    EditAccountName,
   },
   closableStackNavigatorConfig,
 );

--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -77,7 +77,8 @@ export const currenciesSelector = createSelector(accountsSelector, acc =>
 
 export const accountScreenSelector = createSelector(
   accountsSelector,
-  (_, { navigation }) => navigation.state.params.accountId,
+  (_, { navigation }) =>
+    (navigation.state.params && navigation.state.params.accountId) || null,
   (accounts, accountId) => accounts.find(a => a.id === accountId),
 );
 

--- a/src/screens/AccountSettings/EditAccountName.js
+++ b/src/screens/AccountSettings/EditAccountName.js
@@ -23,7 +23,9 @@ export const MAX_ACCOUNT_NAME_LENGHT = 50;
 
 type Props = {
   navigation: NavigationScreenProp<{
-    accountId: string,
+    accountId?: string,
+    accountName?: string,
+    onAccountNameChange?: string => void,
   }>,
   updateAccount: Function,
   account: Account,
@@ -56,17 +58,32 @@ class EditAccountName extends PureComponent<Props, State> {
   onNameEndEditing = () => {
     const { updateAccount, account, navigation } = this.props;
     const { accountName } = this.state;
+    const {
+      accountId,
+      onAccountNameChange,
+    } = this.props.navigation.state.params;
+
+    const isImportingAccounts = accountId === -1;
+
     if (accountName.length) {
-      updateAccount({
-        ...account,
-        name: accountName,
-      });
+      if (isImportingAccounts) {
+        onAccountNameChange(accountName);
+      } else {
+        updateAccount({
+          ...account,
+          name: accountName,
+        });
+      }
+      navigation.goBack();
     }
-    navigation.goBack();
   };
 
   render() {
     const { account } = this.props;
+    const { accountName } = this.state;
+    const { account: accountFromImport } = this.props.navigation.state.params;
+
+    const initialAccountName = account ? account.name : accountFromImport.name;
 
     return (
       <SafeAreaView style={styles.safeArea}>
@@ -78,7 +95,7 @@ class EditAccountName extends PureComponent<Props, State> {
             <TextInput
               autoFocus
               style={styles.textInputAS}
-              defaultValue={account.name}
+              defaultValue={initialAccountName}
               returnKeyType="done"
               maxLength={MAX_ACCOUNT_NAME_LENGHT}
               onChangeText={accountName => this.setState({ accountName })}
@@ -94,6 +111,7 @@ class EditAccountName extends PureComponent<Props, State> {
                 type="primary"
                 title={<Trans i18nKey="common.apply" />}
                 onPress={this.onNameEndEditing}
+                disabled={!accountName.length}
                 containerStyle={styles.buttonContainer}
               />
             </View>

--- a/src/screens/ImportAccounts/DisplayResultItem.js
+++ b/src/screens/ImportAccounts/DisplayResultItem.js
@@ -1,49 +1,193 @@
 // @flow
 import React, { Component } from "react";
-import { TouchableOpacity, StyleSheet } from "react-native";
+import { Animated, View, StyleSheet, PanResponder } from "react-native";
 import type { Account } from "@ledgerhq/live-common/lib/types";
+import Swipeable from "react-native-gesture-handler/Swipeable";
+import type { NavigationScreenProp } from "react-navigation";
+import { withNavigation } from "react-navigation";
 import AccountCard from "../../components/AccountCard";
 import CheckBox from "../../components/CheckBox";
 import { track } from "../../analytics";
+import Button from "../../components/Button";
+import TouchHintCircle from "../../components/TouchHintCircle";
 
 const selectableModes = ["create", "patch"];
 
-export default class DisplayResultItem extends Component<{
-  account: Account,
-  mode: *,
-  checked: boolean,
-  importing: boolean,
-  onSwitch: (boolean, Account) => void,
-}> {
+class DisplayResultItem extends Component<
+  {
+    account: Account,
+    mode: *,
+    checked: boolean,
+    importing: boolean,
+    onSwitch: (boolean, Account) => void,
+    onAccountNameChange: (string, Account) => void,
+    index?: number,
+    navigation: NavigationScreenProp<*>,
+    signalOtherRows: (?number) => void,
+    openIndex?: number,
+  },
+  { animEnded: boolean },
+> {
+  state = {
+    animEnded: false,
+  };
+
+  panResponder: PanResponder;
+  swipeableRow: Swipeable;
+
   onSwitch = () => {
     track(this.props.checked ? "AccountSwitchOff" : "AccountSwitchOn");
     this.props.onSwitch(!this.props.checked, this.props.account);
   };
 
-  render() {
-    const { account, checked, mode, importing } = this.props;
-    const selectable = selectableModes.includes(mode);
+  renderLeftActions = (progress, dragX) => {
+    const translateX = dragX.interpolate({
+      inputRange: [0, 1000],
+      outputRange: [-112, 888],
+    });
+
     return (
-      <TouchableOpacity
-        onPress={importing ? undefined : this.onSwitch}
-        style={[styles.root, { opacity: selectable ? 1 : 0.5 }]}
+      <Animated.View
+        style={[
+          styles.leftAction,
+          { transform: [{ translateX }] },
+          { marginLeft: 12 },
+        ]}
       >
-        <AccountCard account={account} style={styles.card} />
-        {!selectable ? null : (
-          <CheckBox isChecked={checked} style={styles.marginLeft} />
-        )}
-      </TouchableOpacity>
+        <Button
+          event="HardResetModalAction"
+          type="primary"
+          title="Edit Name"
+          onPress={this.editAccountName}
+          containerStyle={styles.buttonContainer}
+        />
+      </Animated.View>
+    );
+  };
+
+  updateRef = ref => {
+    if (ref) this.swipeableRow = ref;
+  };
+
+  editAccountName = () => {
+    const { account, navigation, signalOtherRows } = this.props;
+    signalOtherRows(-1);
+
+    navigation.navigate("EditAccountName", {
+      onAccountNameChange: this.onAccountNameChange.bind(this),
+      account,
+      accountId: -1,
+    });
+  };
+
+  onAccountNameChange = name => {
+    this.props.onAccountNameChange(name, this.props.account);
+  };
+
+  componentDidUpdate() {
+    const { openIndex, index } = this.props;
+
+    // If the open index doesn't match us, some other row is open
+    if (openIndex !== index && this.swipeableRow) {
+      this.swipeableRow.close();
+    }
+  }
+
+  componentDidMount() {
+    // const { index } = this.props;
+    //
+    // if (index === 0) {
+    //   // No easy way to emulate touches without an extra library
+    //   // Opens/closes 1st row with modified styles, looks ok ¯\_(ツ)_/¯
+    //   setTimeout(() => this.swipeableRow.openLeft(), 200);
+    //   setTimeout(() => this.swipeableRow.close(), 1000);
+    //   setTimeout(() => this.setState({ animEnded: true }), 1400);
+    // }
+  }
+
+  constructor(props) {
+    super(props);
+    this.panResponder = PanResponder.create({
+      // Ask to be the responder:
+      onStartShouldSetPanResponder: () => true,
+      onStartShouldSetPanResponderCapture: () => false,
+      onMoveShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponderCapture: () => false,
+
+      onPanResponderGrant: () => {
+        const { index, signalOtherRows } = this.props;
+        signalOtherRows(index);
+      },
+
+      onShouldBlockNativeResponder: () => false,
+    });
+  }
+
+  render() {
+    const { account, checked, mode, importing, index } = this.props;
+    const { animEnded } = this.state;
+    const selectable = selectableModes.includes(mode);
+
+    const showHint = selectable && !index && !animEnded;
+
+    return (
+      <View {...this.panResponder.panHandlers}>
+        <Swipeable
+          ref={this.updateRef}
+          friction={2}
+          leftThreshold={50}
+          renderLeftActions={selectable ? this.renderLeftActions : undefined}
+          style={{ backgroundColor: "#ffffff" }}
+        >
+          <View style={[styles.root, { opacity: selectable ? 1 : 0.5 }]}>
+            <AccountCard account={account} style={styles.card} />
+            {!selectable ? null : (
+              <CheckBox
+                onChange={importing ? undefined : this.onSwitch}
+                isChecked={checked}
+                style={styles.marginLeft}
+              />
+            )}
+            {showHint && (
+              <TouchHintCircle
+                visible={showHint}
+                style={styles.pulsatingCircle}
+              />
+            )}
+          </View>
+        </Swipeable>
+      </View>
     );
   }
 }
+
+export default withNavigation(DisplayResultItem);
 
 const styles = StyleSheet.create({
   root: {
     flexDirection: "row",
     alignItems: "center",
+    paddingHorizontal: 16,
+    flex: 1,
+    backgroundColor: "#ffffff",
+    position: "relative",
   },
   card: {
     marginLeft: 8,
+  },
+  leftAction: {
+    width: 100,
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  buttonContainer: {
+    flex: 1,
+  },
+  pulsatingCircle: {
+    position: "absolute",
+    left: 8,
+    top: 0,
+    bottom: 0,
   },
   marginLeft: { marginLeft: 24 },
 });

--- a/src/screens/ImportAccounts/DisplayResultSettingsSection.js
+++ b/src/screens/ImportAccounts/DisplayResultSettingsSection.js
@@ -1,11 +1,12 @@
 // @flow
 import React, { PureComponent } from "react";
-import { Switch, View, StyleSheet } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { Trans } from "react-i18next";
 import Icon from "react-native-vector-icons/dist/Feather";
 import LText from "../../components/LText";
 import colors from "../../colors";
 import ResultSection from "./ResultSection";
+import CheckBox from "../../components/CheckBox";
 
 class DisplayResultSettingsSection extends PureComponent<{
   checked: boolean,
@@ -14,14 +15,14 @@ class DisplayResultSettingsSection extends PureComponent<{
   render() {
     const { checked, onSwitch } = this.props;
     return (
-      <View style={styles.root}>
+      <View>
         <ResultSection mode="settings" />
         <View style={styles.row}>
           <Icon name="settings" size={20} color={colors.grey} />
           <LText style={styles.label} semiBold>
             <Trans i18nKey="account.import.result.includeGeneralSettings" />
           </LText>
-          <Switch onValueChange={onSwitch} value={checked} />
+          <CheckBox onChange={onSwitch} isChecked={checked} />
         </View>
       </View>
     );
@@ -29,11 +30,11 @@ class DisplayResultSettingsSection extends PureComponent<{
 }
 
 const styles = StyleSheet.create({
-  root: {},
   row: {
+    paddingHorizontal: 8,
     backgroundColor: colors.lightGrey,
     borderRadius: 4,
-    paddingHorizontal: 8,
+    marginHorizontal: 8,
 
     paddingVertical: 10,
     flexDirection: "row",
@@ -42,6 +43,7 @@ const styles = StyleSheet.create({
   label: {
     marginHorizontal: 10,
     flex: 1,
+    color: colors.darkBlue,
   },
 });
 

--- a/src/screens/ImportAccounts/ResultSection.js
+++ b/src/screens/ImportAccounts/ResultSection.js
@@ -46,6 +46,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     paddingTop: 24,
     paddingBottom: 16,
+    paddingHorizontal: 16,
     marginLeft: 8,
   },
 });

--- a/src/screens/OperationDetails/index.js
+++ b/src/screens/OperationDetails/index.js
@@ -3,7 +3,8 @@ import React, { PureComponent } from "react";
 import i18next from "i18next";
 import { View, StyleSheet } from "react-native";
 // $FlowFixMe
-import { SafeAreaView, ScrollView } from "react-navigation";
+import { SafeAreaView } from "react-navigation";
+import { ScrollView } from "react-native-gesture-handler";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";
 import { translate } from "react-i18next";


### PR DESCRIPTION
Add the ability to edit an account imported from Desktop by adding a swipe action to the rows.
![v2](https://user-images.githubusercontent.com/4631227/55832655-5087dc80-5b16-11e9-91f1-bf1d6967b54d.gif)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-593

### Parts of the app affected / Test plan

Import accounts from desktop, potentially test other screens showing account lists :trollface: in case something broke.

