### PR TITLE
LL-1710 Hide send max for currencies that can't handle it

### DIFF
--- a/src/screens/SendFunds/03-Amount.js
+++ b/src/screens/SendFunds/03-Amount.js
@@ -377,16 +377,18 @@ class SendAmount extends Component<Props, State> {
                         />
                       </LText>
                     </View>
-                    <View style={styles.availableRight}>
-                      <LText style={styles.maxLabel}>
-                        <Trans i18nKey="send.amount.useMax" />
-                      </LText>
-                      <Switch
-                        style={{ opacity: 0.99 }}
-                        value={useAllAmount}
-                        onValueChange={this.toggleUseAllAmount}
-                      />
-                    </View>
+                    {typeof useAllAmount === "boolean" ? (
+                      <View style={styles.availableRight}>
+                        <LText style={styles.maxLabel}>
+                          <Trans i18nKey="send.amount.useMax" />
+                        </LText>
+                        <Switch
+                          style={{ opacity: 0.99 }}
+                          value={useAllAmount}
+                          onValueChange={this.toggleUseAllAmount}
+                        />
+                      </View>
+                    ) : null}
                   </View>
                   <View style={styles.continueWrapper}>
                     <Button


### PR DESCRIPTION
XRP was showing the send max button when it can't currently handle that functionality

### Type

BugFix

### Context

https://ledgerhq.atlassian.net/browse/LL-1710

### Parts of the app affected / Test plan

Send flow for XRP account, amount step should no longer show the send max button
