### PR TITLE
fix: Addresses Samsung inconsistencies and fontScaling issues

### DIFF
--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -1,7 +1,8 @@
 /* @flow */
 import React, { PureComponent } from "react";
-import { View, StyleSheet, TextInput } from "react-native";
+import { View, StyleSheet } from "react-native";
 import Icon from "react-native-vector-icons/dist/Feather";
+import TextInput from "./TextInput";
 import Touchable from "./Touchable";
 import { getFontStyle } from "./LText";
 import colors from "../colors";
@@ -67,6 +68,7 @@ class PasswordInput extends PureComponent<Props, { isFocused: boolean }> {
         <TextInput
           allowFontScaling={false}
           autoFocus={autoFocus}
+          containerStyle={styles.containerInput}
           style={[
             styles.input,
             getFontStyle({ semiBold: true }),
@@ -133,8 +135,10 @@ const styles = StyleSheet.create({
   input: {
     fontSize: 16,
     paddingHorizontal: 16,
-    height: 48,
+  },
+  containerInput: {
     flex: 1,
+    height: 48,
   },
   iconInput: {
     justifyContent: "center",

--- a/src/components/TextInput.android.js
+++ b/src/components/TextInput.android.js
@@ -66,6 +66,7 @@ class TextInput extends PureComponent<*, State> {
       withSuggestions,
       innerRef,
       style,
+      textContentType,
       defaultValue,
       clearButtonMode, // Don't pass this down to use our own impl
       ...otherProps
@@ -75,7 +76,7 @@ class TextInput extends PureComponent<*, State> {
 
     const flags = {};
 
-    if (!withSuggestions) {
+    if (!withSuggestions && !textContentType) {
       flags.autoCorrect = false;
       flags.keyboardType = "visible-password";
     }
@@ -83,20 +84,25 @@ class TextInput extends PureComponent<*, State> {
       !!value &&
       ((focused && clearButtonMode === "while-editing") ||
         clearButtonMode === "always");
-    // {...otherProps} needs to come first to allow an override.
 
-    // Preprocess the font size to override system scaling
-    const overrideFontScaling = { fontSize: 20 / PixelRatio.getFontScale() };
-    if (style && style.fontSize) {
-      overrideFontScaling.fontSize = style.fontSize / PixelRatio.getFontScale();
+    // Preprocess the font size to override system scaling, only if this is not
+    // a password field.
+    let overrideFontScaling = {};
+    if (!textContentType) {
+      overrideFontScaling =
+        style && style.fontSize
+          ? { fontSize: 20 / PixelRatio.getFontScale() }
+          : { fontSize: style.fontSize / PixelRatio.getFontScale() };
     }
 
+    // {...otherProps} needs to come first to allow an override.
     return (
       <View style={[styles.container, containerStyle]}>
         <ReactNativeTextInput
           ref={innerRef}
           style={[{ flex: 1 }, style, overrideFontScaling]}
           {...otherProps}
+          textContentType={textContentType}
           onBlur={this.onBlur}
           onFocus={this.onFocus}
           onChangeText={this.onChangeText}

--- a/src/components/TextInput.ios.js
+++ b/src/components/TextInput.ios.js
@@ -6,7 +6,8 @@ import React, { PureComponent } from "react";
 class TextInput extends PureComponent<*> {
   render() {
     const {
-      containerStyle, // Needed to pass flow, since we call the native TextInput
+      containerStyle, // For Android it's two different styles, here we join them
+      style,
       withSuggestions,
       innerRef,
       ...otherProps
@@ -22,6 +23,7 @@ class TextInput extends PureComponent<*> {
       <ReactNativeTextInput
         ref={innerRef}
         allowFontScaling={false}
+        style={[containerStyle, style]}
         {...otherProps}
         {...flags}
       />

--- a/src/index.js
+++ b/src/index.js
@@ -38,11 +38,11 @@ const styles = StyleSheet.create({
 
 // Fixme until third parties address this themselves
 // $FlowFixMe
-Text.defaultProps = { ...(Text.defaultProps || {}), allowFontScaling: false };
+Text.defaultProps = { ...Text.defaultProps, allowFontScaling: false };
 // $FlowFixMe
 TextInput.defaultProps = {
   // $FlowFixMe
-  ...(TextInput.defaultProps || {}),
+  ...TextInput.defaultProps,
   allowFontScaling: false,
   underlineColorAndroid: "transparent",
 };

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import "./polyfill";
 import "./live-common-setup";
 import "./implement-react-native-libcore";
 import React, { Fragment, Component } from "react";
-import { StyleSheet, View, Text } from "react-native";
+import { StyleSheet, View, Text, TextInput } from "react-native";
 import SplashScreen from "react-native-splash-screen";
 import logger from "./logger";
 import { exportSelector as settingsExportSelector } from "./reducers/settings";
@@ -38,9 +38,14 @@ const styles = StyleSheet.create({
 
 // Fixme until third parties address this themselves
 // $FlowFixMe
-Text.defaultProps = Text.defaultProps || {};
+Text.defaultProps = { ...(Text.defaultProps || {}), allowFontScaling: false };
 // $FlowFixMe
-Text.defaultProps.allowFontScaling = false;
+TextInput.defaultProps = {
+  // $FlowFixMe
+  ...(TextInput.defaultProps || {}),
+  allowFontScaling: false,
+  underlineColorAndroid: "transparent",
+};
 
 class App extends Component<*> {
   hasCountervaluesChanged = (a, b) => a.countervalues !== b.countervalues;

--- a/src/modals/PasslockDisclaimerModal.js
+++ b/src/modals/PasslockDisclaimerModal.js
@@ -6,10 +6,7 @@ import { Image, View, StyleSheet } from "react-native";
 import BottomModal from "../components/BottomModal";
 import Button from "../components/Button";
 import colors from "../colors";
-import BulletList, {
-  BulletChevron,
-  BulletItemText,
-} from "../components/BulletList";
+import BulletList, { BulletChevron } from "../components/BulletList";
 
 type Props = { onClose: *, isOpened: *, onAccept: () => * };
 
@@ -42,15 +39,9 @@ class PasslockDisclaimerModal extends Component<Props> {
             Bullet={BulletChevron}
             itemStyle={styles.item}
             list={[
-              <BulletItemText style={styles.text}>
-                <Trans i18nKey="onboarding.stepPassword.modal.step1" />
-              </BulletItemText>,
-              <BulletItemText style={styles.text}>
-                <Trans i18nKey="onboarding.stepPassword.modal.step2" />
-              </BulletItemText>,
-              <BulletItemText style={styles.text}>
-                <Trans i18nKey="onboarding.stepPassword.modal.step3" />
-              </BulletItemText>,
+              <Trans i18nKey="onboarding.stepPassword.modal.step1" />,
+              <Trans i18nKey="onboarding.stepPassword.modal.step2" />,
+              <Trans i18nKey="onboarding.stepPassword.modal.step3" />,
             ]}
           />
         </View>
@@ -90,11 +81,6 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     paddingTop: 24,
     paddingHorizontal: 8,
-  },
-  text: {
-    fontSize: 14,
-    lineHeight: 21,
-    color: colors.grey,
   },
   textBlue: { color: colors.darkBlue },
 });

--- a/src/modals/Pin.js
+++ b/src/modals/Pin.js
@@ -6,10 +6,7 @@ import { Image, View, StyleSheet } from "react-native";
 import BottomModal from "../components/BottomModal";
 import Button from "../components/Button";
 import colors from "../colors";
-import BulletList, {
-  BulletChevron,
-  BulletItemText,
-} from "../components/BulletList";
+import BulletList, { BulletChevron } from "../components/BulletList";
 import LText from "../components/LText";
 
 type Props = { onClose: *, isOpened: *, onAccept: () => * };
@@ -43,21 +40,15 @@ class PinModal extends Component<Props> {
             Bullet={BulletChevron}
             itemStyle={styles.item}
             list={[
-              <BulletItemText style={styles.text}>
-                <Trans i18nKey="onboarding.stepSetupPin.modal.step1">
-                  {"text"}
-                  <LText semiBold style={styles.textBlue}>
-                    bold text
-                  </LText>
-                  {"text"}
-                </Trans>
-              </BulletItemText>,
-              <BulletItemText style={styles.text}>
-                <Trans i18nKey="onboarding.stepSetupPin.modal.step2" />
-              </BulletItemText>,
-              <BulletItemText style={styles.text}>
-                <Trans i18nKey="onboarding.stepSetupPin.modal.step3" />
-              </BulletItemText>,
+              <Trans i18nKey="onboarding.stepSetupPin.modal.step1">
+                {"text"}
+                <LText semiBold style={styles.textBlue}>
+                  bold text
+                </LText>
+                {"text"}
+              </Trans>,
+              <Trans i18nKey="onboarding.stepSetupPin.modal.step2" />,
+              <Trans i18nKey="onboarding.stepSetupPin.modal.step3" />,
             ]}
           />
         </View>
@@ -97,11 +88,6 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     paddingTop: 24,
     paddingHorizontal: 8,
-  },
-  text: {
-    fontSize: 14,
-    lineHeight: 21,
-    color: colors.grey,
   },
   textBlue: { color: colors.darkBlue },
 });

--- a/src/modals/RecoveryPhrase.js
+++ b/src/modals/RecoveryPhrase.js
@@ -5,11 +5,7 @@ import { Trans, translate } from "react-i18next";
 import { Image, View, StyleSheet } from "react-native";
 import BottomModal from "../components/BottomModal";
 import Button from "../components/Button";
-import colors from "../colors";
-import BulletList, {
-  BulletChevron,
-  BulletItemText,
-} from "../components/BulletList";
+import BulletList, { BulletChevron } from "../components/BulletList";
 
 type Props = { isOpened: *, onClose: *, onAccept: () => * };
 
@@ -42,18 +38,10 @@ class RecoveryPhraseModal extends Component<Props> {
             Bullet={BulletChevron}
             itemStyle={styles.item}
             list={[
-              <BulletItemText style={styles.text}>
-                <Trans i18nKey="onboarding.stepWriteRecovery.modal.step1" />
-              </BulletItemText>,
-              <BulletItemText style={styles.text}>
-                <Trans i18nKey="onboarding.stepWriteRecovery.modal.step2" />
-              </BulletItemText>,
-              <BulletItemText style={styles.text}>
-                <Trans i18nKey="onboarding.stepWriteRecovery.modal.step3" />
-              </BulletItemText>,
-              <BulletItemText style={styles.text}>
-                <Trans i18nKey="onboarding.stepWriteRecovery.modal.step4" />
-              </BulletItemText>,
+              <Trans i18nKey="onboarding.stepWriteRecovery.modal.step1" />,
+              <Trans i18nKey="onboarding.stepWriteRecovery.modal.step2" />,
+              <Trans i18nKey="onboarding.stepWriteRecovery.modal.step3" />,
+              <Trans i18nKey="onboarding.stepWriteRecovery.modal.step4" />,
             ]}
           />
         </View>
@@ -93,10 +81,5 @@ const styles = StyleSheet.create({
     flexGrow: 1,
     paddingTop: 24,
     paddingHorizontal: 8,
-  },
-  text: {
-    fontSize: 14,
-    lineHeight: 21,
-    color: colors.grey,
   },
 });


### PR DESCRIPTION
For larger font sizes we had two remaining issues that were mainly present on Samsung devices. First of all, the footer modals that had bullet point lists were shown with huge texts that broke the design. Since this is the first approach at accessibility where we stop the font change altogether to have a stable base for future accessibility we needed to address that.

The issue was caused by[ nested text components](https://github.com/facebook/react-native/issues/19833), causing the `allowFontScaling` prop to be lost at the parent level and rendering the child elements, in this case, the text points of the list, with the scaled size.

The second error was affecting only Samsung devices with font scaling and it made password inputs unusable. This is caused by not using our wrapper for text input and relying on the native one that doesn't have the font scaling recalculation. That is also solved in this pr.


### Type

Fix

### Context

LL-1178

### Parts of the app affected / Test plan

Same as the other time we had a font scaling test plan, go over the app with scale mode enabled and see if there are more broken things. There is one known issue that I've been unable to fix so far, but it's so much more edge case than before that I think we can safely ignore it for now.

### Known issue
With font scaling enabled, on Android, on a text input that allows you to clear the input, the font size goes pretty small (half size) after clearing with the Right X button.