### PR TITLE
LL-1714 Change vendor id to dec

### DIFF
--- a/android/app/src/main/res/xml/usb_device_filter.xml
+++ b/android/app/src/main/res/xml/usb_device_filter.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <usb-device vendor-id="2c97" product-id="00000" id='blue'/>
-    <usb-device vendor-id="2c97" product-id="00001" id='nanoS'/>
-    <usb-device vendor-id="2c97" product-id="00004" id='nanoX'/>
+    <usb-device vendor-id="11415" product-id="00000" id='blue'/>
+    <usb-device vendor-id="11415" product-id="00001" id='nanoS'/>
+    <usb-device vendor-id="11415" product-id="00004" id='nanoX'/>
 </resources>


### PR DESCRIPTION
It seems that the usb filtering declared in `usb_device_filter.xml` needed `vendor-id` and `product-id` to be decimal values and we had hex for the vendor. This results in the attribute being ignored and only filtering by `product-id` causing things like https://github.com/LedgerHQ/ledger-live-mobile/issues/959

### Type

BugFix

### Context

https://ledgerhq.atlassian.net/browse/LL-1714

### Parts of the app affected / Test plan
In order to test this @Arnaud97234 there is no easy way for you to do it, but I think that the qa part should focus on verifying that the app still works for legit devices (blue, x, s) and let https://github.com/LedgerHQ/ledger-live-mobile/issues/959 verify it fixes the issue once it's merged.