### PR TITLE
LL-1392  Sendmax functionality

### DIFF
--- a/src/components/CurrencyInput.js
+++ b/src/components/CurrencyInput.js
@@ -148,6 +148,7 @@ class CurrencyInput extends PureComponent<Props, State> {
             styles.input,
             isActive ? styles.active : null,
             hasError ? styles.error : null,
+            editable ? {} : styles.readOnly,
           ]}
           editable={editable}
           onChangeText={this.handleChange}
@@ -187,6 +188,9 @@ const styles = StyleSheet.create({
   },
   active: {
     fontSize: 32,
+  },
+  readOnly: {
+    color: colors.grey,
   },
   error: {
     color: colors.alert,

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -845,7 +845,8 @@
       "input": "Enter address"
     },
     "amount": {
-      "available": "<1><0>{{amount}}</></> available",
+      "available": "Total available",
+      "useMax": "Use max",
       "loadingNetwork": "Loading Network fees...",
       "noRateProvider": "Not available"
     },

--- a/src/screens/Portfolio/Header.js
+++ b/src/screens/Portfolio/Header.js
@@ -97,7 +97,7 @@ const styles = StyleSheet.create({
   },
   content: {
     flexGrow: 1,
-    flexShrink: 1
+    flexShrink: 1,
   },
   distributionButton: {
     alignItems: "center",

--- a/src/screens/SendFunds/04-Summary.js
+++ b/src/screens/SendFunds/04-Summary.js
@@ -49,6 +49,7 @@ class SendSummary extends Component<
     totalSpent: ?BigNumber,
     error: ?Error,
     highFeesOpen: boolean,
+    maxAmount: ?BigNumber,
   },
 > {
   static navigationOptions = {
@@ -65,16 +66,19 @@ class SendSummary extends Component<
 
   state = {
     totalSpent: null,
+    maxAmount: null,
     error: null, // TODO use error somewhere!
     highFeesOpen: false,
   };
 
   componentDidMount() {
     this.syncTotalSpent();
+    this.syncMaxAmount();
   }
 
   componentDidUpdate() {
     this.syncTotalSpent();
+    this.syncMaxAmount();
   }
 
   componentWillUnmount() {
@@ -159,6 +163,37 @@ class SendSummary extends Component<
     }
   };
 
+  nonceMaxAmount = 0;
+  syncMaxAmount = async () => {
+    const { account, parentAccount, navigation } = this.props;
+    if (!account) return;
+    const bridge = getAccountBridge(account, parentAccount);
+    const mainAccount = getMainAccount(account, parentAccount);
+    const transaction = navigation.getParam("transaction");
+    const nonce = ++this.nonceMaxAmount;
+
+    const useAllAmount = bridge.getTransactionExtra(
+      mainAccount,
+      transaction,
+      "useAllAmount",
+    );
+
+    let maxAmount;
+    if (useAllAmount)
+      maxAmount = await bridge.getMaxAmount(mainAccount, transaction);
+    if (nonce !== this.nonceMaxAmount) return;
+
+    this.setState(old => {
+      if (
+        !maxAmount ||
+        (old.maxAmount && maxAmount && maxAmount.eq(old.maxAmount))
+      ) {
+        return null;
+      }
+      return { maxAmount };
+    });
+  };
+
   onAcceptFees = async () => {
     const { account, parentAccount, navigation } = this.props;
     if (!account) return;
@@ -180,7 +215,7 @@ class SendSummary extends Component<
   };
 
   render() {
-    const { totalSpent, error, highFeesOpen } = this.state;
+    const { totalSpent, error, highFeesOpen, maxAmount } = this.state;
     const { account, parentAccount, navigation } = this.props;
     if (!account) return null;
     const transaction = navigation.getParam("transaction");
@@ -188,6 +223,11 @@ class SendSummary extends Component<
     const mainAccount = getMainAccount(account, parentAccount);
     const amount = bridge.getTransactionAmount(mainAccount, transaction);
     const recipient = bridge.getTransactionRecipient(mainAccount, transaction);
+    const useAllAmount = bridge.getTransactionExtra(
+      mainAccount,
+      transaction,
+      "useAllAmount",
+    );
 
     return (
       <SafeAreaView style={styles.root}>
@@ -205,7 +245,7 @@ class SendSummary extends Component<
           <SummaryAmountSection
             account={account}
             parentAccount={parentAccount}
-            amount={amount}
+            amount={(useAllAmount && maxAmount) || amount}
           />
           <SendRowsFee
             account={mainAccount}
@@ -285,9 +325,9 @@ const styles = StyleSheet.create({
   },
 });
 
-const mapStateToProps = accountAndParentScreenSelector;
-
-export default connect(mapStateToProps)(translate()(SendSummary));
+export default connect(accountAndParentScreenSelector)(
+  translate()(SendSummary),
+);
 
 class VerticalConnector extends Component<*> {
   render() {

--- a/src/screens/SendFunds/AmountInput.js
+++ b/src/screens/SendFunds/AmountInput.js
@@ -42,6 +42,7 @@ type Props = OwnProps & {
   t: T,
   getCounterValue: BigNumber => ?BigNumber,
   getReverseCounterValue: BigNumber => ?BigNumber,
+  editable?: boolean,
 };
 
 type OwnState = {
@@ -100,6 +101,7 @@ class AmountInput extends Component<Props, OwnState> {
       getCounterValue,
       account,
       error,
+      editable,
     } = this.props;
     const isCrypto = active === "crypto";
     const fiat = value ? getCounterValue(value) : BigNumber(0);
@@ -109,6 +111,7 @@ class AmountInput extends Component<Props, OwnState> {
       <View style={styles.container}>
         <View style={styles.wrapper}>
           <CurrencyInput
+            editable={editable}
             isActive={isCrypto}
             onFocus={this.onCryptoFieldFocus}
             onChange={this.onCryptoFieldChange}
@@ -137,7 +140,7 @@ class AmountInput extends Component<Props, OwnState> {
             unit={rightUnit}
             value={value ? fiat : null}
             placeholder={!fiat ? t("send.amount.noRateProvider") : undefined}
-            editable={!!fiat}
+            editable={!!fiat && editable}
             showAllDigits
             renderRight={
               <LText


### PR DESCRIPTION
In the current state of common, it only works with bitcoin family since the ethereum bridge doesn't implement a way of setting the `useAllAmount` extra (~i think this is the cause~ it was). Once https://github.com/LedgerHQ/ledger-live-common/pull/296 is merged in common and we bump it, this pr would work for eth too.

![Group 2](https://user-images.githubusercontent.com/4631227/60661417-26666200-9e5a-11e9-851d-72d00e41dd3d.png)

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Feature

### Context
https://ledgerhq.atlassian.net/browse/LL-1392

### Parts of the app affected / Test plan
Send flow
<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
