### PR TITLE
[Android] Added a command to package.json to allow for a fresh run of the app

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "postinstall": "./scripts/post.sh",
     "start": "react-native start",
     "android": "react-native run-android",
+    "android:clean": "$ANDROID_HOME/platform-tools/adb shell pm clear com.ledger.live && react-native run-android",
     "android:staging": "cd android && ./gradlew assembleStagingRelease",
     "android:mock": "cd android && ENVFILE=.env.mock ./gradlew assembleStagingRelease",
     "android:release": "./scripts/android-release.sh",


### PR DESCRIPTION
Since we removed reset from the interface we now have to manually uninstall the app and it's time-consuming. Since we most likely have the phone plugged in, I've added a convenience yarn command to run the app (on Android) wiping the data first.

Something similar might be doable for iPhone but haven't looked into it.