### PR TITLE
added a button to expand a shortened token list

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -586,6 +586,9 @@
     "tokens": {
       "contractAddress": "Contract address",
       "viewInExplorer": "View in explorer",
+      "seeMore": "See more Tokens",
+      "seeLess": "See less Tokens",
+      "addTokens": "Add tokens",
       "howTo": "To add tokens accounts, you need to <0>receive funds</0> through your <1>Ethereum address</1>."
     },
     "send": "Send",

--- a/src/screens/Account/index.js
+++ b/src/screens/Account/index.js
@@ -216,8 +216,9 @@ class AccountScreen extends PureComponent<Props, State> {
             parentId={parentAccount && parentAccount.id}
           />
         )}
-        {account.type === "Account" && account.tokenAccounts ? (
+        {!empty && account.type === "Account" && account.tokenAccounts ? (
           <TokenAccountsList
+            accountId={account.id}
             onAccountPress={this.onAccountPress}
             tokenAccounts={account.tokenAccounts}
           />


### PR DESCRIPTION
If an eth account has funds but no token, display a touchable.

If an account has 3 tokens or less , render the full list

If an account has more than 3 tokens, render a collapsable list

If an account has no funds and no token, display a generic empty state

![image](https://user-images.githubusercontent.com/9251185/62639829-a5aaf200-b940-11e9-9821-c044b67551f0.png)

### Type

UI Polish

### Context

N / A

### Parts of the app affected / Test plan

Account -> Token list