### PR TITLE
Ll 1525 visual bug portfolio header

### DIFF
--- a/src/screens/Portfolio/Header.js
+++ b/src/screens/Portfolio/Header.js
@@ -97,6 +97,7 @@ const styles = StyleSheet.create({
   },
   content: {
     flexGrow: 1,
+    flexShrink: 1
   },
   distributionButton: {
     alignItems: "center",


### PR DESCRIPTION
fixing a small visual bug on the portfolio screen causing the distribution button to be pushed off-screen when the content block (either error or greeting title) is too large.

### Type

bug fix

### Context

LL-1525

### Parts of the app affected / Test plan

portfolio screen header