### PR TITLE
Use the deleteLibcore function when resetting libcore.

### DIFF
--- a/src/helpers/clearLibcore.js
+++ b/src/helpers/clearLibcore.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { afterLibcoreGC } from "@ledgerhq/live-common/lib/libcore/access";
+import { deleteLibcore, afterLibcoreGC } from "@ledgerhq/live-common/lib/libcore/access";
 import { delay } from "@ledgerhq/live-common/lib/promise";
 
 export default (job?: () => Promise<any>) =>
@@ -10,5 +10,6 @@ export default (job?: () => Promise<any>) =>
       await job();
     }
     await libcore.getPoolInstance().freshResetAll();
+    deleteLibcore();
     await delay(2000);
   });


### PR DESCRIPTION
This call will make future withLibcore calls to actually recreate the
Core structure.