### PR TITLE
LL-1319 Show full precision on operation details

### DIFF
--- a/src/screens/OperationDetails/Content.js
+++ b/src/screens/OperationDetails/Content.js
@@ -57,10 +57,12 @@ class Content extends PureComponent<Props, *> {
           </View>
           <LText
             tertiary
+            numberOfLines={1}
             style={[styles.currencyUnitValue, { color: valueColor }]}
           >
             <CurrencyUnitValue
               showCode
+              showAllDigits={true}
               unit={account.unit}
               value={amount}
               alwaysShowSign
@@ -230,6 +232,7 @@ const styles = StyleSheet.create({
   },
 
   currencyUnitValue: {
+    paddingHorizontal: 8,
     fontSize: 20,
     marginBottom: 8,
     color: colors.smoke,

--- a/src/screens/PairDevices/index.js
+++ b/src/screens/PairDevices/index.js
@@ -119,7 +119,7 @@ class PairDevices extends Component<Props, State> {
         await genuineCheckPromise;
         if (this.unmounted) return;
 
-        const name = await getDeviceName(transport) || device.name;
+        const name = (await getDeviceName(transport)) || device.name;
         if (this.unmounted) return;
 
         this.props.addKnownDevice({ id: device.id, name });


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/56648224-322bf000-6683-11e9-8d78-d2d7a401a9e1.png)
It will also be trimmed if needed, the styles are accounting for that.

### Type

UI Polish - Regression

### Context

https://ledgerhq.atlassian.net/browse/LL-1319

### Parts of the app affected / Test plan

Operation details


> There is a prettier change to another file that kept being changed to that syntax when I run `yarn prettier` if this is not happening to anyone else perhaps my settings are wrong. If it is... it will no longer happen 🤷‍♂️ 
