### PR TITLE
Change from react-native-touch-id to react-native-fingerprint-scanner

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -206,6 +206,8 @@ PODS:
     - React
   - react-native-config (0.11.7):
     - React
+  - react-native-fingerprint-scanner (3.0.2):
+    - React
   - react-native-locale (0.0.19):
     - React
   - react-native-netinfo (4.4.0):
@@ -312,6 +314,7 @@ DEPENDENCIES:
   - react-native-ble-plx-swift (from `../node_modules/react-native-ble-plx`)
   - react-native-camera (from `../node_modules/react-native-camera`)
   - react-native-config (from `../node_modules/react-native-config`)
+  - react-native-fingerprint-scanner (from `../node_modules/react-native-fingerprint-scanner`)
   - react-native-locale (from `../node_modules/react-native-locale`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-randombytes (from `../node_modules/react-native-randombytes`)
@@ -396,6 +399,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-camera"
   react-native-config:
     :path: "../node_modules/react-native-config"
+  react-native-fingerprint-scanner:
+    :path: "../node_modules/react-native-fingerprint-scanner"
   react-native-locale:
     :path: "../node_modules/react-native-locale"
   react-native-netinfo:
@@ -483,6 +488,7 @@ SPEC CHECKSUMS:
   react-native-ble-plx-swift: e0d041529bd7ae66eb9731123eca3df3d132e8ec
   react-native-camera: c529629e3ecd017dcdacfd0355576ef489d9d198
   react-native-config: 55548054279d92e0e4566ea15a8b9b81028ec342
+  react-native-fingerprint-scanner: 388acb4969b681a3f63fbec0c4b740d2b775a1dc
   react-native-locale: bd8edf0e51706d469af3e2fa568a8102213a3139
   react-native-netinfo: 6bb847e64f45a2d69c6173741111cfd95c669301
   react-native-randombytes: 3638d24759d67c68f6ccba60c52a7a8a8faa6a23

--- a/ios/ledgerlivemobile/AppDelegate.h
+++ b/ios/ledgerlivemobile/AppDelegate.h
@@ -11,5 +11,6 @@
 @interface AppDelegate : UIResponder <UIApplicationDelegate, RCTBridgeDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
-
+- (void) showOverlay;
+- (void) hideOverlay;
 @end

--- a/ios/ledgerlivemobile/AppDelegate.m
+++ b/ios/ledgerlivemobile/AppDelegate.m
@@ -29,17 +29,17 @@
                                             initialProperties:nil];
   
   [RNSentry installWithRootView:rootView];
-
+  
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
-
+  
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
-  #ifndef DEBUG
-    [RNSplashScreen show];
-  #endif
+#ifndef DEBUG
+  [RNSplashScreen show];
+#endif
   return YES;
 }
 
@@ -58,7 +58,7 @@
                      restorationHandler:restorationHandler];
 }
 
-- (void)applicationWillResignActive:(UIApplication *)application {
+- (void) showOverlay{
   UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleRegular];
   UIVisualEffectView *blurEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
   UIImageView *logoView = [[UIImageView alloc]initWithImage:[UIImage imageNamed:@"Blurry"]];
@@ -75,14 +75,11 @@
   [logoView setContentHuggingPriority:251 forAxis:UILayoutConstraintAxisHorizontal];
   [logoView setContentHuggingPriority:251 forAxis:UILayoutConstraintAxisVertical];
   logoView.frame = CGRectMake(0, 0, 128, 128);
-
   
   logoView.center = CGPointMake(self.window.frame.size.width  / 2,self.window.frame.size.height / 2);
-
-
 }
 
-- (void)applicationDidBecomeActive:(UIApplication *)application {
+- (void) hideOverlay{
   UIView *blurEffectView = [self.window viewWithTag:12345];
   UIView *logoView = [self.window viewWithTag:12346];
   
@@ -94,6 +91,14 @@
     [blurEffectView removeFromSuperview];
     [logoView removeFromSuperview];
   }];
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+  [self hideOverlay];
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+  [self showOverlay];
 }
 
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "react-native-easy-markdown": "^1.3.0",
     "react-native-extra-dimensions-android": "^1.2.5",
     "react-native-gesture-handler": "1.5.0",
+    "react-native-fingerprint-scanner": "^2.6.0",
     "react-native-keychain": "^3.1.3",
     "react-native-level-fs": "^3.0.0",
     "react-native-locale": "0.0.19",

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "react-native-easy-markdown": "^1.3.0",
     "react-native-extra-dimensions-android": "^1.2.5",
     "react-native-gesture-handler": "1.5.0",
-    "react-native-fingerprint-scanner": "^2.6.0",
+    "react-native-fingerprint-scanner": "^3.0.0",
     "react-native-keychain": "^3.1.3",
     "react-native-level-fs": "^3.0.0",
     "react-native-locale": "0.0.19",

--- a/src/context/AuthPass/auth.js
+++ b/src/context/AuthPass/auth.js
@@ -3,8 +3,9 @@ import biometry from "./methods/biometry";
 
 export default async (reason: string) => {
   let success = false;
-  if (await biometry.isSupported()) {
-    success = await biometry.authenticate(reason);
+  if (await biometry.isSensorAvailable()) {
+    success = await biometry.authenticate({description:reason});
+    biometry.release();
   }
   return success;
 };

--- a/src/context/AuthPass/auth.js
+++ b/src/context/AuthPass/auth.js
@@ -4,7 +4,7 @@ import biometry from "./methods/biometry";
 export default async (reason: string) => {
   let success = false;
   if (await biometry.isSensorAvailable()) {
-    success = await biometry.authenticate({description:reason});
+    success = await biometry.authenticate({ description: reason });
     biometry.release();
   }
   return success;

--- a/src/context/AuthPass/methods/biometry.js
+++ b/src/context/AuthPass/methods/biometry.js
@@ -1,7 +1,7 @@
-import TouchID from "@ledgerhq/react-native-touch-id";
+import FingerprintScanner from 'react-native-fingerprint-scanner';
 import { Platform } from "react-native";
 import unsupported from "./unsupported";
 
 export default Platform.OS === "android" && Platform.Version < 23
   ? unsupported
-  : TouchID;
+  : FingerprintScanner;

--- a/src/context/AuthPass/methods/biometry.js
+++ b/src/context/AuthPass/methods/biometry.js
@@ -1,4 +1,4 @@
-import FingerprintScanner from 'react-native-fingerprint-scanner';
+import FingerprintScanner from "react-native-fingerprint-scanner";
 import { Platform } from "react-native";
 import unsupported from "./unsupported";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7616,10 +7616,10 @@ react-native-extra-dimensions-android@^1.2.5:
   resolved "https://registry.yarnpkg.com/react-native-extra-dimensions-android/-/react-native-extra-dimensions-android-1.2.5.tgz#8ade91029aaac7519bf305116d39019e618a60f0"
   integrity sha512-eorFo9X1vEqAWUkgcZ300yKBG1wtgNeE7tdWAH2CE+P50FGTniJg5Sr6l1iPWG8ZskQOuF+KeiSTFlDa4vLfMw==
 
-react-native-fingerprint-scanner@^2.6.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/react-native-fingerprint-scanner/-/react-native-fingerprint-scanner-2.6.2.tgz#e9b5d40fa0bf7f96ccbf48e8702b54962b233bae"
-  integrity sha512-7mXqE9GUiK+Bh5sG+aVq1RGV94Z0PPl6qTibh6i4+ApZ3DU3HxsJ2di7vHTvZsJ1YfmQCHmQIXs4bNuwp20wEg==
+react-native-fingerprint-scanner@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-fingerprint-scanner/-/react-native-fingerprint-scanner-3.0.2.tgz#ca9994de4b30dcf5ad2f5b420bfdd4d8775e8831"
+  integrity sha512-e6EkSgThwHAI9y5y2G3HdEbuKBka2lu3gRzpWzQs8FQF3t2DIB7fRHdA3/fnd33T39P0vU6hSCc9xwSpDbSdyg==
 
 react-native-gesture-handler@1.5.0:
   version "1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7616,6 +7616,11 @@ react-native-extra-dimensions-android@^1.2.5:
   resolved "https://registry.yarnpkg.com/react-native-extra-dimensions-android/-/react-native-extra-dimensions-android-1.2.5.tgz#8ade91029aaac7519bf305116d39019e618a60f0"
   integrity sha512-eorFo9X1vEqAWUkgcZ300yKBG1wtgNeE7tdWAH2CE+P50FGTniJg5Sr6l1iPWG8ZskQOuF+KeiSTFlDa4vLfMw==
 
+react-native-fingerprint-scanner@^2.6.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/react-native-fingerprint-scanner/-/react-native-fingerprint-scanner-2.6.2.tgz#e9b5d40fa0bf7f96ccbf48e8702b54962b233bae"
+  integrity sha512-7mXqE9GUiK+Bh5sG+aVq1RGV94Z0PPl6qTibh6i4+ApZ3DU3HxsJ2di7vHTvZsJ1YfmQCHmQIXs4bNuwp20wEg==
+
 react-native-gesture-handler@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.5.0.tgz#df7dc5285c152e0656db70f55200fa632c4f45af"


### PR DESCRIPTION
Due to the old library seemingly being no longer maintained, this switch might be beneficial for us. Note that we are using an older version 2.6 than the latest since in order to benefit from the 3.0.x version we'd need to upgrade to react-native 0.60+ I believe @MortalKastor is working on this so once that part is done we could bump this library too.

This might be beneficial for the issues experienced by some users when using biometric authentication. 

I'm still figuring out some kinks (coming back to the app on ios does a weird placement of the prompt behind the logo screen for instance)


### Type

Code Quality Improvement
