### PR TITLE
LL-1848 Show architecture + version for android

### DIFF
--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -8,6 +8,10 @@ import { Platform } from "react-native";
 import analytics from "@segment/analytics-react-native";
 import VersionNumber from "react-native-version-number";
 import Locale from "react-native-locale";
+import {
+  getAndroidArchitecture,
+  getAndroidVersionCode,
+} from "../logic/cleanBuildVersion";
 import getOrCreateUser from "../user";
 import { analyticsEnabledSelector } from "../reducers/settings";
 import { knownDevicesSelector } from "../reducers/ble";
@@ -22,8 +26,11 @@ const extraProperties = store => {
   const state: State = store.getState();
   const { localeIdentifier, preferredLanguages } = Locale.constants();
   const devices = knownDevicesSelector(state);
+
   return {
     appVersion,
+    androidVersionCode: getAndroidVersionCode(VersionNumber.buildVersion),
+    androidArchitecture: getAndroidArchitecture(VersionNumber.buildVersion),
     environment: ANALYTICS_LOGS ? "development" : "production",
     localeIdentifier,
     preferredLanguage: preferredLanguages ? preferredLanguages[0] : null,

--- a/src/logic/cleanBuildVersion.js
+++ b/src/logic/cleanBuildVersion.js
@@ -1,0 +1,34 @@
+// @flow
+
+import { Platform } from "react-native";
+
+const mega = 1048576;
+export const getAndroidArchitecture = (buildVersion?: ?string) => {
+  const buildVersionNumber = parseInt(buildVersion, 10);
+  if (!buildVersionNumber) return "";
+
+  if (Platform.OS === "android" && buildVersionNumber) {
+    // https://github.com/LedgerHQ/ledger-live-mobile/blob/develop/android/app/build.gradle#L166
+    const platforms = ["armeabi-v7a", "x86", "arm64-v8a", "x86_64"];
+    return platforms[Math.floor(buildVersionNumber / mega) - 1];
+  }
+
+  return buildVersion;
+};
+
+export const getAndroidVersionCode = (buildVersion?: ?string) => {
+  const buildVersionNumber = parseInt(buildVersion, 10);
+  if (!buildVersionNumber) return "";
+
+  return Platform.OS === "android" && buildVersionNumber
+    ? buildVersionNumber % mega
+    : buildVersion;
+};
+
+export default (buildVersion?: ?string) => {
+  if (Platform.OS === "android" && buildVersion) {
+    return `${getAndroidArchitecture(buildVersion) ||
+      ""} ${getAndroidVersionCode(buildVersion) || ""}`;
+  }
+  return buildVersion;
+};

--- a/src/screens/SendFunds/ValidateOnDevice.js
+++ b/src/screens/SendFunds/ValidateOnDevice.js
@@ -176,15 +176,13 @@ class ValidateOnDevice extends PureComponent<Props, State> {
               unit={unit}
               value={useAllAmount && maxAmount ? maxAmount : amount}
             />
-            {
-              !fees.isZero() ? (
-                <DataRow
-                  label={<Trans i18nKey="send.validation.fees" />}
-                  unit={mainAccount.unit}
-                  value={fees}
-                />
-              ) : null
-            }
+            {!fees.isZero() ? (
+              <DataRow
+                label={<Trans i18nKey="send.validation.fees" />}
+                unit={mainAccount.unit}
+                value={fees}
+              />
+            ) : null}
           </View>
         </View>
 

--- a/src/screens/Settings/About/AppVersionRow.js
+++ b/src/screens/Settings/About/AppVersionRow.js
@@ -3,6 +3,7 @@ import React, { PureComponent } from "react";
 import VersionNumber from "react-native-version-number";
 import { Trans } from "react-i18next";
 import { View, StyleSheet } from "react-native";
+import cleanBuildVersion from "../../../logic/cleanBuildVersion";
 import SettingsRow from "../../../components/SettingsRow";
 import LText from "../../../components/LText";
 import colors from "../../../colors";
@@ -10,7 +11,8 @@ import colors from "../../../colors";
 class AppVersionRow extends PureComponent<*> {
   render() {
     const { appVersion, buildVersion } = VersionNumber;
-    const version = `${appVersion || ""} (${buildVersion || ""})`;
+    const version = `${appVersion || ""} (${cleanBuildVersion(buildVersion) ||
+      ""})`;
     return (
       <SettingsRow
         event="AppVersionRow"


### PR DESCRIPTION
<img width="624" alt="image" src="https://user-images.githubusercontent.com/4631227/64620334-f7351980-d3e3-11e9-9428-32d957e68a3a.png">


### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1848

### Parts of the app affected / Test plan

The about section of settings should reflect a compound value for the Version on Android. iOS should remain the same. Also make sure I'm not breaking the stats :trollface: 
