### PR TITLE
Uses live-common logic for addAccounts

### DIFF
--- a/src/actions/accounts.js
+++ b/src/actions/accounts.js
@@ -25,9 +25,13 @@ export const importAccounts = ({
   selectedAccounts,
 });
 
-export const addAccount = (account: Account) => ({
+export const replaceAccounts = (payload: {
+  scannedAccounts: Account[],
+  selectedIds: string[],
+  renamings: { [id: string]: string },
+}) => ({
   type: "ACCOUNTS_ADD",
-  account,
+  ...payload,
 });
 
 export type UpdateAccountWithUpdater = (

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -902,9 +902,18 @@
     },
     "imported": "Accounts successfully added",
     "sections": {
-      "accountsToImport": "Add existing account",
-      "addNewAccount": "Add new account",
-      "existing": "Accounts already in portfolio"
+      "importable": {
+        "title": "Add existing account"
+      },
+      "creatable": {
+        "title": "Add new account"
+      },
+      "imported": {
+        "title": "Accounts already in portfolio ({{length}})"
+      },
+      "migrate": {
+        "title": "Accounts to update"
+      }
     },
     "success": {
       "desc": "View your accounts or add more of them",

--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -4,6 +4,7 @@ import { createSelector } from "reselect";
 import uniq from "lodash/uniq";
 import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import {
+  addAccounts,
   flattenAccounts,
   importAccountsReduce,
 } from "@ledgerhq/live-common/lib/account";
@@ -25,8 +26,13 @@ const handlers: Object = {
     active: importAccountsReduce(s.active, { items, selectedAccounts }),
   }),
 
-  ACCOUNTS_ADD: (s, { account }) => ({
-    active: s.active.concat(account),
+  ACCOUNTS_ADD: (s, { scannedAccounts, selectedIds, renamings }) => ({
+    active: addAccounts({
+      existingAccounts: s.active,
+      scannedAccounts,
+      selectedIds,
+      renamings,
+    }),
   }),
 
   SET_ACCOUNTS: (


### PR DESCRIPTION
Reuse logic of live-common for the add accounts logic that have the logic for sections, have "accounts to migrate" section and also will correctly dedup the accounts.

### Type

bug fix / feature

### Context

LL-1716

### Parts of the app affected / Test plan

add accounts
