### PR TITLE
UI Polish Simplified Confetti, alternative approach

### DIFF
--- a/src/components/ConfettiParty/index.js
+++ b/src/components/ConfettiParty/index.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React, { PureComponent } from "react";
-import { View } from "react-native";
+import { View, InteractionManager } from "react-native";
 import Confetti1 from "../../icons/confetti/confetti1";
 import Confetti2 from "../../icons/confetti/confetti2";
 import Confetti3 from "../../icons/confetti/confetti3";
@@ -9,99 +9,53 @@ import Confetti4 from "../../icons/confetti/confetti4";
 import Confetti from "./Confetti";
 
 const shapes = [Confetti1, Confetti2, Confetti3, Confetti4];
+let id = 0;
 
-let id = 1;
+const confettiMap = () => (
+  <Confetti
+    key={id++}
+    {...{
+      shape: shapes[Math.floor(shapes.length * Math.random())],
+      initialRotation: 360 * Math.random(),
+      initialYPercent: -0.04 + -0.25 * Math.random(),
+      initialXPercent: 0.2 + 0.6 * Math.random(),
+      initialScale: 1,
+      rotations: 8 * Math.random() - 4,
+      delta: [(Math.random() - 0.5) * 1500, 500 + 500 * Math.random()],
+      duration: 12000 + 8000 * Math.random(),
+    }}
+  />
+);
 
-const nextConfetti = (mode: ?string) =>
-  mode === "emit"
-    ? {
-        id: id++,
-        shape: shapes[Math.floor(shapes.length * Math.random())],
-        initialRotation: 360 * Math.random(),
-        initialYPercent: -0.05,
-        initialXPercent:
-          0.5 +
-          0.5 *
-            Math.cos(Date.now() / 1000) *
-            (0.5 + 0.5 * Math.sin(Date.now() / 6000)),
-        initialScale: 1,
-        rotations: 4 * Math.random() - 2,
-        delta: [(Math.random() - 0.5) * 200, 600 + 200 * Math.random()],
-        duration: 10000,
-      }
-    : {
-        id: id++,
-        shape: shapes[Math.floor(shapes.length * Math.random())],
-        initialRotation: 360 * Math.random(),
-        initialYPercent: -0.04 + -0.25 * Math.random(),
-        initialXPercent: 0.2 + 0.6 * Math.random(),
-        initialScale: 1,
-        rotations: 8 * Math.random() - 4,
-        delta: [(Math.random() - 0.5) * 1500, 500 + 500 * Math.random()],
-        duration: 12000 + 8000 * Math.random(),
-      };
-
-class ConfettiParty extends PureComponent<
-  { emit: boolean },
-  { confettis: Array<Object> },
-> {
-  state = {
-    // $FlowFixMe
-    confettis: Array(100)
-      .fill(null)
-      .map(nextConfetti),
-  };
+class ConfettiParty extends PureComponent<*, { confetti: Array<Object> }> {
+  state = { confetti: [] };
+  handler: *;
 
   componentDidMount() {
-    this.setEmit(this.props.emit);
-    this.initialTimeout = setTimeout(() => {
-      clearInterval(this.initialInterval);
-    }, 5000);
-    this.initialInterval = setInterval(() => {
-      this.setState(({ confettis }) => ({
-        confettis: confettis
-          .slice(confettis.length > 200 ? 1 : 0)
-          .concat(nextConfetti()),
-      }));
-    }, 100);
-  }
-
-  componentDidUpdate(prevProps: *) {
-    if (this.props.emit !== prevProps.emit) {
-      this.setEmit(this.props.emit);
-    }
+    this.handler = InteractionManager.runAfterInteractions(() => {
+      this.emitConfetti();
+    });
   }
 
   componentWillUnmount() {
-    this.setEmit(false);
-    clearInterval(this.initialInterval);
-    clearTimeout(this.initialTimeout);
+    if (this.handler) this.handler.cancel();
   }
 
-  setEmit(on: boolean) {
-    if (on) {
-      this.interval = setInterval(() => {
-        this.setState(({ confettis }) => ({
-          confettis: confettis
-            .slice(confettis.length > 200 ? 1 : 0)
-            .concat(nextConfetti("emit")),
-        }));
-      }, 40);
-    } else {
-      clearInterval(this.interval);
-    }
-  }
-  interval: *;
-  initialInterval: *;
-  initialTimeout: *;
+  emitConfetti = () => {
+    this.setState(prevState => ({
+      confetti: [
+        ...prevState.confetti,
+        ...Array(100)
+          .fill(null)
+          .map(confettiMap),
+      ],
+    }));
+  };
 
   render() {
-    const { confettis } = this.state;
     return (
       <View style={{ position: "relative", width: "100%", height: "100%" }}>
-        {confettis.map(c => (
-          <Confetti key={c.id} {...c} />
-        ))}
+        {this.state.confetti}
       </View>
     );
   }

--- a/src/screens/Onboarding/steps/finish.js
+++ b/src/screens/Onboarding/steps/finish.js
@@ -45,7 +45,7 @@ class OnboardingStepFinish extends Component<Props> {
       <View style={styles.wrapper}>
         <TrackScreen category="Onboarding" name="Finish" />
         <View style={styles.confettiContainer} pointerEvents="none">
-          <ConfettiParty emit={false} />
+          <ConfettiParty />
         </View>
         <OnboardingLayout isCentered style={styles.onboardingLayout}>
           <View style={styles.hero}>{logo}</View>


### PR DESCRIPTION
There is a pretty obvious lag between the `share analytics` step and the `finish` step of the onboarding flow. This made the app seem irresponsive for a few seconds, depending on the speed of your device. I played with a few alternatives like using pngs, prerendering on previous steps, not using svgs, etc but the performance gains were negligible, at least from my vague measurements.

This is a compromise where we will render the page immediately after the user clicks on the button by using `InteractionManager.runAfterInteractions` and then in the background try to do the confetti party without making the app choke. Granted the confetti takes a while to appear, but I'd rather be able to ignore the confetti and Open the app, and be surprised by the confetti if I'm in that screen long enough than be stuck in a white screen until the forced confetti appears.

I removed all the `emit` logic that we aren't currently using too, it's still in desktop shall we want to randomly emit particles somewhere :trollface: 

### Type

Performance, UI Polish

### Parts of the app affected / Test plan

Confetti party after onboarding.