### PR TITLE
Ll 1412 - Mobile - Add Bitcoin in the list of possible countervalues

### DIFF
--- a/src/screens/Settings/General/CountervalueSettings.js
+++ b/src/screens/Settings/General/CountervalueSettings.js
@@ -1,13 +1,16 @@
 /* @flow */
 import { connect } from "react-redux";
-import { listFiatCurrencies } from "@ledgerhq/live-common/lib/currencies";
+import {
+  getCryptoCurrencyById,
+  listFiatCurrencies,
+} from "@ledgerhq/live-common/lib/currencies";
 import i18next from "i18next";
 import { setCountervalue } from "../../../actions/settings";
 import { counterValueCurrencySelector } from "../../../reducers/settings";
 import type { State } from "../../../reducers";
 import makeGenericSelectScreen from "../../makeGenericSelectScreen";
 
-const items = listFiatCurrencies()
+const items = [...listFiatCurrencies(), getCryptoCurrencyById("bitcoin")]
   .map(cur => ({ value: cur.ticker, label: `${cur.name} (${cur.ticker})` }))
   .sort((a, b) => a.label.localeCompare(b.label));
 

--- a/src/screens/Settings/General/RateProviderSettingsRow.js
+++ b/src/screens/Settings/General/RateProviderSettingsRow.js
@@ -30,7 +30,8 @@ class RateProviderSettingsRow extends PureComponent<{
       counterValueExchange,
       counterValueCurrency,
     } = this.props;
-    return (
+    return counterValueCurrency.ticker ===
+      intermediaryCurrency.ticker ? null : (
       <SettingsRow
         event="RateProviderSettingsRow"
         title={<Trans i18nKey="settings.display.exchange" />}


### PR DESCRIPTION
Same as [LL-1388 ](https://github.com/LedgerHQ/ledger-live-desktop/pull/2010) but for mobile, it adds BTC as a valid countervalue to set up and also hides the rate provider like on Desktop.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1412
