### PR TITLE
Fix keyboard covering bottom modal on iOS on select validator screen

### DIFF
--- a/src/components/InfoModal.js
+++ b/src/components/InfoModal.js
@@ -46,13 +46,14 @@ class InfoModal extends PureComponent<Props> {
       children,
       confirmLabel,
       confirmProps,
+      style,
     } = this.props;
     return (
       <BottomModal
         id={id}
         isOpened={isOpened}
         onClose={onClose}
-        style={styles.modal}
+        style={[styles.modal, style || {}]}
       >
         <Circle bg={rgba(colors.live, 0.1)} size={56}>
           {Icon ? <Icon /> : <IconHelp size={24} color={colors.live} />}

--- a/src/families/tezos/DelegationFlow/SelectValidator.js
+++ b/src/families/tezos/DelegationFlow/SelectValidator.js
@@ -1,8 +1,8 @@
 /* @flow */
 
 import invariant from "invariant";
-import React, { useState, useCallback } from "react";
-import { View, StyleSheet, FlatList } from "react-native";
+import React, { useState, useCallback, useEffect } from "react";
+import { View, StyleSheet, FlatList, Keyboard, Platform } from "react-native";
 import i18next from "i18next";
 import { connect } from "react-redux";
 import { SafeAreaView } from "react-navigation";
@@ -97,6 +97,37 @@ const ModalIcon = () => <Icon name="user-plus" size={24} color={colors.live} />;
 const SelectValidator = ({ account, parentAccount, navigation }: Props) => {
   const bakers = useBakers(whitelist);
   const [editingCustom, setEditingCustom] = useState(false);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  if (Platform.OS === "ios") {
+    const keyboardDidShow = event => {
+      const { height } = event.endCoordinates;
+
+      setKeyboardHeight(height);
+    };
+
+    const keyboardDidHide = () => {
+      setKeyboardHeight(0);
+    };
+
+    // The platform changing during runtime seems... unlikely
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    useEffect(() => {
+      const keyboardDidShowListener = Keyboard.addListener(
+        "keyboardDidShow",
+        keyboardDidShow,
+      );
+      const keyboardDidHideListener = Keyboard.addListener(
+        "keyboardDidHide",
+        keyboardDidHide,
+      );
+
+      return () => {
+        keyboardDidShowListener.remove();
+        keyboardDidHideListener.remove();
+      };
+    });
+  }
 
   const {
     transaction,
@@ -198,6 +229,7 @@ const SelectValidator = ({ account, parentAccount, navigation }: Props) => {
           disabled: bridgePending || !!error,
           pending: bridgePending,
         }}
+        style={keyboardHeight ? { marginBottom: keyboardHeight } : undefined}
       >
         <TextInput
           placeholder="Enter validator address"


### PR DESCRIPTION
It still doesn't make any sense to me to have a text input in a drawer, but at least it's working.

![image](https://user-images.githubusercontent.com/13920153/69819959-424f1380-1200-11ea-8e99-22e28a2d4861.png)

Android was handling this without issue, out of the box.

### Type

Bug fix

### Context

Tezos integrations

### Parts of the app affected / Test plan

Adding a custom validator in delegation flow
