### PR TITLE
LL-1589: See related transactions in ETH fee operations

### DIFF
--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -14,4 +14,6 @@ export const urls = {
   feesEthereum: "https://support.ledger.com/hc/en-us/articles/115005197845",
   verifyTransactionDetails:
     "https://support.ledgerwallet.com/hc/en-us/articles/360006433934",
+  erc20:
+    "https://support.ledger.com/hc/en-us/articles/115005197845-Manage-ERC20-tokens",
 };

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -564,6 +564,11 @@
     "viewInExplorer": "View in explorer",
     "sending": "Sending...",
     "receiving": "Receiving...",
+    "tokenOperations": "Token transactions",
+    "tokenModal": {
+      "desc": "This operation is related to the following token transactions"
+    },
+    "details": "{{ currency }} details",
     "extra": {
       "tag": "Tag"
     }

--- a/src/screens/OperationDetails/Modal.js
+++ b/src/screens/OperationDetails/Modal.js
@@ -1,0 +1,80 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { StyleSheet, View, Linking } from "react-native";
+import { Trans } from "react-i18next";
+
+import BottomModal from "../../components/BottomModal";
+import Circle from "../../components/Circle";
+import IconInfo from "../../icons/Info";
+import LText from "../../components/LText";
+import Button from "../../components/Button";
+
+import colors, { rgba } from "../../colors";
+import { urls } from "../../config/urls";
+
+export type Props = {|
+  isOpened: boolean,
+  onClose: () => void,
+|};
+
+class Modal extends PureComponent<Props> {
+  render() {
+    return (
+      <BottomModal
+        id="TokenOperationsInfo"
+        isOpened={this.props.isOpened}
+        onClose={this.props.onClose}
+        style={styles.modal}
+      >
+        <Circle bg={rgba(colors.live, 0.1)} size={56}>
+          <IconInfo size={24} color={colors.live} />
+        </Circle>
+        <LText style={styles.modalDesc}>
+          <Trans i18nKey="operationDetails.tokenModal.desc" />
+        </LText>
+        <View style={styles.buttonContainer}>
+          <Button
+            event="TokenOperationsModalClose"
+            type="secondary"
+            title={<Trans i18nKey="common.close" />}
+            containerStyle={styles.modalBtn}
+            onPress={this.props.onClose}
+          />
+          <Button
+            event="TokenOperationsModalLearnMore"
+            type="primary"
+            title={<Trans i18nKey="common.learnMore" />}
+            containerStyle={[styles.modalBtn, styles.learnMore]}
+            onPress={() => Linking.openURL(urls.erc20)}
+          />
+        </View>
+      </BottomModal>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  modal: {
+    paddingHorizontal: 16,
+    paddingTop: 24,
+    alignItems: "center",
+  },
+  modalDesc: {
+    textAlign: "center",
+    color: colors.smoke,
+    marginVertical: 24,
+  },
+  modalBtn: {
+    flexGrow: 1,
+  },
+  learnMore: {
+    marginLeft: 16,
+  },
+  buttonContainer: {
+    flexDirection: "row",
+    alignItems: "stretch",
+  },
+});
+
+export default Modal;


### PR DESCRIPTION
> :information_source: Related PR: https://github.com/LedgerHQ/ledger-live-desktop/pull/2201

This PR adds related `subOperations` to the operation detail view. It helps users understand why some transactions they may not have made are there (e.g. in the case of ETH, when sending tokens, an ETH fee will apply which shows up as a separate transaction).

### :camera_flash: Screenshots

<a href="https://user-images.githubusercontent.com/1671753/61643976-2eb8fc80-aca4-11e9-8e08-bd210dca7c87.png"><img src="https://user-images.githubusercontent.com/1671753/61643976-2eb8fc80-aca4-11e9-8e08-bd210dca7c87.png" height=300 /></a> <a href="https://user-images.githubusercontent.com/1671753/61643972-2eb8fc80-aca4-11e9-8e9e-6f51c5551e3c.png"><img src="https://user-images.githubusercontent.com/1671753/61643972-2eb8fc80-aca4-11e9-8e9e-6f51c5551e3c.png" height=300 /></a> <a href="https://user-images.githubusercontent.com/1671753/61643974-2eb8fc80-aca4-11e9-8ec2-0461db8402bf.png"><img src="https://user-images.githubusercontent.com/1671753/61643974-2eb8fc80-aca4-11e9-8ec2-0461db8402bf.png" height=300 /></a>

### :ok_hand: Type

Feature / UX

### :mag: Context

LL-1589

### :clipboard: Parts of the app affected / Test plan

Operation details