### PR TITLE
now using style to toggle token list display

### DIFF
--- a/src/screens/Accounts/AccountRow.js
+++ b/src/screens/Accounts/AccountRow.js
@@ -119,20 +119,23 @@ class AccountRow extends PureComponent<Props, State> {
               </View>
             </View>
           </RectButton>
-          {account.tokenAccounts && account.tokenAccounts.length !== 0 && (
+          {account.type === "TokenAccount" && account.tokenAccounts && account.tokenAccounts.length !== 0 && (
             <Fragment>
-              {!this.state.collapsed && (
-                <View style={styles.tokenAccountList}>
-                  {account.tokenAccounts.map((tkn, i) => (
-                    <TokenRow
-                      nested
-                      key={i}
-                      account={tkn}
-                      onTokenAccountPress={this.onTokenAccountPress}
-                    />
-                  ))}
-                </View>
-              )}
+              <View
+                style={
+                  (styles.tokenAccountList,
+                  { display: this.state.collapsed ? "none" : "flex" })
+                }
+              >
+                {account.tokenAccounts.map((tkn, i) => (
+                  <TokenRow
+                    nested
+                    key={i}
+                    account={tkn}
+                    onTokenAccountPress={this.onTokenAccountPress}
+                  />
+                ))}
+              </View>
               <View style={styles.tokenButton}>
                 <Button
                   type="lightSecondary"


### PR DESCRIPTION
rendering token list with condition at the render level was slow (especially on android) because it needed to mount / unmount each tame.

Token list is now always mounted and the toggle button hide them with style.

### Type

Bug Fix

### Context

N/A

### Parts of the app affected / Test plan

Accounts screen -> Rows with tokens