### PR TITLE
LL-1807 Fixes crash on empty state rendering on Add Account flow

### DIFF
--- a/src/components/SelectableAccountsList.js
+++ b/src/components/SelectableAccountsList.js
@@ -38,7 +38,7 @@ type ListProps = {
   selectedIds: string[],
   isDisabled?: boolean,
   forceSelected?: boolean,
-  EmptyState?: React$ComponentType<*>,
+  emptyState?: React$Node,
   header: React$Node,
   style?: *,
   index: number,
@@ -75,7 +75,7 @@ class SelectableAccountsList extends Component<ListProps> {
       selectedIds,
       isDisabled,
       forceSelected,
-      EmptyState,
+      emptyState,
       header,
       showHint,
       index,
@@ -108,7 +108,7 @@ class SelectableAccountsList extends Component<ListProps> {
             onPress={onPressAccount}
           />
         ))}
-        {accounts.length === 0 && EmptyState ? <EmptyState /> : null}
+        {accounts.length === 0 && emptyState ? emptyState : null}
       </View>
     );
   }

--- a/src/screens/AddAccounts/03-Accounts.js
+++ b/src/screens/AddAccounts/03-Accounts.js
@@ -300,7 +300,7 @@ class AddAccountsAccounts extends PureComponent<Props, State> {
               onSelectAll={!selectable ? undefined : this.selectAll}
               onUnselectAll={!selectable ? undefined : this.unselectAll}
               selectedIds={selectedIds}
-              EmptyState={emptyTexts[id]}
+              emptyState={emptyTexts[id]}
               isDisabled={!selectable}
               forceSelected={id === "existing"}
             />


### PR DESCRIPTION
There was a fun bug in the add account flow when we tried rendering an empty state in would sometimes cause a crash. This addresses it.

### Type

Bug Fix

### Parts of the app affected / Test plan

Add account flow. To replicate this *before* using this fix, you can use mock and add ethereum accounts on the device, it should crash after finding the first two accounts. On this branch it should work as expected.
