### PR TITLE
[iOS] Strip x86 libcore binaries on "archive"

### DIFF
--- a/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -459,6 +459,13 @@
 			remoteGlobalIDString = 2D2A28201D9B03D100D4039D;
 			remoteInfo = "RCTAnimation-tvOS";
 		};
+		76AF0523229C15B30087B066 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4AD2AECC687D45E9BBCCED05 /* RNVectorIcons.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = A39873CE1EA65EE60051E01A;
+			remoteInfo = "RNVectorIcons-tvOS";
+		};
 		7FB701E021C6C70B00DF1E93 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 7FB701C721C6C70B00DF1E93 /* RCTVibration.xcodeproj */;
@@ -638,7 +645,7 @@
 		};
 		B91C4698216812CD00E250AB /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
+			buildActionMask = 12;
 			dstPath = x86_64;
 			dstSubfolderSpec = 10;
 			files = (
@@ -1257,6 +1264,7 @@
 			isa = PBXGroup;
 			children = (
 				8FAC6EE921490C0C00FA9316 /* libRNVectorIcons.a */,
+				76AF0524229C15B30087B066 /* libRNVectorIcons-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1353,6 +1361,7 @@
 				C5DD91777D904DF2BEB7E83C /* Upload Debug Symbols to Sentry */,
 				B91C42DB2163F71100E250AB /* Embed Frameworks */,
 				B91C4698216812CD00E250AB /* Copy Files */,
+				76AF0529229C1BFA0087B066 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -1907,6 +1916,13 @@
 			remoteRef = 5E9157341DD0AC6500FF2AA8 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		76AF0524229C15B30087B066 /* libRNVectorIcons-tvOS.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libRNVectorIcons-tvOS.a";
+			remoteRef = 76AF0523229C15B30087B066 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		7FB701E121C6C70B00DF1E93 /* libRCTVibration.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -2124,6 +2140,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "export SENTRY_PROPERTIES=sentry.properties\n\n# Setup nvm and set node\n[ -z \"$NVM_DIR\" ] && export NVM_DIR=\"$HOME/.nvm\"\n\nif [[ -s \"$HOME/.nvm/nvm.sh\" ]]; then\n. \"$HOME/.nvm/nvm.sh\"\nelif [[ -x \"$(command -v brew)\" && -s \"$(brew --prefix nvm)/nvm.sh\" ]]; then\n. \"$(brew --prefix nvm)/nvm.sh\"\nfi\n\n# Set up the nodenv node version manager if present\nif [[ -x \"$HOME/.nodenv/bin/nodenv\" ]]; then\neval \"$(\"$HOME/.nodenv/bin/nodenv\" init -)\"\nfi\n\n[ -z \"$NODE_BINARY\" ] && export NODE_BINARY=\"node\"\n\n$NODE_BINARY ../node_modules/@sentry/cli/bin/sentry-cli react-native xcode ../node_modules/react-native/scripts/react-native-xcode.sh\n";
+		};
+		76AF0529229C1BFA0087B066 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 8;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+			shellPath = /bin/sh;
+			shellScript = "rm -rf \"${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}/x86_64\"\n";
 		};
 		C5DD91777D904DF2BEB7E83C /* Upload Debug Symbols to Sentry */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
x86_64 libcore binaries needed for the iPhone simulator where embedded when doing an _archive_ to deploy on App Store, which was getting promptly rejected unless removed manually.

This should fix that ⓒ 

#### Before

<img width="723" alt="Screen Shot 2019-05-27 at 17 00 44" src="https://user-images.githubusercontent.com/13920153/58428356-7b1bfd80-80a2-11e9-8794-1b5dd800d32c.png">

#### After

<img width="717" alt="Screen Shot 2019-05-27 at 17 02 11" src="https://user-images.githubusercontent.com/13920153/58428389-94bd4500-80a2-11e9-8dce-906495d6197d.png">

### Type

Bugfix

### Context

- https://ledgerhq.atlassian.net/browse/LL-916
- #263 

### Parts of the app affected / Test plan

- Archive
- Publish
- ???
- Profit