### PR TITLE
Add gradientUnits to lineaGradient to fix regression

### DIFF
--- a/src/components/Graph/DefGrad.js
+++ b/src/components/Graph/DefGrad.js
@@ -12,7 +12,14 @@ export default class DefGraph extends PureComponent<Props> {
   render() {
     const { height, color } = this.props;
     return (
-      <LinearGradient id="grad" x1="0" y1="0" x2="0" y2={height}>
+      <LinearGradient
+        id="grad"
+        x1="0"
+        y1="0"
+        x2="0"
+        y2={height}
+        gradientUnits="userSpaceOnUse"
+      >
         <Stop offset="0" stopColor={color} stopOpacity="0.3" />
         <Stop offset="1" stopColor={color} stopOpacity="0" />
       </LinearGradient>


### PR DESCRIPTION
There was a regression in the graph chart that broke the lineargradient introduced when updating the `react-native-svg` library due to a less lenient rendering of the gradients that meant we'd show a solid color instead of the gradient. This fixes that

![image](https://user-images.githubusercontent.com/4631227/70373776-d64d6900-18eb-11ea-90a8-6361ef56569a.png)

### Type

Regression

### Context

Slack

### Parts of the app affected / Test plan
Graphs