### PR TITLE
added parent currency icons

### DIFF
--- a/src/components/ParentCurrencyIcon.js
+++ b/src/components/ParentCurrencyIcon.js
@@ -1,0 +1,47 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { View, StyleSheet } from "react-native";
+
+import colors from "../colors";
+import CurrencyIcon from "./CurrencyIcon";
+
+type Props = {
+  currency: *,
+  size: number,
+};
+
+export default class ParentCurrencyIcon extends PureComponent<Props> {
+  render() {
+    const { currency, size } = this.props;
+
+    if (currency.type === "TokenCurrency") {
+      return (
+        <View style={{ width: size }}>
+          <View style={styles.parentIconWrapper}>
+            <CurrencyIcon size={size} currency={currency.parentCurrency} />
+          </View>
+          <View style={styles.tokenIconWrapper}>
+            <CurrencyIcon size={size - 2} currency={currency} />
+          </View>
+        </View>
+      );
+    }
+
+    return <CurrencyIcon size={size} currency={currency} />;
+  }
+}
+
+const styles = StyleSheet.create({
+  tokenIconWrapper: {
+    marginLeft: 3,
+    marginTop: -6,
+    borderWidth: 2,
+    borderColor: colors.white,
+    borderRadius: 4,
+    backgroundColor: colors.white,
+  },
+  parentIconWrapper: {
+    marginLeft: -5,
+  },
+});

--- a/src/screens/Account/AccountHeaderTitle.js
+++ b/src/screens/Account/AccountHeaderTitle.js
@@ -6,8 +6,8 @@ import type { NavigationScreenProp } from "react-navigation";
 import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import { getAccountCurrency } from "@ledgerhq/live-common/lib/account";
 import LText from "../../components/LText";
-import CurrencyIcon from "../../components/CurrencyIcon";
 import { accountAndParentScreenSelector } from "../../reducers/accounts";
+import ParentCurrencyIcon from "../../components/ParentCurrencyIcon";
 
 type Props = {
   navigation: NavigationScreenProp<*>,
@@ -30,7 +30,7 @@ class AccountHeaderTitle extends Component<Props> {
       <TouchableWithoutFeedback onPress={this.onPress}>
         <View style={styles.headerContainer}>
           <View style={styles.iconContainer}>
-            <CurrencyIcon size={18} currency={currency} />
+            <ParentCurrencyIcon size={18} currency={currency} />
           </View>
           <LText
             semiBold

--- a/src/screens/Distribution/DistributionCard.js
+++ b/src/screens/Distribution/DistributionCard.js
@@ -8,11 +8,11 @@ import type {
 } from "@ledgerhq/live-common/lib/types/currencies";
 import colors from "../../colors";
 import LText from "../../components/LText";
-import CurrencyIcon from "../../components/CurrencyIcon";
 import CurrencyUnitValue from "../../components/CurrencyUnitValue";
 import ProgressBar from "../../components/ProgressBar";
 import CounterValue from "../../components/CounterValue";
 import CurrencyRate from "../../components/CurrencyRate";
+import ParentCurrencyIcon from "../../components/ParentCurrencyIcon";
 
 export type DistributionItem = {
   currency: CryptoCurrency | TokenCurrency,
@@ -43,7 +43,7 @@ class DistributionCard extends PureComponent<Props> {
     return (
       <View style={[styles.root, highlighting ? { borderColor: color } : {}]}>
         <View style={styles.currencyLogo}>
-          <CurrencyIcon size={18} currency={currency} />
+          <ParentCurrencyIcon currency={currency} size={18} />
         </View>
         <View style={styles.rightContainer}>
           <View style={styles.currencyRow}>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/9251185/60898568-6ae26b00-a269-11e9-9cae-23552a9867dc.png)


Add double icons (parent && token) to the account header and distribution panels

### Type

Ui Polish

### Parts of the app affected / Test plan

Distribution screen / Token Account Screen