### PR TITLE
LL-1888 pass key param to navigate to prevent double operation details

### DIFF
--- a/src/components/OperationRow.js
+++ b/src/components/OperationRow.js
@@ -58,9 +58,10 @@ class OperationRow extends PureComponent<Props, *> {
       parentId: parentAccount && parentAccount.id,
       operation, // FIXME we should pass a operationId instead because data can changes over time.
       isSubOperation,
+      key: operation.id,
     };
 
-    navigation.push("OperationDetails", params);
+    navigation.navigate("OperationDetails", params);
   };
 
   render() {


### PR DESCRIPTION
Address LL-1888 preventing the opening of multiple Operation Detail's screens.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1888

### Parts of the app affected / Test plan

Operation list, click on an operation fast multiple times. Close the operation details screen.
Only one screen should be open.
