### PR TITLE
slider for Ethereum transaction

### DIFF
--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -11,6 +11,7 @@ export const urls = {
     "itms-apps://itunes.apple.com/WebObjects/MZStore.woa/wa/viewContentsUserReviews?id=1361671700&onlyLatestVersion=true&pageNumber=0&sortOrdering=1&type=Purple+Software",
   feesMoreInfo:
     "https://support.ledgerwallet.com/hc/en-us/articles/360006535873",
+  feesEthereum: "https://support.ledger.com/hc/en-us/articles/115005197845",
   verifyTransactionDetails:
     "https://support.ledgerwallet.com/hc/en-us/articles/360006433934",
 };

--- a/src/families/SendRowsFee.js
+++ b/src/families/SendRowsFee.js
@@ -1,7 +1,8 @@
 /* @flow */
 import React from "react";
-import type { Account } from "@ledgerhq/live-common/lib/types";
+import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import type { NavigationScreenProp } from "react-navigation";
+import { getMainAccount } from "@ledgerhq/live-common/lib/account";
 
 import bitcoin from "./bitcoin/SendRowsFee";
 import ripple from "./ripple/SendRowsFee";
@@ -17,14 +18,22 @@ const perFamily: { [_: string]: * } = {
 export default ({
   transaction,
   account,
+  parentAccount,
   navigation,
 }: {
   transaction: *,
-  account: Account,
+  account: Account | TokenAccount,
+  parentAccount: ?Account,
   navigation: NavigationScreenProp<*>,
 }) => {
-  const C = perFamily[account.currency.family];
+  const mainAccount = getMainAccount(account, parentAccount);
+  const C = perFamily[mainAccount.currency.family];
   return C ? (
-    <C transaction={transaction} account={account} navigation={navigation} />
+    <C
+      transaction={transaction}
+      account={account}
+      parentAccount={parentAccount}
+      navigation={navigation}
+    />
   ) : null;
 };

--- a/src/families/bitcoin/SendRowsFee.js
+++ b/src/families/bitcoin/SendRowsFee.js
@@ -1,15 +1,18 @@
 /* @flow */
 import React from "react";
-import type { Account } from "@ledgerhq/live-common/lib/types";
+import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import type { NavigationScreenProp } from "react-navigation";
 
 import BitcoinFeePerByteRow from "./BitcoinFeePerByteRow";
 
 type Props = {
   transaction: *,
-  account: Account,
+  account: Account | TokenAccount,
   navigation: NavigationScreenProp<*>,
 };
-export default function BitcoinSendRowsFee(props: Props) {
-  return <BitcoinFeePerByteRow {...props} />;
+
+export default function BitcoinSendRowsFee({ account, ...props }: Props) {
+  if (account.type === "TokenAccount") return null;
+
+  return <BitcoinFeePerByteRow {...props} account={account} />;
 }

--- a/src/families/ethereum/EditFeeUnitEthereum.js
+++ b/src/families/ethereum/EditFeeUnitEthereum.js
@@ -1,0 +1,198 @@
+// @flow
+import React, { useMemo, useState, useCallback } from "react";
+import { View, StyleSheet } from "react-native";
+import { translate } from "react-i18next";
+import Slider from "react-native-slider";
+import type { NavigationScreenProp } from "react-navigation";
+import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
+import type { Transaction } from "@ledgerhq/live-common/lib/bridge/EthereumJSBridge";
+import {
+  inferDynamicRange,
+  reverseRangeIndex,
+  projectRangeIndex,
+} from "@ledgerhq/live-common/lib/range";
+import { getAccountBridge } from "@ledgerhq/live-common/lib/bridge";
+import { getMainAccount } from "@ledgerhq/live-common/lib/account";
+import { BigNumber } from "bignumber.js";
+
+import { editTxFeeByFamily } from "../helpers";
+import type { T } from "../../types/common";
+import colors from "../../colors";
+import LText from "../../components/LText";
+import CurrencyUnitValue from "../../components/CurrencyUnitValue";
+import SettingsRow from "../../components/SettingsRow";
+import Button from "../../components/Button";
+
+type Props = {
+  account: Account | TokenAccount,
+  parentAccount: ?Account,
+  transaction: Transaction,
+  t: T,
+  navigation: NavigationScreenProp<*>,
+};
+
+const GasSlider = React.memo(({ defaultGas, value, onChange }: *) => {
+  const range = useMemo(() => inferDynamicRange(defaultGas), [defaultGas]);
+  const index = reverseRangeIndex(range, value);
+  const setValueIndex = useCallback(
+    i => onChange(projectRangeIndex(range, i)),
+    [range, onChange],
+  );
+
+  return (
+    <Slider
+      value={index}
+      step={1}
+      onValueChange={setValueIndex}
+      minimumValue={0}
+      maximumValue={range.steps - 1}
+      thumbTintColor={colors.live}
+      minimumTrackTintColor={colors.live}
+    />
+  );
+});
+
+const EditFeeUnitEthereum = ({
+  account,
+  parentAccount,
+  transaction,
+  t,
+  navigation,
+}: Props) => {
+  const mainAccount = getMainAccount(account, parentAccount);
+  const bridge = getAccountBridge(account, parentAccount);
+
+  const [gasPrice, setGasPrice] = useState(() =>
+    bridge.getTransactionExtra(mainAccount, transaction, "gasPrice"),
+  );
+  const feeCustomUnit = bridge.getTransactionExtra(
+    mainAccount,
+    transaction,
+    "feeCustomUnit",
+  );
+
+  const onChangeF = useCallback(
+    value => {
+      const { gasPrice: gp } = bridge.editTransactionExtra(
+        mainAccount,
+        transaction,
+        "gasPrice",
+        value,
+      );
+      setGasPrice(gp);
+    },
+    [bridge, account, transaction],
+  );
+
+  const onValidateFees = useCallback(() => {
+    navigation.navigate("SendSummary", {
+      accountId: account.id,
+      parentId: parentAccount && parentAccount.id,
+      transaction: editTxFeeByFamily(
+        mainAccount,
+        navigation,
+        "gasPrice",
+        gasPrice,
+      ),
+    });
+  }, [account, gasPrice, navigation, mainAccount]);
+
+  const fees = bridge.getTransactionNetworkInfo(mainAccount, transaction);
+
+  if (!fees) return null;
+
+  const serverGas = BigNumber(fees.serverFees.gas_price);
+
+  return (
+    <View style={styles.root}>
+      <View style={styles.sliderContainer}>
+        <SettingsRow
+          title={t("send.fees.chooseGas")}
+          desc={t("send.fees.higherFaster")}
+          onPress={null}
+          alignedTop
+        >
+          <LText
+            tertiary
+            style={[
+              styles.currencyUnitText,
+              { color: colors.live, marginLeft: 8 },
+            ]}
+          >
+            <CurrencyUnitValue
+              unit={feeCustomUnit || mainAccount.unit}
+              value={gasPrice}
+            />
+          </LText>
+        </SettingsRow>
+        <View style={styles.container}>
+          <GasSlider
+            defaultGas={serverGas}
+            value={gasPrice}
+            onChange={onChangeF}
+          />
+          <View style={styles.textContainer}>
+            <LText
+              tertiary
+              style={[styles.currencyUnitText, { color: colors.grey }]}
+            >
+              {t("common.slow")}
+            </LText>
+            <LText
+              tertiary
+              style={[styles.currencyUnitText, { color: colors.grey }]}
+            >
+              {t("common.fast")}
+            </LText>
+          </View>
+        </View>
+        <LText />
+      </View>
+      <View style={styles.buttonContainer}>
+        <Button
+          event="EditFeeUnitConfirm"
+          type="primary"
+          title={t("common.confirm")}
+          containerStyle={styles.continueButton}
+          onPress={onValidateFees}
+        />
+      </View>
+    </View>
+  );
+};
+
+export default translate()(EditFeeUnitEthereum);
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    paddingTop: 16,
+  },
+  sliderContainer: {
+    backgroundColor: "white",
+    minHeight: 200,
+  },
+  container: {
+    flex: 1,
+    flexDirection: "column",
+    justifyContent: "center",
+    paddingTop: 8,
+    paddingHorizontal: 16,
+  },
+  textContainer: {
+    flex: 1,
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  currencyUnitText: {
+    fontSize: 16,
+  },
+  buttonContainer: {
+    flex: 1,
+    padding: 16,
+    justifyContent: "flex-end",
+  },
+  continueButton: {
+    alignSelf: "stretch",
+  },
+});

--- a/src/families/ethereum/EthereumFeeRow.js
+++ b/src/families/ethereum/EthereumFeeRow.js
@@ -35,7 +35,7 @@ class EthereumFeeRow extends Component<Props> {
     });
   };
   extraInfoFees = () => {
-    Linking.openURL(urls.feesMoreInfo);
+    Linking.openURL(urls.feesEthereum);
   };
 
   render() {

--- a/src/families/ethereum/ScreenEditFee.js
+++ b/src/families/ethereum/ScreenEditFee.js
@@ -4,20 +4,20 @@ import { StyleSheet } from "react-native";
 import { SafeAreaView } from "react-navigation";
 import type { NavigationScreenProp } from "react-navigation";
 import { connect } from "react-redux";
-import { createStructuredSelector } from "reselect";
 import i18next from "i18next";
-import type { Account } from "@ledgerhq/live-common/lib/types";
+import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import type { Transaction } from "@ledgerhq/live-common/lib/bridge/EthereumJSBridge";
 
 import colors from "../../colors";
-import { accountScreenSelector } from "../../reducers/accounts";
+import { accountAndParentScreenSelector } from "../../reducers/accounts";
 import type { T } from "../../types/common";
 
 import KeyboardView from "../../components/KeyboardView";
-import EditFeeUnit from "../EditFeeUnit";
+import EditFeeUnitEthereum from "./EditFeeUnitEthereum";
 
 type Props = {
-  account: Account,
+  account: Account | TokenAccount,
+  parentAccount: ?Account,
   navigation: NavigationScreenProp<{
     params: {
       accountId: string,
@@ -34,17 +34,17 @@ class EthereumEditFee extends Component<Props> {
   };
 
   render() {
-    const { navigation, account } = this.props;
+    const { navigation, account, parentAccount } = this.props;
     const transaction: Transaction = navigation.getParam("transaction");
     if (!transaction) return null;
     return (
       <SafeAreaView style={styles.root}>
         <KeyboardView style={styles.container}>
-          <EditFeeUnit
+          <EditFeeUnitEthereum
             account={account}
+            parentAccount={parentAccount}
             transaction={transaction}
             navigation={navigation}
-            field="gasPrice"
           />
         </KeyboardView>
       </SafeAreaView>
@@ -62,8 +62,6 @@ const styles = StyleSheet.create({
   },
 });
 
-const mapStateToProps = createStructuredSelector({
-  account: accountScreenSelector,
-});
+const mapStateToProps = accountAndParentScreenSelector;
 
 export default connect(mapStateToProps)(EthereumEditFee);

--- a/src/families/ethereum/SendRowGasLimit.js
+++ b/src/families/ethereum/SendRowGasLimit.js
@@ -2,17 +2,19 @@
 import React, { PureComponent } from "react";
 import { View, StyleSheet } from "react-native";
 import { translate } from "react-i18next";
-import type { Account } from "@ledgerhq/live-common/lib/types";
+import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import type { Transaction } from "@ledgerhq/live-common/lib/bridge/EthereumJSBridge";
 import { getAccountBridge } from "@ledgerhq/live-common/lib/bridge";
 import { BigNumber } from "bignumber.js";
+import { getMainAccount } from "@ledgerhq/live-common/lib/account/helpers";
 import type { T } from "../../types/common";
 import LText from "../../components/LText";
 import colors from "../../colors";
 import SummaryRow from "../../screens/SendFunds/SummaryRow";
 
 type Props = {
-  account: Account,
+  account: Account | TokenAccount,
+  parentAccount: ?Account,
   transaction: Transaction,
   navigation: *,
   t: T,
@@ -23,18 +25,20 @@ type State = {
 };
 class EthereumGasLimit extends PureComponent<Props, State> {
   editGasLimit = () => {
-    const { account, navigation, transaction } = this.props;
+    const { account, parentAccount, navigation, transaction } = this.props;
     navigation.navigate("EthereumEditGasLimit", {
       accountId: account.id,
+      parentId: parentAccount && parentAccount.id,
       transaction,
     });
   };
 
   render() {
-    const { account, t, transaction } = this.props;
-    const bridge = getAccountBridge(account);
+    const { account, parentAccount, t, transaction } = this.props;
+    const mainAccount = getMainAccount(account, parentAccount);
+    const bridge = getAccountBridge(account, parentAccount);
     const gasLimit = bridge.getTransactionExtra(
-      account,
+      mainAccount,
       transaction,
       "gasLimit",
     );

--- a/src/families/ethereum/SendRowsFee.js
+++ b/src/families/ethereum/SendRowsFee.js
@@ -1,6 +1,6 @@
 /* @flow */
 import React from "react";
-import type { Account } from "@ledgerhq/live-common/lib/types";
+import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import type { NavigationScreenProp } from "react-navigation";
 import type { Transaction } from "@ledgerhq/live-common/lib/bridge/EthereumJSBridge";
 
@@ -8,7 +8,8 @@ import EthereumFeeRow from "./EthereumFeeRow";
 
 type Props = {
   transaction: Transaction,
-  account: Account,
+  account: Account | TokenAccount,
+  parentAccount: ?Account,
   navigation: NavigationScreenProp<*>,
 };
 export default function EthereumSendRowsFee(props: Props) {

--- a/src/families/ripple/SendRowsFee.js
+++ b/src/families/ripple/SendRowsFee.js
@@ -1,16 +1,18 @@
 /* @flow */
 import React from "react";
 import type { NavigationScreenProp } from "react-navigation";
-import type { Account } from "@ledgerhq/live-common/lib/types";
+import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import type { Transaction } from "@ledgerhq/live-common/lib/bridge/RippleJSBridge";
 
 import RippleFeeRow from "./RippleFeeRow";
 
 type Props = {
   transaction: Transaction,
-  account: Account,
+  account: Account | TokenAccount,
   navigation: NavigationScreenProp<*>,
 };
-export default function RippleSendRowsFee(props: Props) {
-  return <RippleFeeRow {...props} />;
+export default function RippleSendRowsFee({ account, ...props }: Props) {
+  if (account.type === "TokenAccount") return null;
+
+  return <RippleFeeRow {...props} account={account} />;
 }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -38,6 +38,8 @@
     "bluetooth": "Bluetooth",
     "usb": "USB",
     "add": "Add",
+    "slow": "slow",
+    "fast": "fast",
     "forgetDevice": "Remove device",
     "sync": {
       "ago": "Synchronized {{time}}"
@@ -878,6 +880,8 @@
       "title": "Network fees",
       "validate": "Confirm",
       "required": "Fees are required",
+      "chooseGas": "Choose a gas price",
+      "higherFaster": "Higher gas price means a faster confirmation",
       "edit": {
         "title": "Choose Unit"
       }

--- a/src/screens/SendFunds/04-Summary.js
+++ b/src/screens/SendFunds/04-Summary.js
@@ -84,9 +84,9 @@ class SendSummary extends Component<
   openFees = () => {
     const { account, parentAccount, navigation } = this.props;
     if (!account) return;
-    const mainAccount = getMainAccount(account, parentAccount);
     this.props.navigation.navigate("EditFees", {
-      accountId: mainAccount.id,
+      accountId: account.id,
+      parentAccount: parentAccount && parentAccount.id,
       transaction: navigation.getParam("transaction"),
     });
   };
@@ -208,7 +208,8 @@ class SendSummary extends Component<
             amount={amount}
           />
           <SendRowsFee
-            account={mainAccount}
+            account={account}
+            parentAccount={parentAccount}
             transaction={transaction}
             navigation={navigation}
           />


### PR DESCRIPTION
Adds a slider to select the gas of a transaction for Ethereum-like currencies

### Type

Feat

### Context

LL-1363

### Parts of the app affected / Test plan

Send Flow => step 4 Summary => edit gas

![IMG_9701E8CB6E84-1](https://user-images.githubusercontent.com/671786/60678976-79560e80-9e86-11e9-961f-370496ec3d17.jpeg)