### PR TITLE
LL-1666: Prevent switching graph view when no countervalues

### DIFF
--- a/src/screens/Account/index.js
+++ b/src/screens/Account/index.js
@@ -126,19 +126,23 @@ class AccountScreen extends PureComponent<Props, State> {
     const { countervalueAvailable } = this.props;
     const items = [
       { unit: cryptoCurrencyUnit, value: item.value },
-      item.countervalue
+      countervalueAvailable && item.countervalue
         ? { unit: counterValueUnit, value: item.countervalue }
         : null,
     ];
-    if (useCounterValue && countervalueAvailable && item.countervalue) {
+
+    const shouldUseCounterValue = countervalueAvailable && useCounterValue;
+    if (shouldUseCounterValue && item.countervalue) {
       items.reverse();
     }
 
     return (
       <Touchable
         event="SwitchAccountCurrency"
-        eventProperties={{ useCounterValue }}
-        onPress={this.onSwitchAccountCurrency}
+        eventProperties={{ useCounterValue: shouldUseCounterValue }}
+        onPress={
+          countervalueAvailable ? this.onSwitchAccountCurrency : undefined
+        }
       >
         <View style={styles.balanceContainer}>
           {items[0] ? (
@@ -167,8 +171,12 @@ class AccountScreen extends PureComponent<Props, State> {
       cryptoChange,
       countervalueChange,
     } = this.props;
+
     if (!account) return null;
+
     const empty = isAccountEmpty(account);
+    const shouldUseCounterValue = countervalueAvailable && useCounterValue;
+
     return (
       <View style={styles.header}>
         <Header accountId={account.id} />
@@ -178,8 +186,10 @@ class AccountScreen extends PureComponent<Props, State> {
             range={range}
             unit={account.unit}
             history={history}
-            useCounterValue={useCounterValue}
-            valueChange={useCounterValue ? countervalueChange : cryptoChange}
+            useCounterValue={shouldUseCounterValue}
+            valueChange={
+              shouldUseCounterValue ? countervalueChange : cryptoChange
+            }
             countervalueAvailable={countervalueAvailable}
             counterValueCurrency={counterValueCurrency}
             renderTitle={this.renderListHeaderTitle}


### PR DESCRIPTION
Prevent switching graph to countervalue view when no countervalues are available

### Type

UX improvement

### Context

LL-1666

### Parts of the app affected / Test plan

Account view