### PR TITLE
LL-1562 Allows Recipient/Sender to use the width of the screen properly

### DIFF
--- a/src/screens/SendFunds/SummaryRowCustom.js
+++ b/src/screens/SendFunds/SummaryRowCustom.js
@@ -2,7 +2,6 @@ import React, { PureComponent } from "react";
 import { View, StyleSheet } from "react-native";
 import LText from "../../components/LText/index";
 import colors from "../../colors";
-import getWindowDimensions from "../../logic/getWindowDimensions";
 
 export default class SummaryRowCustom extends PureComponent<{
   onPress: () => void,
@@ -13,9 +12,9 @@ export default class SummaryRowCustom extends PureComponent<{
   render() {
     const { label, data, iconLeft } = this.props;
     return (
-      <View style={[styles.root]}>
+      <View style={styles.root}>
         <View style={styles.iconLeft}>{iconLeft}</View>
-        <View>
+        <View style={styles.right}>
           <LText style={styles.labelStyle}>{label}</LText>
           {data}
         </View>
@@ -28,8 +27,6 @@ const styles = StyleSheet.create({
   root: {
     flexDirection: "row",
     paddingVertical: 16,
-    // NOTE: temp solution
-    width: getWindowDimensions().width - 48,
   },
   labelStyle: {
     fontSize: 16,
@@ -37,5 +34,8 @@ const styles = StyleSheet.create({
   },
   iconLeft: {
     paddingRight: 16,
+  },
+  right: {
+    flex: 1,
   },
 });


### PR DESCRIPTION
Basically the right container wasn't receiving any styles, so it wasn't expanding to the fill the parent, I don't understand the need for an explicit display width use here so maybe I'm missing something.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
<img width="545" alt="Screenshot 2019-07-01 at 20 52 12" src="https://user-images.githubusercontent.com/4631227/60460190-5ee02300-9c43-11e9-9e75-e9cd10709783.png">
<img width="404" alt="image" src="https://user-images.githubusercontent.com/4631227/60460320-acf52680-9c43-11e9-95e6-de3b6ae57ff5.png">


### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1562

### Parts of the app affected / Test plan

Summary screen, addresses should be visible without going offscreen. There should be a wrap to a second line. In the case of needing a third line it will ellipse, this was in place but could be expanded to 3 lines if we need it (?)
