### PR TITLE
LL-1259 fix: Fallback to device name if no custom device name available

### DIFF
--- a/src/screens/PairDevices/index.js
+++ b/src/screens/PairDevices/index.js
@@ -119,7 +119,7 @@ class PairDevices extends Component<Props, State> {
         await genuineCheckPromise;
         if (this.unmounted) return;
 
-        const name = await getDeviceName(transport);
+        const name = await getDeviceName(transport) || device.name;
         if (this.unmounted) return;
 
         this.props.addKnownDevice({ id: device.id, name });


### PR DESCRIPTION
Addresses the empty device name regression

### Type

Regression

### Context

LL-1259

### Parts of the app affected / Test plan

Device pairing
