### PR TITLE
Bump to 1.1.0 to fix ios build

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "react-i18next": "8",
     "react-native": "0.59.9",
     "react-native-android-location-services-dialog-box": "^2.8.1",
-    "react-native-ble-plx": "^1.0.3",
+    "react-native-ble-plx": "^1.1.0",
     "react-native-camera": "1.9.2",
     "react-native-config": "0.11.7",
     "react-native-crypto": "^2.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7086,10 +7086,10 @@ react-native-animatable@^1.2.4:
   dependencies:
     prop-types "^15.5.10"
 
-react-native-ble-plx@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/react-native-ble-plx/-/react-native-ble-plx-1.0.3.tgz#d5068f633522c2420b5e095d4c67286c31515c84"
-  integrity sha512-JOagdLCjT9GrD3yT3kV0Ib2+tBl+IqQ4r7alXQdZoKLdT0Ceb1UaevSmM4S6eSE6XI2DOdpOEDqUGubmysPVyA==
+react-native-ble-plx@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-ble-plx/-/react-native-ble-plx-1.1.0.tgz#95ba0025f9bfb507633c7f1d1ffd6eaa54296d4d"
+  integrity sha512-+ddyRRf7QT4ldELC7hb0AZMYOSTga1l7sp7lT+HQX87rpBrGTwIBEE8gRFqriLpsTqL67Vt6xgIOj3Ko/vHhhw==
 
 react-native-camera@1.9.2:
   version "1.9.2"


### PR DESCRIPTION
This allows to build on xcode preventing the error we were getting.

Should be tested on Android/iOS with a nano x to ensure the communication is still working over ble.

![image](https://user-images.githubusercontent.com/4631227/66205703-5a962c80-e6ae-11e9-8827-dc6bf6422eb4.png)
