### PR TITLE
Fixed ui issue on SubAccounts List view

### DIFF
--- a/src/screens/Account/SubAccountsList.js
+++ b/src/screens/Account/SubAccountsList.js
@@ -4,7 +4,9 @@ import React, { useCallback, useState, useMemo } from "react";
 import { compose } from "redux";
 import { Trans } from "react-i18next";
 import take from "lodash/take";
-import { FlatList, Platform, StyleSheet, View } from "react-native";
+import { Platform, StyleSheet, View } from "react-native";
+// !! Using nested list via react-navigation prompts some ui warnings some investigating needed to fully resolve this issue !!
+import { FlatList } from "react-navigation";
 import type { Account, SubAccount } from "@ledgerhq/live-common/lib/types";
 import Icon from "react-native-vector-icons/dist/FontAwesome";
 import MaterialIcon from "react-native-vector-icons/dist/MaterialIcons";

--- a/src/screens/Account/SubAccountsList.js
+++ b/src/screens/Account/SubAccountsList.js
@@ -6,11 +6,10 @@ import { Trans } from "react-i18next";
 import take from "lodash/take";
 import { Platform, StyleSheet, View } from "react-native";
 // !! Using nested list via react-navigation prompts some ui warnings some investigating needed to fully resolve this issue !!
-import { FlatList } from "react-navigation";
+import { FlatList, withNavigation } from "react-navigation";
 import type { Account, SubAccount } from "@ledgerhq/live-common/lib/types";
 import Icon from "react-native-vector-icons/dist/FontAwesome";
 import MaterialIcon from "react-native-vector-icons/dist/MaterialIcons";
-import { withNavigation } from "react-navigation";
 import { listSubAccounts } from "@ledgerhq/live-common/lib/account";
 import { listTokenTypesForCryptoCurrency } from "@ledgerhq/live-common/lib/currencies";
 import SubAccountRow from "../../components/SubAccountRow";


### PR DESCRIPTION
LLM UI issue on eth accounts with lot of ERC20:

an issue occured when sub account list view has too many accounts to show, thus not correctly rendering the Ui list and making it unusable for long lists of accounts.

```diff
- some UI warnings are still present related to react-navigation
```

### Type

Bug Fix

### Context

Jira

### Parts of the app affected / Test plan

SubAccount List view
