### PR TITLE
[Android] Debug app doesn't replace production one

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -178,6 +178,7 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
+            applicationIdSuffix ".debug"
         }
         release {
             minifyEnabled enableProguardInReleaseBuilds

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "postinstall": "./scripts/post.sh",
     "start": "react-native start",
-    "android": "react-native run-android",
+    "android": "react-native run-android --appIdSuffix=debug",
     "android:internal": "bundle exec fastlane android redo_beta",
     "preandroid:internal": "bundle install",
     "android:waldo": "bundle exec fastlane android upload_waldo --env mock",


### PR DESCRIPTION
Tiny QOL/DX PR: the app in debug mode (`yarn android`) is using the same id as the production one (`com.ledger.live`), which prevents running the former without uninstalling the later. Pretty annoying when you're on the go and testing on your personal phone.

This fixes that by adding `.debug` as a suffix to the app id when in debug, and updates `yarn android` accordingly.

### Type

QOL / DX

### Context

Trying to do Android dev during a major transportation strike.

### Parts of the app affected / Test plan

Running `yarn android` targeting an Android phone with the production app installed should install and run the debug app without touching the production one.
