### PR TITLE
fixed token colours on asset distribs

### DIFF
--- a/src/components/CurrencyRate.js
+++ b/src/components/CurrencyRate.js
@@ -8,6 +8,7 @@ import type {
   CryptoCurrency,
   TokenCurrency,
 } from "@ledgerhq/live-common/lib/types/currencies";
+import { getCurrencyColor } from "@ledgerhq/live-common/lib/currencies";
 import colors from "../colors";
 import LText from "./LText";
 import CounterValue from "./CounterValue";
@@ -28,7 +29,7 @@ class CurrencyRate extends PureComponent<Props> {
     const { currency, fontStyle, iconSize } = this.props;
     const one = new BigNumber(10 ** currency.units[0].magnitude);
     // $FlowFixMe
-    const color = currency.color;
+    const color = getCurrencyColor(currency);
 
     return (
       <View style={styles.wrapper}>

--- a/src/screens/Distribution/DistributionCard.js
+++ b/src/screens/Distribution/DistributionCard.js
@@ -6,6 +6,8 @@ import type {
   CryptoCurrency,
   TokenCurrency,
 } from "@ledgerhq/live-common/lib/types/currencies";
+import { getCurrencyColor } from "@ledgerhq/live-common/lib/currencies";
+
 import colors from "../../colors";
 import LText from "../../components/LText";
 import CurrencyUnitValue from "../../components/CurrencyUnitValue";
@@ -36,8 +38,8 @@ class DistributionCard extends PureComponent<Props> {
       item: { currency, amount, distribution },
       highlighting,
     } = this.props;
-    // $FlowFixMe
-    const color = currency.color || colors.live;
+
+    const color = getCurrencyColor(currency);
     const percentage = (Math.floor(distribution * 10000) / 100).toFixed(2);
 
     return (

--- a/src/screens/Distribution/RingChart.js
+++ b/src/screens/Distribution/RingChart.js
@@ -5,6 +5,7 @@ import { PanResponder, View } from "react-native";
 import type { PressEvent } from "react-native/Libraries/Types/CoreEventTypes";
 import * as d3shape from "d3-shape";
 import Svg, { Path, G, Circle } from "react-native-svg";
+import { getCurrencyColor } from "@ledgerhq/live-common/lib/currencies";
 import colors from "../../colors";
 import type { DistributionItem } from "./DistributionCard";
 
@@ -101,7 +102,7 @@ class RingChart extends PureComponent<Props> {
 
     const parsedItem = {
       // $FlowFixMe
-      color: item.currency.color || colors.live,
+      color: getCurrencyColor(item.currency),
       pathData,
       endAngle: data.angle + increment,
       id: item.currency.id,


### PR DESCRIPTION
Fixing distribution colours and usage of lib-common's `getCurrencyColor`

![image](https://user-images.githubusercontent.com/9251185/62289811-ffeb1500-b45f-11e9-98e6-dab70032d788.png)


### Type

Bug Fix

### Context

LL-1717

### Parts of the app affected / Test plan

Distribution screen