### PR TITLE
LL-1376 Prevent bottom modal dismissals for device steps

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 src/locales/index.js
 package.json
+flow-typed

--- a/src/components/BottomModal.js
+++ b/src/components/BottomModal.js
@@ -17,6 +17,7 @@ export type Props = {
   onClose: () => *,
   children?: *,
   style?: *,
+  preventBackdropClick?: boolean,
 };
 
 // Add some extra padding at the bottom of the modal
@@ -31,15 +32,23 @@ class BottomModal extends Component<Props> {
     onClose: () => {},
   };
   render() {
-    const { isOpened, onClose, children, style, id, ...rest } = this.props;
+    const {
+      isOpened,
+      onClose,
+      children,
+      style,
+      preventBackdropClick,
+      id,
+      ...rest
+    } = this.props;
     const { width, height } = getWindowDimensions();
 
     return (
       <ButtonUseTouchable.Provider value={true}>
         <ReactNativeModal
           isVisible={isOpened}
-          onBackdropPress={onClose}
-          onBackButtonPress={onClose}
+          onBackdropPress={!preventBackdropClick && onClose}
+          onBackButtonPress={!preventBackdropClick && onClose}
           deviceWidth={width}
           deviceHeight={height}
           useNativeDriver

--- a/src/components/DeviceJob/StepRunnerModal.js
+++ b/src/components/DeviceJob/StepRunnerModal.js
@@ -24,7 +24,12 @@ class SelectDeviceConnectModal extends PureComponent<{
     const { meta, onClose, onRetry, onStepDone, error, step } = this.props;
 
     return (
-      <BottomModal id="DeviceJobModal" isOpened={!!meta} onClose={onClose}>
+      <BottomModal
+        id="DeviceJobModal"
+        isOpened={!!meta}
+        onClose={onClose}
+        preventBackdropClick
+      >
         {error ? (
           <RenderError
             error={error}


### PR DESCRIPTION
For modals that involve device interactions, most of them except notices and warnings, we now have disabled the backdrop and back button dismissals while maintaining the X cta active. This will prevent unwanted dismissals of the modal.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1376

### Parts of the app affected / Test plan

All modals.