### PR TITLE
LL-1410 Allow modal dismiss on success/error

### DIFF
--- a/src/screens/Manager/AppAction.js
+++ b/src/screens/Manager/AppAction.js
@@ -192,7 +192,12 @@ class AppAction extends PureComponent<
     );
 
     return (
-      <BottomModal id={action.type + "AppActionModal"} isOpened={isOpened}>
+      <BottomModal
+        id={action.type + "AppActionModal"}
+        preventBackdropClick={pending}
+        onClose={this.onClose}
+        isOpened={isOpened}
+      >
         <SafeAreaView forceInset={forceInset} style={styles.root}>
           <View style={styles.body}>
             <View style={styles.headIcon}>


### PR DESCRIPTION
Modal actions involving interactions with the device should not allow the modal to be dismissed (it still can be cancelled if the X is shown). However, on end cases such as a success or an error, the modal should once again become dismmissable by tapping on the backdrop/pressing back.

### Type

UX Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1410

### Parts of the app affected / Test plan

Bottom Modals (install, uninstall, genuine check, etc)
