### PR TITLE
fixed distribution placeholders when no countervalue

### DIFF
--- a/src/screens/Distribution/DistributionCard.js
+++ b/src/screens/Distribution/DistributionCard.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { PureComponent } from "react";
+import React, { Fragment, PureComponent } from "react";
 import { View, StyleSheet } from "react-native";
 import { BigNumber } from "bignumber.js";
 import type {
@@ -54,16 +54,23 @@ class DistributionCard extends PureComponent<Props> {
               {<CurrencyUnitValue unit={currency.units[0]} value={amount} />}
             </LText>
           </View>
-          <View style={styles.rateRow}>
-            <CurrencyRate currency={currency} />
-            <LText tertiary style={styles.counterValue}>
-              <CounterValue currency={currency} value={amount} />
-            </LText>
-          </View>
-          <View style={styles.distributionRow}>
-            <ProgressBar progress={percentage} progressColor={color} />
-            <LText tertiary style={styles.percentage}>{`${percentage}%`}</LText>
-          </View>
+          {
+            distribution ? (
+              <Fragment>
+                <View style={styles.rateRow}>
+                  <CurrencyRate currency={currency} />
+                  <LText tertiary style={styles.counterValue}>
+                    <CounterValue currency={currency} value={amount} />
+                  </LText>
+                </View>
+                <View style={styles.distributionRow}>
+                  <ProgressBar progress={percentage} progressColor={color} />
+                  <LText tertiary style={styles.percentage}>{`${percentage}%`}</LText>
+                </View>
+
+              </Fragment>
+            ) : null
+          }
         </View>
       </View>
     );

--- a/src/screens/Distribution/index.js
+++ b/src/screens/Distribution/index.js
@@ -76,7 +76,7 @@ class Distribution extends PureComponent<Props, *> {
     this.flatListRef.scrollToIndex({ index }, true);
   };
 
-  keyExtractor = item => item.id;
+  keyExtractor = item => item.currency.id;
 
   ListHeaderComponent = () => {
     const { counterValueCurrency, distribution } = this.props;


### PR DESCRIPTION
Fixed distribution flatlist item keys were not generated
Hiding distribution asset card percent and countervalue when no countervalue is available

### Type

Bug Fix

### Parts of the app affected / Test plan

Distribution Screen