### PR TITLE
LL-1403 No Apps literal

### DIFF
--- a/src/screens/Manager/AppsList.js
+++ b/src/screens/Manager/AppsList.js
@@ -166,7 +166,7 @@ class ManagerAppsList extends Component<Props, State> {
 
   renderEmptySearch = () => (
     <View>
-      <LText>{i18next.t("manager.appList.noapps")}</LText>
+      <LText>{i18next.t("manager.appList.noApps")}</LText>
     </View>
   );
 


### PR DESCRIPTION
We (I) were incorrectly pointing to `manager.apps.noapps` instead of `manager.apps.noApps`

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1413

### Parts of the app affected / Test plan

    

- Go to manager -> Select a divice
- In app catalog search input type "skoheshw"
