### PR TITLE
UI Polish: used checkbox from design instead of native

### DIFF
--- a/src/components/CheckBox.js
+++ b/src/components/CheckBox.js
@@ -11,7 +11,7 @@ type Props = {
   isChecked: boolean,
   onChange?: boolean => void,
   disabled?: boolean,
-  style: *,
+  style?: *,
 };
 
 const checkBoxHitSlop = {
@@ -32,7 +32,7 @@ export default class CheckBox extends PureComponent<Props> {
 
     const body = (
       <IconCheck
-        size={16}
+        size={20}
         color={colors.white}
         style={[!isChecked && styles.invisible]}
       />

--- a/src/screens/ImportAccounts/DisplayResultItem.js
+++ b/src/screens/ImportAccounts/DisplayResultItem.js
@@ -41,6 +41,7 @@ const styles = StyleSheet.create({
   root: {
     flexDirection: "row",
     alignItems: "center",
+    marginRight: 8,
   },
   card: {
     marginLeft: 8,

--- a/src/screens/ImportAccounts/DisplayResultSettingsSection.js
+++ b/src/screens/ImportAccounts/DisplayResultSettingsSection.js
@@ -1,11 +1,12 @@
 // @flow
 import React, { PureComponent } from "react";
-import { Switch, View, StyleSheet } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { Trans } from "react-i18next";
 import Icon from "react-native-vector-icons/dist/Feather";
 import LText from "../../components/LText";
 import colors from "../../colors";
 import ResultSection from "./ResultSection";
+import CheckBox from "../../components/CheckBox";
 
 class DisplayResultSettingsSection extends PureComponent<{
   checked: boolean,
@@ -21,7 +22,7 @@ class DisplayResultSettingsSection extends PureComponent<{
           <LText style={styles.label} semiBold>
             <Trans i18nKey="account.import.result.includeGeneralSettings" />
           </LText>
-          <Switch onValueChange={onSwitch} value={checked} />
+          <CheckBox onChange={onSwitch} isChecked={checked} />
         </View>
       </View>
     );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/56580091-11579200-65d2-11e9-9f1e-2d56170d55b4.png)

When I did the swipe to edit account name functionality in the wrong place, I also polished the UI of that screen (Import accounts). This simply makes the checkbox check a bit larger, adds a bit of margin to align with the checkbox from the settings import. 

This is more aligned with what's on zpl
![image](https://user-images.githubusercontent.com/4631227/56580214-58458780-65d2-11e9-8bc3-8efcfc4e956c.png)

### Type

UI Polish


### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
