### PR TITLE
LL-1552 Show transaction status instead of asset icon in portfolio

### DIFF
--- a/src/components/OperationRow.js
+++ b/src/components/OperationRow.js
@@ -10,7 +10,6 @@ import type { Account, Operation } from "@ledgerhq/live-common/lib/types";
 import LText from "./LText";
 import CurrencyUnitValue from "./CurrencyUnitValue";
 import CounterValue from "./CounterValue";
-import CurrencyIcon from "./CurrencyIcon";
 
 import OperationIcon from "./OperationIcon";
 import colors from "../colors";
@@ -73,17 +72,13 @@ class OperationRow extends PureComponent<Props, *> {
       <View style={[styles.root, isLast ? styles.last : null]}>
         <RectButton onPress={this.goToOperationDetails} style={styles.button}>
           <View style={isOptimistic ? styles.optimistic : null}>
-            {multipleAccounts ? (
-              <CurrencyIcon size={20} currency={account.currency} />
-            ) : (
-              <View>
-                <OperationIcon
-                  size={28}
-                  operation={operation}
-                  account={account}
-                />
-              </View>
-            )}
+            <View>
+              <OperationIcon
+                size={28}
+                operation={operation}
+                account={account}
+              />
+            </View>
           </View>
           <View
             style={[styles.wrapper, isOptimistic ? styles.optimistic : null]}


### PR DESCRIPTION

<img width="404" alt="Screenshot 2019-07-01 at 23 47 34" src="https://user-images.githubusercontent.com/4631227/60468745-e7b68900-9c5a-11e9-8a69-3b41afb0d1db.png">
We keep the use of the account name instead of "sent/receive" but lose the currency icon.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-1552

### Parts of the app affected / Test plan

On the portfolio history, the list rows should no longer display the currency icon but rather the transaction status indicator. 
