### PR TITLE
Remove references to old module, bump fork

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -176,9 +176,9 @@ android {
 }
 
 dependencies {
-    implementation project(':@ledgerhq_react-native-touch-id')
     // Make sure to keep android-jsc as the first
     implementation "org.webkit:android-jsc-intl:r241213"
+    implementation project(':@ledgerhq_react-native-touch-id')
     implementation project(':react-native-vector-icons')
     implementation project(':@react-native-community_netinfo')
     implementation project(':lottie-react-native')
@@ -196,7 +196,6 @@ dependencies {
     implementation project(':react-native-locale')
     implementation project(':react-native-sentry')
     implementation project(':react-native-splash-screen')
-    implementation project(':react-native-touch-id')
     implementation project(':react-native-ble-plx')
     implementation (project(':react-native-camera')) {
         exclude group: "com.google.android.gms"

--- a/android/app/src/main/java/com/ledger/live/MainApplication.java
+++ b/android/app/src/main/java/com/ledger/live/MainApplication.java
@@ -22,7 +22,6 @@ import org.reactnative.camera.RNCameraPackage;
 import io.fixd.rctlocale.RCTLocalePackage;
 import io.sentry.RNSentryPackage;
 import org.devio.rn.splashscreen.SplashScreenReactPackage;
-import com.rnfingerprint.FingerprintAuthPackage;
 import com.polidea.reactnativeble.BlePackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
@@ -55,7 +54,6 @@ public class MainApplication extends Application implements ReactApplication {
     protected List<ReactPackage> getPackages() {
       return Arrays.<ReactPackage>asList(
           new MainReactPackage(),
-            new FingerprintAuthPackage(),
             new VectorIconsPackage(),
             new NetInfoPackage(),
             new LottiePackage(),

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -37,8 +37,6 @@ include ':react-native-sentry'
 project(':react-native-sentry').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-sentry/android')
 include ':react-native-splash-screen'
 project(':react-native-splash-screen').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-splash-screen/android')
-include ':react-native-touch-id'
-project(':react-native-touch-id').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-touch-id/android')
 include ':react-native-ble-plx'
 project(':react-native-ble-plx').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-ble-plx/android')
 include ':react-native-version-number'

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@ledgerhq/react-native-hw-transport-ble": "4.68.4",
     "@ledgerhq/react-native-ledger-core": "^3.1.0-beta.3",
     "@ledgerhq/react-native-passcode-auth": "^2.0.0",
-    "@ledgerhq/react-native-touch-id": "^4.5.0",
+    "@ledgerhq/react-native-touch-id": "^4.6.3",
     "@react-native-community/netinfo": "^2.0.5",
     "@segment/analytics-ios": "github:LedgerHQ/analytics-ios#efb4cd1771dab568422473fd680ffb748b102f07",
     "@segment/analytics-react-native": "^0.1.0-beta.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -877,10 +877,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-passcode-auth/-/react-native-passcode-auth-2.0.0.tgz#18f8fcc64d72b410300de203c2ddf8b4ae2a7fc3"
   integrity sha512-ZsdtZQuyAp+50zJGvyBMJ/Zf3wq5PN/ipOND+CmQghILvvrDPOzK23ch49zjUqnJfMSuUwqLqJuuOm72Weofmg==
 
-"@ledgerhq/react-native-touch-id@^4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-touch-id/-/react-native-touch-id-4.5.0.tgz#51cd20dd5bfd4949ba405402c5c1581276b0c11f"
-  integrity sha512-4qGn/Qt25/Cb2g6+v+wc5AqOMOFsQEVwrcZVXMClnJnm+/TrQm0TuCsxyO0Y7/GYMdewS3mC0eVCSRXIOgPysA==
+"@ledgerhq/react-native-touch-id@^4.6.3":
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-touch-id/-/react-native-touch-id-4.6.3.tgz#cd7ef3d98874eaca11fc1cf9a058e0adf573a3e7"
+  integrity sha512-+gxjR1SmB/aTdiVgJCIPy3EWt2Rl6+LHnEBHyqElZF0M2FJ5DUkAqjF4FnW2pXdoKk4jHiiGXQOZSxJc/RS4Yw==
 
 "@octokit/rest@^15.12.1":
   version "15.18.1"


### PR DESCRIPTION
There were apparently lingering references to the old name of the module (that's what happenes when you've never done this before) and also some references on the fork itself. I had to remove them from here and bump a new version of the fork https://github.com/LedgerHQ/react-native-touch-id

### Type

Bug Fix

### Parts of the app affected / Test plan

Make sure you are able to build the project. I was able to build locally and test the touch id functionality.
