### PR TITLE
LL-1620 Allow for error specific urls for the HelpLink component

### DIFF
--- a/src/components/HelpLink.js
+++ b/src/components/HelpLink.js
@@ -9,14 +9,14 @@ import colors from "../colors";
 import { urls } from "../config/urls";
 import Help from "../icons/Help";
 
-class HelpLink extends PureComponent<{ style?: * }> {
+class HelpLink extends PureComponent<{ url?: string, style?: * }> {
   render() {
-    const { style } = this.props;
+    const { url, style } = this.props;
     return (
       <Touchable
         event="HelpLink"
         style={[styles.linkContainer, style]}
-        onPress={() => Linking.openURL(urls.faq)}
+        onPress={() => Linking.openURL(url || urls.faq)}
       >
         <Help size={16} color={colors.live} />
         <LText style={styles.linkText} semiBold>

--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -13,4 +13,7 @@ export const urls = {
     "https://support.ledgerwallet.com/hc/en-us/articles/360006535873",
   verifyTransactionDetails:
     "https://support.ledgerwallet.com/hc/en-us/articles/360006433934",
+  errors: {
+    PairingFailed: "https://support.ledger.com/hc/en-us/articles/360025864773",
+  },
 };

--- a/src/screens/PairDevices/RenderError.js
+++ b/src/screens/PairDevices/RenderError.js
@@ -14,6 +14,7 @@ import GenericErrorView from "../../components/GenericErrorView";
 import HelpLink from "../../components/HelpLink";
 import IconArrowRight from "../../icons/ArrowRight";
 import colors from "../../colors";
+import { urls } from "../../config/urls";
 
 type Props = {
   error: Error,
@@ -45,6 +46,7 @@ class RenderError extends Component<Props> {
 
     const isPairingStatus = status === "pairing";
     const isGenuineCheckStatus = status === "genuinecheck";
+    const url = (isPairingStatus && urls.errors.PairingFailed) || undefined;
 
     const outerError = isPairingStatus
       ? new PairingFailed()
@@ -84,7 +86,7 @@ class RenderError extends Component<Props> {
               <IconArrowRight size={16} color={colors.live} />
             </Touchable>
           ) : (
-            <HelpLink style={styles.linkContainer} />
+            <HelpLink url={url} style={styles.linkContainer} />
           )}
         </View>
         {isGenuineCheckStatus ? (


### PR DESCRIPTION
This will change the url of the ble pairing error but also allow an override of the help link url for other uses.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1620

### Parts of the app affected / Test plan

Deny ble pairing to trigger the error, check the url matches https://support.ledger.com/hc/en-us/articles/360025864773 
