### PR TITLE
Fix connection to bundler on Android (in dev mode)

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
+
+    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
+</manifest>


### PR DESCRIPTION
Starting with Android 9.0 (API level 28), cleartext communication is disabled by default, which breaks the plain HTTP connection to the bundler used in dev mode.

This PR allows un-encrypted traffic for the app in dev mode *only*.

### TO DO

- [ ] Check if we rely on plain HTTP in production
- [ ] Whitelist domains in `android/app/src/main/AndroidManifest.xml` if we do
