### PR TITLE
LL-1823: Fees should use the parent account currency for token TX

### DIFF
--- a/src/screens/OperationDetails/Content.js
+++ b/src/screens/OperationDetails/Content.js
@@ -73,7 +73,9 @@ class Content extends PureComponent<Props, State> {
     const { account, parentAccount, operation, currencySettings } = this.props;
     const mainAccount = getMainAccount(account, parentAccount);
     const unit = getAccountUnit(account);
+    const parentUnit = getAccountUnit(mainAccount);
     const currency = getAccountCurrency(account);
+    const parentCurrency = getAccountCurrency(mainAccount);
     const amount = getOperationAmountNumber(operation);
     const valueColor = amount.isNegative() ? colors.smoke : colors.green;
     const confirmations = operation.blockHeight
@@ -259,7 +261,7 @@ class Content extends PureComponent<Props, State> {
                 <LText style={styles.sectionValue} semiBold>
                   <CurrencyUnitValue
                     showCode
-                    unit={unit}
+                    unit={parentUnit}
                     value={operation.fee}
                   />
                 </LText>
@@ -272,7 +274,7 @@ class Content extends PureComponent<Props, State> {
                     disableRounding={true}
                     date={operation.date}
                     subMagnitude={1}
-                    currency={currency}
+                    currency={parentCurrency}
                     value={operation.fee}
                   />
                 </LText>


### PR DESCRIPTION
Token transactions dont use correct currency to display fees. This PR fixes that.

### :camera_flash: Screenshot

![https://uplr.it/d9003.png](https://uplr.it/d9003.png)

### :ok_hand: Type
Bug fix

### :mag: Context
LL-1823

### :clipboard: Parts of the app affected / Test plan
Operation details