### PR TITLE
[iOS] Fix invisible chars in password field when OS is in dark mode

### DIFF
--- a/ios/ledgerlivemobile/Info.plist
+++ b/ios/ledgerlivemobile/Info.plist
@@ -93,5 +93,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -131,6 +131,7 @@ const styles = StyleSheet.create({
     fontSize: 20,
   },
   input: {
+    color: colors.darkBlue,
     fontSize: 16,
     paddingHorizontal: 16,
     height: 48,


### PR DESCRIPTION
### Type

UI Polish

### Parts of the app affected / Test plan

Password lock screen on iOS 13, with dark mode on
