### PR TITLE
LL-1786: Add ERC20 empty state

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -601,6 +601,7 @@
     "emptyState": {
       "title": "No crypto assets yet?",
       "desc": "Make sure the <1><0>{{managerAppName}}</0></1> app is installed and start receiving",
+        "descToken": "Make sure the <1><0>{{managerAppName}}</0></1> app is installed and start receiving <3><0>{{currencyTicker}}</0></3> and <5><0>{{tokenType}}</0> tokens</5>",
       "buttons": {
         "receiveFunds": "Receive"
       }

--- a/src/screens/Account/EmptyStateAccount.js
+++ b/src/screens/Account/EmptyStateAccount.js
@@ -5,6 +5,7 @@ import { View, Image, StyleSheet } from "react-native";
 import type { NavigationScreenProp } from "react-navigation";
 import type { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import { getMainAccount } from "@ledgerhq/live-common/lib/account";
+import { listTokenTypesForCryptoCurrency } from "@ledgerhq/live-common/lib/currencies";
 import colors from "../../colors";
 import LText from "../../components/LText";
 import Button from "../../components/Button";
@@ -26,6 +27,8 @@ class EmptyStateAccount extends PureComponent<{
   render() {
     const { account, parentAccount } = this.props;
     const mainAccount = getMainAccount(account, parentAccount);
+    const hasTokens = Array.isArray(mainAccount.tokenAccounts);
+
     return (
       <View style={styles.root}>
         <View style={styles.body}>
@@ -34,13 +37,36 @@ class EmptyStateAccount extends PureComponent<{
             <Trans i18nKey="account.emptyState.title" />
           </LText>
           <LText style={styles.desc}>
-            <Trans i18nKey="common:account.emptyState.desc">
-              {"Make sure the"}
-              <LText semiBold style={styles.managerAppName}>
-                {mainAccount.currency.managerAppName}
-              </LText>
-              {"app is installed and start receiving"}
-            </Trans>
+            {hasTokens ? (
+              <Trans i18nKey="common:account.emptyState.descToken">
+                {"Make sure the"}
+                <LText semiBold style={styles.managerAppName}>
+                  {mainAccount.currency.managerAppName}
+                </LText>
+                {"app is installed and start receiving"}
+                <LText semiBold style={styles.managerAppName}>
+                  {mainAccount.currency.ticker}
+                </LText>
+                {"and"}
+                <LText semiBold style={styles.managerAppName}>
+                  {account &&
+                    account.currency &&
+                    // $FlowFixMe
+                    listTokenTypesForCryptoCurrency(account.currency).join(
+                      ", ",
+                    )}
+                  {"tokens"}
+                </LText>
+              </Trans>
+            ) : (
+              <Trans i18nKey="common:account.emptyState.desc">
+                {"Make sure the"}
+                <LText semiBold style={styles.managerAppName}>
+                  {mainAccount.currency.managerAppName}
+                </LText>
+                {"app is installed and start receiving"}
+              </Trans>
+            )}
           </LText>
           <Button
             event="AccountEmptyStateReceive"


### PR DESCRIPTION
> :information_source: Desktop: https://github.com/LedgerHQ/ledger-live-desktop/pull/2299

This PR adds an empty state for ERC20.

### :camera_flash: Screenshot
![https://uplr.it/fc4db.png](https://uplr.it/fc4db.png)

### :ok_hand: Type
UX Polish

### :mag: Context
LL-1786

### Parts of the app affected / Test plan
Ethereum accout screen
Other account screens (check ERC20 CTA isnt displayed)