### PR TITLE
LL-1708 Allow user to go back to operation details from suboperation

### DIFF
--- a/src/components/OperationRow.js
+++ b/src/components/OperationRow.js
@@ -32,6 +32,7 @@ type Props = {
   navigation: *,
   multipleAccounts?: boolean,
   isLast: boolean,
+  isSubOperation?: boolean,
 };
 
 const placeholderProps = {
@@ -45,12 +46,21 @@ class OperationRow extends PureComponent<Props, *> {
   };
 
   goToOperationDetails = () => {
-    const { navigation, account, parentAccount, operation } = this.props;
-    navigation.navigate("OperationDetails", {
+    const {
+      navigation,
+      account,
+      parentAccount,
+      operation,
+      isSubOperation,
+    } = this.props;
+    const params = {
       accountId: account.id,
       parentId: parentAccount && parentAccount.id,
       operation, // FIXME we should pass a operationId instead because data can changes over time.
-    });
+      isSubOperation,
+    };
+
+    navigation.push("OperationDetails", params);
   };
 
   render() {

--- a/src/screens/OperationDetails/Content.js
+++ b/src/screens/OperationDetails/Content.js
@@ -180,6 +180,7 @@ class Content extends PureComponent<Props, State> {
 
               return (
                 <OperationRow
+                  isSubOperation
                   key={op.id}
                   operation={op}
                   parentAccount={account}

--- a/src/screens/OperationDetails/index.js
+++ b/src/screens/OperationDetails/index.js
@@ -3,7 +3,7 @@ import React, { PureComponent } from "react";
 import i18next from "i18next";
 import { View, StyleSheet } from "react-native";
 // $FlowFixMe
-import { SafeAreaView, ScrollView } from "react-navigation";
+import { HeaderBackButton, SafeAreaView, ScrollView } from "react-navigation";
 import { connect } from "react-redux";
 import { translate } from "react-i18next";
 import type {
@@ -22,21 +22,50 @@ import { TrackScreen } from "../../analytics";
 import Footer from "./Footer";
 import Content from "./Content";
 import colors from "../../colors";
+import HeaderBackImage from "../../components/HeaderBackImage";
 
 type Props = {
   account: ?(Account | TokenAccount),
   parentAccount: ?Account,
-  navigation: NavigationScreenProp<{
-    params: {
-      accountId: string,
-      operation: Operation,
-    },
-  }>,
+  navigation: Navigation,
 };
+
+type Navigation = NavigationScreenProp<{
+  params: {
+    accountId: string,
+    operation: Operation,
+  },
+}>;
+
+const BackButton = ({ navigation }: { navigation: Navigation }) => (
+  <HeaderBackButton
+    tintColor={colors.grey}
+    onPress={() => {
+      navigation.goBack();
+    }}
+  >
+    <HeaderBackImage />
+  </HeaderBackButton>
+);
+
 class OperationDetails extends PureComponent<Props, *> {
-  static navigationOptions = {
-    title: i18next.t("operationDetails.title"),
-    headerLeft: null,
+  static navigationOptions = ({ navigation }) => {
+    const {
+      params: { isSubOperation },
+    } = navigation.state;
+
+    if (isSubOperation) {
+      return {
+        title: i18next.t("operationDetails.title"),
+        headerLeft: <BackButton navigation={navigation} />,
+        headerRight: null,
+      };
+    }
+
+    return {
+      title: i18next.t("operationDetails.title"),
+      headerLeft: null,
+    };
   };
 
   render() {


### PR DESCRIPTION
Overrides the left/right buttons on operation details if we are in a suboperation allowing the user to go back to source operation without closing the whole thing.

![goback](https://user-images.githubusercontent.com/4631227/62150023-42e0a780-b2fd-11e9-946b-9c99e2b8f60e.gif)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1708

### Parts of the app aff

ected / Test plan

Operation details for an operation with suboperations
