### PR TITLE
LL-1317 Trim account name on edition/import

### DIFF
--- a/src/screens/AccountSettings/EditAccountName.js
+++ b/src/screens/AccountSettings/EditAccountName.js
@@ -64,14 +64,15 @@ class EditAccountName extends PureComponent<Props, State> {
     } = this.props.navigation.state.params;
 
     const isImportingAccounts = !!accountFromAdd;
+    const cleanAccountName = accountName.trim();
 
-    if (accountName.length) {
+    if (cleanAccountName.length) {
       if (isImportingAccounts) {
-        onAccountNameChange(accountName, accountFromAdd);
+        onAccountNameChange(cleanAccountName, accountFromAdd);
       } else {
         updateAccount({
           ...account,
-          name: accountName,
+          name: cleanAccountName,
         });
       }
       navigation.goBack();
@@ -111,7 +112,7 @@ class EditAccountName extends PureComponent<Props, State> {
                 type="primary"
                 title={<Trans i18nKey="common.apply" />}
                 onPress={this.onNameEndEditing}
-                disabled={!accountName.length}
+                disabled={!accountName.trim().length}
                 containerStyle={styles.buttonContainer}
               />
             </View>


### PR DESCRIPTION
Prevents users from changing an account's name to an empty string.

### Type

UX improvement

### Context

https://ledgerhq.atlassian.net/browse/LL-1317

### Parts of the app affected / Test plan

Account edit screen