### PR TITLE
LL-1836: More generic wording when connection fails

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -62,7 +62,7 @@
     },
     "CantOpenDevice": {
       "title": "Sorry, connection failed",
-      "description": "Your Ledger Nano X should be unlocked and within range"
+      "description": "Your Ledger device should be unlocked and within range"
     },
     "CantScanQRCode": {
       "title": "Couldn't scan this QR-code: auto-verification not supported by this address"

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -62,7 +62,7 @@
     },
     "CantOpenDevice": {
       "title": "Sorry, connection failed",
-      "description": "Your Ledger device should be unlocked and within range"
+      "description": "Your Ledger device should be unlocked and in range when using Bluetooth"
     },
     "CantScanQRCode": {
       "title": "Couldn't scan this QR-code: auto-verification not supported by this address"


### PR DESCRIPTION
This PR includes more generic wording (i.e. don't assume it's always a Nano X)

### :ok_hand: Type
Wording

### :mag: Context
LL-1836

### :clipboard: Parts of the app affected / Test plan
Can't open device error