### PR TITLE
LL-1661: Allow searching by ticker

### DIFF
--- a/src/screens/ReceiveFunds/01-SelectAccount.js
+++ b/src/screens/ReceiveFunds/01-SelectAccount.js
@@ -24,7 +24,7 @@ import KeyboardView from "../../components/KeyboardView";
 import { formatSearchResults } from "../../helpers/formatAccountSearchResults";
 import type { SearchResult } from "../../helpers/formatAccountSearchResults";
 
-const SEARCH_KEYS = ["name", "unit.code", "token.name"];
+const SEARCH_KEYS = ["name", "unit.code", "token.name", "token.ticker"];
 
 type Navigation = NavigationScreenProp<{ params: {} }>;
 

--- a/src/screens/SendFunds/01-SelectAccount.js
+++ b/src/screens/SendFunds/01-SelectAccount.js
@@ -27,7 +27,7 @@ import KeyboardView from "../../components/KeyboardView";
 import { formatSearchResults } from "../../helpers/formatAccountSearchResults";
 import type { SearchResult } from "../../helpers/formatAccountSearchResults";
 
-const SEARCH_KEYS = ["name", "unit.code", "token.name"];
+const SEARCH_KEYS = ["name", "unit.code", "token.name", "token.ticker"];
 
 type Props = {
   accounts: Account[],


### PR DESCRIPTION
This PR allows searching by ticker in the account selection screen.

### :camera_flash: Screenshot
![https://uplr.it/1d420.png](https://uplr.it/1d420.png)

### :ok_hand: Type
UX improvement

### :mag: Context
LL-1661

### :clipboard: Parts of the app affected / Test plan
Account selection screens (Send / Receive funds)