### PR TITLE
LL-1387 Changed the look of the UserRefusedAllowManager error

### DIFF
--- a/src/components/DeviceJob/StepRunnerModal.js
+++ b/src/components/DeviceJob/StepRunnerModal.js
@@ -28,7 +28,7 @@ class SelectDeviceConnectModal extends PureComponent<{
         id="DeviceJobModal"
         isOpened={!!meta}
         onClose={onClose}
-        preventBackdropClick
+        preventBackdropClick={error ? undefined : true}
       >
         {error ? (
           <RenderError

--- a/src/components/ErrorCrossBadge.js
+++ b/src/components/ErrorCrossBadge.js
@@ -1,0 +1,51 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { View, StyleSheet } from "react-native";
+
+import colors from "../colors";
+import Close from "../icons/Close";
+
+type Props = {
+  style?: *,
+};
+
+class ErrorCrossBadge extends PureComponent<Props> {
+  render() {
+    const { style } = this.props;
+    return (
+      <View style={[styles.outer, style]}>
+        <View style={styles.inner}>
+          <Close size={14} color={colors.white} />
+        </View>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  outer: {
+    padding: 0,
+    borderRadius: 16,
+    top: -12,
+    right: -12,
+    backgroundColor: colors.white,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  inner: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: colors.alert,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  txt: {
+    color: colors.white,
+  },
+});
+
+export default ErrorCrossBadge;

--- a/src/components/ErrorIcon.js
+++ b/src/components/ErrorIcon.js
@@ -6,6 +6,7 @@ import {
   CantOpenDevice,
   WrongDeviceForAccount,
   PairingFailed,
+  UserRefusedAllowManager,
 } from "@ledgerhq/errors";
 import Rounded from "./Rounded";
 import IconNanoX from "../icons/NanoX";
@@ -13,6 +14,7 @@ import ErrorBadge from "./ErrorBadge";
 import Circle from "./Circle";
 import colors, { lighten } from "../colors";
 import BluetoothScanning from "./BluetoothScanning";
+import ErrorCrossBadge from "./ErrorCrossBadge";
 
 type Props = {
   error: ?Error,
@@ -26,6 +28,15 @@ class ErrorIcon extends PureComponent<Props> {
       // this case should not happen (it is supposed to be a ?Error)
       console.error(`ErrorIcon invalid usage: ${String(error)}`);
       return null;
+    }
+
+    if (error instanceof UserRefusedAllowManager) {
+      return (
+        <Rounded bg={colors.pillActiveBackground}>
+          <IconNanoX color={colors.live} height={36} width={8} />
+          <ErrorCrossBadge style={styles.badge} />
+        </Rounded>
+      );
     }
 
     if (error instanceof PairingFailed) {

--- a/src/components/GenericErrorView.js
+++ b/src/components/GenericErrorView.js
@@ -29,7 +29,7 @@ class GenericErrorRendering extends PureComponent<{
       <View style={styles.root}>
         {withIcon ? (
           <View style={styles.headIcon}>
-            <ErrorIcon error={titleError} />
+            <ErrorIcon error={error} />
           </View>
         ) : null}
         <LText

--- a/src/icons/USB.js
+++ b/src/icons/USB.js
@@ -7,7 +7,7 @@ type Props = {
   height?: number,
   color?: string,
 };
-const USB = function Truck({
+export default function USB({
   width = 15,
   height = 32,
   color = "#6490F1",
@@ -20,6 +20,4 @@ const USB = function Truck({
       />
     </Svg>
   );
-};
-
-export default USB;
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -247,7 +247,8 @@
       "description": "Uninstall and reinstall the {{managerAppName}} app in the Manager"
     },
     "UserRefusedAllowManager": {
-      "title": "Manager refused on device"
+      "title": "Manager refused on device",
+      "description": "You need to allow the manager on your device in order to access it, please try again"
     },
     "UserRefusedAddress": {
       "title": "Receive address rejected",


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
I didn't add the close button because I didn't see an easy way of adding it, if it's a big deal (you can dismiss and close with the X top right) I can dedicate more time to it.

![image](https://user-images.githubusercontent.com/4631227/58128029-06b30b80-7c17-11e9-895d-88e3742e3239.png)

### Type

UI Polish
### Context

https://ledgerhq.atlassian.net/browse/LL-1387

### Parts of the app affected / Test plan

Inside the manager, when selecting a device, refuse the authorization on the device. It should trigger the above error instead of the one shown in the issue. We could potentially show a different device icon depending on the device since we can refuse on both types of devices... but I think it's good for now.