### PR TITLE
LL-1477 Hide empty token accounts

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { setEnvUnsafe } from "@ledgerhq/live-common/lib/env";
 import type { Currency } from "@ledgerhq/live-common/lib/types";
 
 export type CurrencySettings = {
@@ -108,13 +107,7 @@ export const switchCountervalueFirst = () => ({
   type: "SETTINGS_SWITCH_COUNTERVALUE_FIRST",
 });
 
-export const setHideEmptyTokenAccounts = (hideEmptyTokenAccounts: boolean) => (
-  dispatch: *,
-) => {
-  if (setEnvUnsafe("HIDE_EMPTY_TOKEN_ACCOUNTS", hideEmptyTokenAccounts)) {
-    dispatch({
-      type: "SETTINGS_HIDE_EMPTY_TOKEN_ACCOUNTS",
-      hideEmptyTokenAccounts,
-    });
-  }
-};
+export const setHideEmptyTokenAccounts = (hideEmptyTokenAccounts: boolean) => ({
+  type: "SETTINGS_HIDE_EMPTY_TOKEN_ACCOUNTS",
+  hideEmptyTokenAccounts,
+});

--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -1,5 +1,6 @@
 // @flow
 
+import { setEnvUnsafe } from "@ledgerhq/live-common/lib/env";
 import type { Currency } from "@ledgerhq/live-common/lib/types";
 
 export type CurrencySettings = {
@@ -106,3 +107,14 @@ export const installAppFirstTime = () => ({
 export const switchCountervalueFirst = () => ({
   type: "SETTINGS_SWITCH_COUNTERVALUE_FIRST",
 });
+
+export const setHideEmptyTokenAccounts = (hideEmptyTokenAccounts: boolean) => (
+  dispatch: *,
+) => {
+  if (setEnvUnsafe("HIDE_EMPTY_TOKEN_ACCOUNTS", hideEmptyTokenAccounts)) {
+    dispatch({
+      type: "SETTINGS_HIDE_EMPTY_TOKEN_ACCOUNTS",
+      hideEmptyTokenAccounts,
+    });
+  }
+};

--- a/src/components/SetEnvsFromSettings.js
+++ b/src/components/SetEnvsFromSettings.js
@@ -1,0 +1,35 @@
+// @flow
+import { PureComponent } from "react";
+import { connect } from "react-redux";
+import { createStructuredSelector } from "reselect";
+import { setEnvUnsafe } from "@ledgerhq/live-common/lib/env";
+import { hideEmptyTokenAccountsEnabledSelector } from "../reducers/settings";
+
+const mapStateToProps = createStructuredSelector({
+  hideEmptyTokenAccountsEnabled: hideEmptyTokenAccountsEnabledSelector,
+});
+
+class SetEnvsFromSettings extends PureComponent<{
+  hideEmptyTokenAccountsEnabled: boolean,
+}> {
+  apply() {
+    const { hideEmptyTokenAccountsEnabled } = this.props;
+
+    setEnvUnsafe("HIDE_EMPTY_TOKEN_ACCOUNTS", hideEmptyTokenAccountsEnabled);
+  }
+
+  componentDidMount() {
+    this.apply();
+  }
+
+  // No componentDidUpdate() here.
+  // The env needs to be set in the action itself, before dispatch.
+  // Otherwise components connected to the related setting
+  // would re-render before the env is effectively changed.
+
+  render() {
+    return null;
+  }
+}
+
+export default connect(mapStateToProps)(SetEnvsFromSettings);

--- a/src/components/SetEnvsFromSettings.js
+++ b/src/components/SetEnvsFromSettings.js
@@ -22,10 +22,9 @@ class SetEnvsFromSettings extends PureComponent<{
     this.apply();
   }
 
-  // No componentDidUpdate() here.
-  // The env needs to be set in the action itself, before dispatch.
-  // Otherwise components connected to the related setting
-  // would re-render before the env is effectively changed.
+  componentDidUpdate() {
+    this.apply();
+  }
 
   render() {
     return null;

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ import { OnboardingContextProvider } from "./screens/Onboarding/onboardingContex
 import HookAnalytics from "./analytics/HookAnalytics";
 import HookSentry from "./components/HookSentry";
 import AppContainer from "./navigators";
+import SetEnvsFromSettings from "./components/SetEnvsFromSettings"
 
 // useScreens();
 const styles = StyleSheet.create({
@@ -129,6 +130,7 @@ export default class Root extends Component<
             ready ? (
               <Fragment>
                 <StyledStatusBar />
+                <SetEnvsFromSettings />
                 <HookSentry />
                 <HookAnalytics store={store} />
                 <AuthPass>

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ import { OnboardingContextProvider } from "./screens/Onboarding/onboardingContex
 import HookAnalytics from "./analytics/HookAnalytics";
 import HookSentry from "./components/HookSentry";
 import AppContainer from "./navigators";
-import SetEnvsFromSettings from "./components/SetEnvsFromSettings"
+import SetEnvsFromSettings from "./components/SetEnvsFromSettings";
 
 // useScreens();
 const styles = StyleSheet.create({

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -733,7 +733,9 @@
         "bullet2": "Ledger Live version, OS region, language and region"
       },
       "termsOfUse": "Terms of use",
-      "termsOfUseDesc": "By continuing you acknowledge that you have read and agree to the <1>Terms of Use</1> and <3>Privacy Policy</3>."
+      "termsOfUseDesc": "By continuing you acknowledge that you have read and agree to the <1>Terms of Use</1> and <3>Privacy Policy</3>.",
+      "hideEmptyTokenAccounts": "Hide empty token accounts",
+      "hideEmptyTokenAccountsDesc": "Hide token accounts with zero balance on the Accounts page."
     },
     "cryptoAssets": {
       "header": "Crypto assets",

--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -9,8 +9,6 @@ import {
   importAccountsReduce,
 } from "@ledgerhq/live-common/lib/account";
 import accountModel from "../logic/accountModel";
-// eslint-disable-next-line import/no-cycle
-import { hideEmptyTokenAccountsEnabledSelector } from "./settings";
 import { UP_TO_DATE_THRESHOLD } from "../constants";
 
 export type AccountsState = {
@@ -94,8 +92,7 @@ export const flattenAccountsSelector = createSelector(
 // $FlowFixMe
 export const flattenAccountsEnforceHideEmptyTokenSelector = createSelector(
   accountsSelector,
-  hideEmptyTokenAccountsEnabledSelector,
-  (accounts, _) =>
+  accounts =>
     flattenAccounts(accounts, { enforceHideEmptyTokenAccounts: true }),
 );
 

--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -9,6 +9,8 @@ import {
   importAccountsReduce,
 } from "@ledgerhq/live-common/lib/account";
 import accountModel from "../logic/accountModel";
+// eslint-disable-next-line import/no-cycle
+import { hideEmptyTokenAccountsEnabledSelector } from "./settings";
 import { UP_TO_DATE_THRESHOLD } from "../constants";
 
 export type AccountsState = {
@@ -87,6 +89,14 @@ export const accountsSelector = (s: *): Account[] => s.accounts.active;
 export const flattenAccountsSelector = createSelector(
   accountsSelector,
   flattenAccounts,
+);
+
+// $FlowFixMe
+export const flattenAccountsEnforceHideEmptyTokenSelector = createSelector(
+  accountsSelector,
+  hideEmptyTokenAccountsEnabledSelector,
+  (accounts, _) =>
+    flattenAccounts(accounts, { enforceHideEmptyTokenAccounts: true }),
 );
 
 // $FlowFixMe

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -68,6 +68,7 @@ export type SettingsState = {
   readOnlyModeEnabled: boolean,
   experimentalUSBEnabled: boolean,
   countervalueFirst: boolean,
+  hideEmptyTokenAccounts: boolean,
 };
 
 const INITIAL_STATE: SettingsState = {
@@ -86,6 +87,7 @@ const INITIAL_STATE: SettingsState = {
   readOnlyModeEnabled: !Config.DISABLE_READ_ONLY,
   experimentalUSBEnabled: false,
   countervalueFirst: false,
+  hideEmptyTokenAccounts: false,
 };
 
 const pairHash = (from, to) => `${from.ticker}_${to.ticker}`;
@@ -218,6 +220,11 @@ const handlers: Object = {
     ...state,
     countervalueFirst: !state.countervalueFirst,
   }),
+
+  SETTINGS_HIDE_EMPTY_TOKEN_ACCOUNTS: (state, { hideEmptyTokenAccounts }) => ({
+    ...state,
+    hideEmptyTokenAccounts,
+  }),
 };
 
 const storeSelector = (state: *): SettingsState => state.settings;
@@ -344,5 +351,8 @@ export const exportSettingsSelector = createSelector(
     developerModeEnabled,
   }),
 );
+
+export const hideEmptyTokenAccountsEnabledSelector = (state: State) =>
+  state.settings.hideEmptyTokenAccounts;
 
 export default handleActions(handlers, INITIAL_STATE);

--- a/src/screens/Account/TokenAccountsList.js
+++ b/src/screens/Account/TokenAccountsList.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import take from "lodash/take";
 import { FlatList, Platform, StyleSheet, View } from "react-native";
@@ -12,14 +12,11 @@ import { createStructuredSelector } from "reselect";
 import { listTokenAccounts } from "@ledgerhq/live-common/lib/account";
 import { hideEmptyTokenAccountsEnabledSelector } from "../../reducers/settings";
 import TokenRow from "../../components/TokenRow";
+import withEnv from "../../logic/withEnv";
 import colors from "../../colors";
 import LText from "../../components/LText";
 import Button from "../../components/Button";
 import Touchable from "../../components/Touchable";
-
-const mapStateToProps = createStructuredSelector({
-  hideEmptyTokenAccountsEnabled: hideEmptyTokenAccountsEnabledSelector,
-});
 
 const keyExtractor = o => o.id;
 
@@ -201,3 +198,4 @@ const TokenAccountsList = ({
 };
 
 export default withNavigation(TokenAccountsList);
+export default withEnv("HIDE_EMPTY_TOKEN_ACCOUNTS")(TokenAccountsList);

--- a/src/screens/Account/TokenAccountsList.js
+++ b/src/screens/Account/TokenAccountsList.js
@@ -1,6 +1,7 @@
 // @flow
 
-import React, { useCallback } from "react";
+import React, { useCallback, useState } from "react";
+import { compose } from "redux";
 import { Trans } from "react-i18next";
 import take from "lodash/take";
 import { FlatList, Platform, StyleSheet, View } from "react-native";
@@ -8,9 +9,7 @@ import type { TokenAccount, Account } from "@ledgerhq/live-common/lib/types";
 import Icon from "react-native-vector-icons/dist/FontAwesome";
 import MaterialIcon from "react-native-vector-icons/dist/MaterialIcons";
 import { withNavigation } from "react-navigation";
-import { createStructuredSelector } from "reselect";
 import { listTokenAccounts } from "@ledgerhq/live-common/lib/account";
-import { hideEmptyTokenAccountsEnabledSelector } from "../../reducers/settings";
 import TokenRow from "../../components/TokenRow";
 import withEnv from "../../logic/withEnv";
 import colors from "../../colors";
@@ -87,6 +86,8 @@ const TokenAccountsList = ({
   accountId: string,
 }) => {
   const [isCollapsed, setCollapsed] = useState(true);
+  const tokenAccounts = listTokenAccounts(parentAccount);
+
   const renderHeader = useCallback(
     () => (
       <View style={styles.header}>
@@ -173,8 +174,6 @@ const TokenAccountsList = ({
     );
   }, [isCollapsed, navigation, tokenAccounts, accountId]);
 
-  const tokenAccounts = listTokenAccounts(parentAccount);
-
   const renderItem = useCallback(
     ({ item }) => (
       <Card>
@@ -197,5 +196,7 @@ const TokenAccountsList = ({
   );
 };
 
-export default withNavigation(TokenAccountsList);
-export default withEnv("HIDE_EMPTY_TOKEN_ACCOUNTS")(TokenAccountsList);
+export default compose(
+  withNavigation,
+  withEnv("HIDE_EMPTY_TOKEN_ACCOUNTS"),
+)(TokenAccountsList);

--- a/src/screens/Account/TokenAccountsList.js
+++ b/src/screens/Account/TokenAccountsList.js
@@ -4,15 +4,22 @@ import React, { useCallback, useState } from "react";
 import { Trans } from "react-i18next";
 import take from "lodash/take";
 import { FlatList, Platform, StyleSheet, View } from "react-native";
-import type { TokenAccount } from "@ledgerhq/live-common/lib/types";
+import type { TokenAccount, Account } from "@ledgerhq/live-common/lib/types";
 import Icon from "react-native-vector-icons/dist/FontAwesome";
-import { withNavigation } from "react-navigation";
 import MaterialIcon from "react-native-vector-icons/dist/MaterialIcons";
+import { withNavigation } from "react-navigation";
+import { createStructuredSelector } from "reselect";
+import { listTokenAccounts } from "@ledgerhq/live-common/lib/account";
+import { hideEmptyTokenAccountsEnabledSelector } from "../../reducers/settings";
 import TokenRow from "../../components/TokenRow";
 import colors from "../../colors";
 import LText from "../../components/LText";
 import Button from "../../components/Button";
 import Touchable from "../../components/Touchable";
+
+const mapStateToProps = createStructuredSelector({
+  hideEmptyTokenAccountsEnabled: hideEmptyTokenAccountsEnabledSelector,
+});
 
 const keyExtractor = o => o.id;
 
@@ -72,12 +79,12 @@ const Card = ({ children }: { children: any }) => (
 );
 
 const TokenAccountsList = ({
-  tokenAccounts,
+  parentAccount,
   onAccountPress,
   navigation,
   accountId,
 }: {
-  tokenAccounts: TokenAccount[],
+  parentAccount: Account,
   onAccountPress: TokenAccount => *,
   navigation: *,
   accountId: string,
@@ -168,6 +175,8 @@ const TokenAccountsList = ({
       </Card>
     );
   }, [isCollapsed, navigation, tokenAccounts, accountId]);
+
+  const tokenAccounts = listTokenAccounts(parentAccount);
 
   const renderItem = useCallback(
     ({ item }) => (

--- a/src/screens/Account/index.js
+++ b/src/screens/Account/index.js
@@ -220,7 +220,7 @@ class AccountScreen extends PureComponent<Props, State> {
           <TokenAccountsList
             accountId={account.id}
             onAccountPress={this.onAccountPress}
-            tokenAccounts={account.tokenAccounts}
+            parentAccount={account}
           />
         ) : null}
       </View>

--- a/src/screens/Accounts/AccountRow.js
+++ b/src/screens/Accounts/AccountRow.js
@@ -3,6 +3,7 @@ import React, { Fragment, PureComponent } from "react";
 import { View, StyleSheet, Platform } from "react-native";
 import { Trans } from "react-i18next";
 import { RectButton } from "react-native-gesture-handler";
+import { compose } from "redux";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";
 import { listTokenAccounts } from "@ledgerhq/live-common/lib/account";
@@ -16,15 +17,14 @@ import colors from "../../colors";
 import { isUpToDateAccountSelector } from "../../reducers/accounts";
 import { accountSyncStateSelector } from "../../reducers/bridgeSync";
 import type { AsyncState } from "../../reducers/bridgeSync";
-import { hideEmptyTokenAccountsEnabledSelector } from "../../reducers/settings";
 import AccountSyncStatus from "./AccountSyncStatus";
 import Button from "../../components/Button";
 import TokenRow from "../../components/TokenRow";
+import withEnv from "../../logic/withEnv";
 
 const mapStateToProps = createStructuredSelector({
   syncState: accountSyncStateSelector,
   isUpToDateAccount: isUpToDateAccountSelector,
-  hideEmptyTokenAccountsEnabled: hideEmptyTokenAccountsEnabledSelector,
 });
 
 type Props = {
@@ -188,7 +188,10 @@ const AccountCv = ({ children }: { children: * }) => (
   </LText>
 );
 
-export default connect(mapStateToProps)(AccountRow);
+export default compose(
+  connect(mapStateToProps),
+  withEnv("HIDE_EMPTY_TOKEN_ACCOUNTS"),
+)(AccountRow);
 
 const styles = StyleSheet.create({
   button: {

--- a/src/screens/Accounts/AccountRow.js
+++ b/src/screens/Accounts/AccountRow.js
@@ -5,6 +5,7 @@ import { Trans } from "react-i18next";
 import { RectButton } from "react-native-gesture-handler";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";
+import { listTokenAccounts } from "@ledgerhq/live-common/lib/account";
 import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import Icon from "react-native-vector-icons/dist/FontAwesome";
 import LText from "../../components/LText";
@@ -15,6 +16,7 @@ import colors from "../../colors";
 import { isUpToDateAccountSelector } from "../../reducers/accounts";
 import { accountSyncStateSelector } from "../../reducers/bridgeSync";
 import type { AsyncState } from "../../reducers/bridgeSync";
+import { hideEmptyTokenAccountsEnabledSelector } from "../../reducers/settings";
 import AccountSyncStatus from "./AccountSyncStatus";
 import Button from "../../components/Button";
 import TokenRow from "../../components/TokenRow";
@@ -22,6 +24,7 @@ import TokenRow from "../../components/TokenRow";
 const mapStateToProps = createStructuredSelector({
   syncState: accountSyncStateSelector,
   isUpToDateAccount: isUpToDateAccountSelector,
+  hideEmptyTokenAccountsEnabled: hideEmptyTokenAccountsEnabledSelector,
 });
 
 type Props = {
@@ -70,6 +73,7 @@ class AccountRow extends PureComponent<Props, State> {
 
   render() {
     const { account, isUpToDateAccount, syncState } = this.props;
+    const tokenAccounts = listTokenAccounts(account);
 
     return (
       <View style={styles.root}>
@@ -77,7 +81,7 @@ class AccountRow extends PureComponent<Props, State> {
           style={[
             styles.accountRowCard,
             {
-              elevation: account.tokenAccounts && this.state.collapsed ? 2 : 1,
+              elevation: tokenAccounts && this.state.collapsed ? 2 : 1,
             },
           ]}
         >
@@ -123,7 +127,7 @@ class AccountRow extends PureComponent<Props, State> {
               </View>
             </View>
           </RectButton>
-          {account.tokenAccounts && account.tokenAccounts.length !== 0 ? (
+          {tokenAccounts.length !== 0 ? (
             <Fragment>
               <View
                 style={[
@@ -131,7 +135,7 @@ class AccountRow extends PureComponent<Props, State> {
                   { display: this.state.collapsed ? "none" : "flex" },
                 ]}
               >
-                {account.tokenAccounts.map((tkn, i) => (
+                {tokenAccounts.map((tkn, i) => (
                   <TokenRow
                     nested
                     key={i}
@@ -152,9 +156,7 @@ class AccountRow extends PureComponent<Props, State> {
                           : "accounts.row.hideTokens"
                       }
                       values={{
-                        length: account.tokenAccounts
-                          ? account.tokenAccounts.length
-                          : 0,
+                        length: tokenAccounts.length,
                       }}
                     />
                   }
@@ -172,9 +174,7 @@ class AccountRow extends PureComponent<Props, State> {
             </Fragment>
           ) : null}
         </View>
-        {!!this.state.collapsed &&
-        account.tokenAccounts &&
-        account.tokenAccounts.length ? (
+        {!!this.state.collapsed && tokenAccounts.length ? (
           <View style={styles.tokenAccountIndicator} />
         ) : null}
       </View>

--- a/src/screens/SendFunds/01-SelectAccount.js
+++ b/src/screens/SendFunds/01-SelectAccount.js
@@ -12,7 +12,7 @@ import type { TokenAccount, Account } from "@ledgerhq/live-common/lib/types";
 
 import { isAccountEmpty } from "@ledgerhq/live-common/lib/account";
 import {
-  flattenAccountsSelector,
+  flattenAccountsEnforceHideEmptyTokenSelector,
   accountsSelector,
 } from "../../reducers/accounts";
 import colors from "../../colors";
@@ -120,7 +120,7 @@ class SendFundsSelectAccount extends Component<Props, State> {
 }
 
 const mapStateToProps = createStructuredSelector({
-  allAccounts: flattenAccountsSelector,
+  allAccounts: flattenAccountsEnforceHideEmptyTokenSelector,
   accounts: accountsSelector,
 });
 

--- a/src/screens/SendFunds/01-SelectAccount.js
+++ b/src/screens/SendFunds/01-SelectAccount.js
@@ -6,6 +6,7 @@ import { SafeAreaView, FlatList } from "react-navigation";
 import type { NavigationScreenProp } from "react-navigation";
 import { createStructuredSelector } from "reselect";
 import { connect } from "react-redux";
+import { compose } from "redux";
 import i18next from "i18next";
 import { translate, Trans } from "react-i18next";
 import type { TokenAccount, Account } from "@ledgerhq/live-common/lib/types";
@@ -15,6 +16,7 @@ import {
   flattenAccountsEnforceHideEmptyTokenSelector,
   accountsSelector,
 } from "../../reducers/accounts";
+import withEnv from "../../logic/withEnv";
 import colors from "../../colors";
 import { TrackScreen } from "../../analytics";
 import LText from "../../components/LText";
@@ -161,4 +163,8 @@ const styles = StyleSheet.create({
   },
 });
 
-export default translate()(connect(mapStateToProps)(SendFundsSelectAccount));
+export default compose(
+  connect(mapStateToProps),
+  withEnv("HIDE_EMPTY_TOKEN_ACCOUNTS"),
+  translate(),
+)(SendFundsSelectAccount);

--- a/src/screens/Settings/General/HideEmptyTokenAccountsRow.js
+++ b/src/screens/Settings/General/HideEmptyTokenAccountsRow.js
@@ -1,20 +1,17 @@
 /* @flow */
 import React, { PureComponent } from "react";
 import { Trans } from "react-i18next";
+import { compose } from "redux";
 import { connect } from "react-redux";
 import { Switch } from "react-native";
-import { createStructuredSelector } from "reselect";
 import SettingsRow from "../../../components/SettingsRow";
 import { setHideEmptyTokenAccounts } from "../../../actions/settings";
-import { hideEmptyTokenAccountsEnabledSelector } from "../../../reducers/settings";
+import withEnv from "../../../logic/withEnv";
 
 type Props = {
   hideEmptyTokenAccountsEnabled: boolean,
   setHideEmptyTokenAccounts: boolean => void,
 };
-const mapStateToProps = createStructuredSelector({
-  hideEmptyTokenAccountsEnabled: hideEmptyTokenAccountsEnabledSelector,
-});
 
 const mapDispatchToProps = {
   setHideEmptyTokenAccounts,
@@ -46,7 +43,10 @@ class HideEmptyTokenAccountsRow extends PureComponent<Props> {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
+export default compose(
+  withEnv("HIDE_EMPTY_TOKEN_ACCOUNTS", "hideEmptyTokenAccountsEnabled"),
+  connect(
+    null,
+    mapDispatchToProps,
+  ),
 )(HideEmptyTokenAccountsRow);

--- a/src/screens/Settings/General/HideEmptyTokenAccountsRow.js
+++ b/src/screens/Settings/General/HideEmptyTokenAccountsRow.js
@@ -1,0 +1,52 @@
+/* @flow */
+import React, { PureComponent } from "react";
+import { Trans } from "react-i18next";
+import { connect } from "react-redux";
+import { Switch } from "react-native";
+import { createStructuredSelector } from "reselect";
+import SettingsRow from "../../../components/SettingsRow";
+import { setHideEmptyTokenAccounts } from "../../../actions/settings";
+import { hideEmptyTokenAccountsEnabledSelector } from "../../../reducers/settings";
+
+type Props = {
+  hideEmptyTokenAccountsEnabled: boolean,
+  setHideEmptyTokenAccounts: boolean => void,
+};
+const mapStateToProps = createStructuredSelector({
+  hideEmptyTokenAccountsEnabled: hideEmptyTokenAccountsEnabledSelector,
+});
+
+const mapDispatchToProps = {
+  setHideEmptyTokenAccounts,
+};
+
+class HideEmptyTokenAccountsRow extends PureComponent<Props> {
+  render() {
+    const {
+      hideEmptyTokenAccountsEnabled,
+      setHideEmptyTokenAccounts,
+      ...props
+    } = this.props;
+    return (
+      <SettingsRow
+        event="HideEmptyTokenAccountsRow"
+        title={<Trans i18nKey="settings.display.hideEmptyTokenAccounts" />}
+        desc={<Trans i18nKey="settings.display.hideEmptyTokenAccountsDesc" />}
+        onPress={null}
+        alignedTop
+        {...props}
+      >
+        <Switch
+          style={{ opacity: 0.99 }}
+          value={hideEmptyTokenAccountsEnabled}
+          onValueChange={setHideEmptyTokenAccounts}
+        />
+      </SettingsRow>
+    );
+  }
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(HideEmptyTokenAccountsRow);

--- a/src/screens/Settings/General/index.js
+++ b/src/screens/Settings/General/index.js
@@ -11,6 +11,7 @@ import CountervalueSettingsRow from "./CountervalueSettingsRow";
 import AuthSecurityToggle from "./AuthSecurityToggle";
 import ReportErrorsRow from "./ReportErrorsRow";
 import AnalyticsRow from "./AnalyticsRow";
+import HideEmptyTokenAccountsRow from "./HideEmptyTokenAccountsRow";
 
 class GeneralSettings extends PureComponent<{
   navigation: NavigationScreenProp<*>,
@@ -25,6 +26,7 @@ class GeneralSettings extends PureComponent<{
       <ScrollView contentContainerStyle={styles.root}>
         <TrackScreen category="Settings" name="General" />
         <CountervalueSettingsRow navigation={navigation} />
+        <HideEmptyTokenAccountsRow />
         <AuthSecurityToggle navigation={navigation} />
         <ReportErrorsRow />
         <AnalyticsRow />


### PR DESCRIPTION
Adds a toggle in the _General_ settings page to hide token accounts with 0 balance.

This selectively hides the accounts only in some part of the UI:

- Accounts screen
- Token list in parent account screen
- Send modal (including search)

Other parts shouldn't be affected by this toggle, like (non exhaustive list):
- Operations
- Operation details
- Receive flow
- …

HODL for now until #965 gets merged

### Type

Feature

### Context

LedgerHQ/ledger-live-common#294
LedgerHQ/ledger-live-desktop#2198
https://ledgerhq.atlassian.net/browse/LL-1477

### Parts of app affected

- Accounts screen
- Token list in parent account screen
- Send modal (including search)
