### PR TITLE
fixe ui glitch on slider fees

### DIFF
--- a/src/families/ethereum/EditFeeUnitEthereum.js
+++ b/src/families/ethereum/EditFeeUnitEthereum.js
@@ -169,6 +169,7 @@ const styles = StyleSheet.create({
     paddingTop: 16,
   },
   sliderContainer: {
+    flex: 1,
     backgroundColor: "white",
     minHeight: 200,
   },


### PR DESCRIPTION
fix ui glitch where having two figures in the slider fee selection screen who push and crop the "slow" and "fast" text

### Type

UI Fix

### Context

Slack Feedback

### Parts of the app affected / Test plan

Fees Slider selection screen
