### PR TITLE
LL-1306 Mobile: prevent backdrop click while installing/uninstalling

### DIFF
--- a/src/screens/Manager/AppAction.js
+++ b/src/screens/Manager/AppAction.js
@@ -192,11 +192,7 @@ class AppAction extends PureComponent<
     );
 
     return (
-      <BottomModal
-        id={action.type + "AppActionModal"}
-        isOpened={isOpened}
-        onClose={this.onClose}
-      >
+      <BottomModal id={action.type + "AppActionModal"} isOpened={isOpened}>
         <SafeAreaView forceInset={forceInset} style={styles.root}>
           <View style={styles.body}>
             <View style={styles.headIcon}>


### PR DESCRIPTION
Type
Feature

Context
https://ledgerhq.atlassian.net/browse/LL-1306

Parts of the app affected / Test plan
Clicking outside of the modal (in the backdrop) should not close the modal while installing or uninstalling an app. Clicking on the X should still cancel the action

