### PR TITLE
LL-2013 Add crypto.com description for the partners page

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -336,6 +336,7 @@
     "coinberry": "Coinberry is the most trusted crypto platform in Canada with better-than-bank security, best-in-class user interface and No Fee funding & withdraw. Pre-register to get early access to our platform if you are not a Canadian citizen.",
     "coinhouse": "Coinhouse is a trusted platform for individuals and institutional investors looking to analyze, acquire, sell and securely store crypto assets.",
     "coinmama": "Coinmama is a financial service that makes it fast, safe and fun to buy digital assets, anywhere in the world.",
+    "crypto": "Crypto.com is the best place to buy, sell, track and pay with crypto",
     "genesis": "Genesis is an institutional trading firm offering liquidity and borrow for digital currencies, including bitcoin, bitcoin cash, ethereum, ethereum classic, litecoin, and XRP.",
     "kyberswap": "Fast, simple and secure token swap platform. Powered by Kyber Network's on-chain liquidity protocol.",
     "luno": "Luno makes it safe and easy to buy, store and learn about cryptocurrencies like Bitcoin and Ethereum",


### PR DESCRIPTION
Live-common was already bumped enough to have have the svgs and links for crypto.com so all that was missing was this description, took longer to write this description that the one used in the app.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-2013
### Parts of the app affected / Test plan

Partners screen