### PR TITLE
LL-2081 Flipper integration 🐬

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -231,6 +231,15 @@ dependencies {
     } else {
         implementation jscFlavor
     }
+
+    implementation 'com.facebook.soloader:soloader:0.6.0+'
+
+    debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}") {
+        exclude group:'com.facebook.yoga'
+        exclude group:'com.facebook.flipper', module: 'fbjni'
+        exclude group:'com.facebook.litho', module: 'litho-annotations'
+        exclude group:'com.squareup.okhttp3'
+    }
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/debug/java/com/ledger/live/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/com/ledger/live/ReactNativeFlipper.java
@@ -1,0 +1,72 @@
+package com.ledger.live;
+
+import android.content.Context;
+import com.facebook.flipper.android.AndroidFlipperClient;
+import com.facebook.flipper.android.utils.FlipperUtils;
+import com.facebook.flipper.core.FlipperClient;
+import com.facebook.flipper.plugins.crashreporter.CrashReporterPlugin;
+import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin;
+import com.facebook.flipper.plugins.fresco.FrescoFlipperPlugin;
+import com.facebook.flipper.plugins.inspector.DescriptorMapping;
+import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin;
+import com.facebook.flipper.plugins.network.FlipperOkhttpInterceptor;
+import com.facebook.flipper.plugins.network.NetworkFlipperPlugin;
+import com.facebook.flipper.plugins.react.ReactFlipperPlugin;
+import com.facebook.flipper.plugins.sharedpreferences.SharedPreferencesFlipperPlugin;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.modules.network.NetworkingModule;
+import okhttp3.OkHttpClient;
+
+public class ReactNativeFlipper {
+
+  public static void initializeFlipper(Context context) {
+    ReactNativeFlipper.initializeFlipper(context, null);
+  }
+
+  public static void initializeFlipper(Context context, final ReactInstanceManager reactInstanceManager) {
+    if (!FlipperUtils.shouldEnableFlipper(context)) {
+      return;
+    }
+    final FlipperClient client = AndroidFlipperClient.getInstance(context);
+
+    client.addPlugin(new InspectorFlipperPlugin(context, DescriptorMapping.withDefaults()));
+    client.addPlugin(new ReactFlipperPlugin());
+    client.addPlugin(new DatabasesFlipperPlugin(context));
+    client.addPlugin(new SharedPreferencesFlipperPlugin(context));
+    client.addPlugin(CrashReporterPlugin.getInstance());
+
+    final NetworkFlipperPlugin networkFlipperPlugin = new NetworkFlipperPlugin();
+    NetworkingModule.setCustomClientBuilder(
+        new NetworkingModule.CustomClientBuilder() {
+          @Override
+          public void apply(OkHttpClient.Builder builder) {
+            builder.addNetworkInterceptor(new FlipperOkhttpInterceptor(networkFlipperPlugin));
+          }
+        });
+    client.addPlugin(networkFlipperPlugin);
+    client.start();
+
+    // Fresco Plugin needs to ensure that ImagePipelineFactory is initialized
+    // Hence we run if after all native modules have been initialized
+    ReactContext reactContext = reactInstanceManager == null ? null : reactInstanceManager.getCurrentReactContext();
+    if (reactContext == null) {
+      reactInstanceManager.addReactInstanceEventListener(
+          new ReactInstanceManager.ReactInstanceEventListener() {
+            @Override
+            public void onReactContextInitialized(ReactContext reactContext) {
+              reactInstanceManager.removeReactInstanceEventListener(this);
+              reactContext.runOnNativeModulesQueueThread(
+                  new Runnable() {
+                    @Override
+                    public void run() {
+                      client.addPlugin(new FrescoFlipperPlugin());
+                    }
+                  });
+            }
+          });
+    } else {
+      client.addPlugin(new FrescoFlipperPlugin());
+    }
+  }
+}

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" /> <!-- Needed by Flipper 🐬 -->
     <uses-sdk
         android:targetSdkVersion="27"
         tools:overrideLibrary="com.ledger.reactnative" />
@@ -49,6 +50,8 @@
         <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" android:resource="@xml/usb_device_filter" />
       </activity>
       <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+      <activity android:name="com.facebook.flipper.android.diagnostics.FlipperDiagnosticActivity"
+        android:exported="true"/>
     </application>
 
 </manifest>

--- a/android/app/src/main/java/com/ledger/live/MainApplication.java
+++ b/android/app/src/main/java/com/ledger/live/MainApplication.java
@@ -7,6 +7,7 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
+import com.facebook.react.ReactInstanceManager;
 
 import org.reactnative.camera.RNCameraPackage;
 
@@ -54,7 +55,7 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
-    initializeFlipper(this); // Remove this line if you don't want Flipper enabled
+    initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }
 
   /**
@@ -62,15 +63,15 @@ public class MainApplication extends Application implements ReactApplication {
    *
    * @param context
    */
-  private static void initializeFlipper(Context context) {
+  private static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
     if (BuildConfig.DEBUG) {
       try {
         /*
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.facebook.flipper.ReactNativeFlipper");
-        aClass.getMethod("initializeFlipper", Context.class).invoke(null, context);
+        Class<?> aClass = Class.forName("com.ledger.live.ReactNativeFlipper");
+        aClass.getMethod("initializeFlipper", Context.class, ReactInstanceManager.class).invoke(null, context, reactInstanceManager);
       } catch (ClassNotFoundException e) {
         e.printStackTrace();
       } catch (NoSuchMethodException e) {

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -25,6 +25,9 @@ android.enableJetifier=true
 
 AsyncStorage_db_size_in_MB=42
 
+# On Android, React Native currently has issues with higher versions
+FLIPPER_VERSION=0.23.4
+
 STAGING_STORE_FILE=staging.kstr
 STAGING_KEY_ALIAS=staging
 STAGING_STORE_PASSWORD=staging

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,6 +1,39 @@
 platform :ios, '9.0'
 require_relative '../node_modules/@react-native-community/cli-platform-ios/native_modules'
 
+def flipper_pods()
+  flipperkit_version = '0.27'
+  pod 'FlipperKit', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitLayoutPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/SKIOSNetworkPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
+  pod 'FlipperKit/FlipperKitUserDefaultsPlugin', '~>' + flipperkit_version, :configuration => 'Debug'
+end
+
+# Post Install processing for Flipper
+def flipper_post_install(installer)
+  installer.pods_project.targets.each do |target|
+    if target.name == 'YogaKit'
+      target.build_configurations.each do |config|
+        config.build_settings['SWIFT_VERSION'] = '4.1'
+      end
+    end
+  end
+  file_name = Dir.glob("*.xcodeproj")[0]
+  app_project = Xcodeproj::Project.open(file_name)
+  app_project.native_targets.each do |target|
+    target.build_configurations.each do |config|
+      cflags = config.build_settings['OTHER_CFLAGS'] || '$(inherited) '
+      unless cflags.include? '-DFB_SONARKIT_ENABLED=1'
+        puts 'Adding -DFB_SONARKIT_ENABLED=1 in OTHER_CFLAGS...'
+        cflags << '-DFB_SONARKIT_ENABLED=1'
+      end
+      config.build_settings['OTHER_CFLAGS'] = cflags
+    end
+    app_project.save
+  end
+  installer.pods_project.save
+end
+
 target 'ledgerlivemobile' do
   # Pods for ledgerlivemobile
   pod 'FBLazyVector', :path => "../node_modules/react-native/Libraries/FBLazyVector"
@@ -28,7 +61,7 @@ target 'ledgerlivemobile' do
   pod 'React-jsinspector', :path => '../node_modules/react-native/ReactCommon/jsinspector'
   pod 'ReactCommon/jscallinvoker', :path => "../node_modules/react-native/ReactCommon"
   pod 'ReactCommon/turbomodule/core', :path => "../node_modules/react-native/ReactCommon"
-  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga'
+  pod 'Yoga', :path => '../node_modules/react-native/ReactCommon/yoga', :modular_headers => true
 
   pod 'DoubleConversion', :podspec => '../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec'
   pod 'glog', :podspec => '../node_modules/react-native/third-party-podspecs/glog.podspec'
@@ -48,19 +81,21 @@ target 'ledgerlivemobile' do
   end
 
   use_native_modules!
-end
 
-post_install do |installer|
-  installer.pods_project.targets.each do |target|
-    if target.name == 'react-native-config'
-      phase = target.project.new(Xcodeproj::Project::Object::PBXShellScriptBuildPhase)
-      phase.shell_script = "cd ../../"\
-      " && RNC_ROOT=./node_modules/react-native-config/"\
-      " && export SYMROOT=$RNC_ROOT/ios/ReactNativeConfig"\
-      " && ruby $RNC_ROOT/ios/ReactNativeConfig/BuildDotenvConfig.ruby"
-      
-      target.build_phases << phase
-      target.build_phases.move(phase,0)
+  flipper_pods()
+  post_install do |installer|
+    flipper_post_install(installer)
+    installer.pods_project.targets.each do |target|
+      if target.name == 'react-native-config'
+        phase = target.project.new(Xcodeproj::Project::Object::PBXShellScriptBuildPhase)
+        phase.shell_script = "cd ../../"\
+        " && RNC_ROOT=./node_modules/react-native-config/"\
+        " && export SYMROOT=$RNC_ROOT/ios/ReactNativeConfig"\
+        " && ruby $RNC_ROOT/ios/ReactNativeConfig/BuildDotenvConfig.ruby"
+        
+        target.build_phases << phase
+        target.build_phases.move(phase,0)
+      end
     end
   end
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,6 +1,8 @@
 PODS:
   - Analytics (3.7.0)
   - boost-for-react-native (1.63.0)
+  - CocoaAsyncSocket (7.6.3)
+  - CocoaLibEvent (1.0.0)
   - djinni_objc (4.4.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.61.2)
@@ -11,6 +13,48 @@ PODS:
     - React-Core (= 0.61.2)
     - React-jsi (= 0.61.2)
     - ReactCommon/turbomodule/core (= 0.61.2)
+  - Flipper (0.30.0):
+    - Flipper-Folly (~> 2.1)
+    - Flipper-RSocket (~> 1.0)
+  - Flipper-Folly (2.1.0):
+    - boost-for-react-native
+    - CocoaLibEvent (~> 1.0)
+    - DoubleConversion
+    - glog
+    - OpenSSL-Universal (= 1.0.2.19)
+  - Flipper-PeerTalk (0.0.4)
+  - Flipper-RSocket (1.0.0):
+    - Flipper-Folly (~> 2.0)
+  - FlipperKit (0.30.0):
+    - FlipperKit/Core (= 0.30.0)
+  - FlipperKit/Core (0.30.0):
+    - Flipper (~> 0.30.0)
+    - FlipperKit/CppBridge
+    - FlipperKit/FBCxxFollyDynamicConvert
+    - FlipperKit/FBDefines
+    - FlipperKit/FKPortForwarding
+  - FlipperKit/CppBridge (0.30.0):
+    - Flipper (~> 0.30.0)
+  - FlipperKit/FBCxxFollyDynamicConvert (0.30.0):
+    - Flipper-Folly (~> 2.1)
+  - FlipperKit/FBDefines (0.30.0)
+  - FlipperKit/FKPortForwarding (0.30.0):
+    - CocoaAsyncSocket (~> 7.6)
+    - Flipper-PeerTalk (~> 0.0.4)
+  - FlipperKit/FlipperKitHighlightOverlay (0.30.0)
+  - FlipperKit/FlipperKitLayoutPlugin (0.30.0):
+    - FlipperKit/Core
+    - FlipperKit/FlipperKitHighlightOverlay
+    - FlipperKit/FlipperKitLayoutTextSearchable
+    - YogaKit (~> 1.18)
+  - FlipperKit/FlipperKitLayoutTextSearchable (0.30.0)
+  - FlipperKit/FlipperKitNetworkPlugin (0.30.0):
+    - FlipperKit/Core
+  - FlipperKit/FlipperKitUserDefaultsPlugin (0.30.0):
+    - FlipperKit/Core
+  - FlipperKit/SKIOSNetworkPlugin (0.30.0):
+    - FlipperKit/Core
+    - FlipperKit/FlipperKitNetworkPlugin
   - Folly (2018.10.22.00):
     - boost-for-react-native
     - DoubleConversion
@@ -27,6 +71,9 @@ PODS:
   - lottie-react-native (3.2.1):
     - lottie-ios (~> 3.1.3)
     - React
+  - OpenSSL-Universal (1.0.2.19):
+    - OpenSSL-Universal/Static (= 1.0.2.19)
+  - OpenSSL-Universal/Static (1.0.2.19)
   - PasscodeAuth (2.1.0):
     - React
   - RCTRequired (0.61.2)
@@ -286,12 +333,18 @@ PODS:
   - TcpSockets (3.3.2):
     - React
   - Yoga (1.14.0)
+  - YogaKit (1.18.1):
+    - Yoga (~> 1.14)
 
 DEPENDENCIES:
   - "djinni_objc (from `../node_modules/@ledgerhq/react-native-ledger-core`)"
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
   - FBLazyVector (from `../node_modules/react-native/Libraries/FBLazyVector`)
   - FBReactNativeSpec (from `../node_modules/react-native/Libraries/FBReactNativeSpec`)
+  - FlipperKit (~> 0.27)
+  - FlipperKit/FlipperKitLayoutPlugin (~> 0.27)
+  - FlipperKit/FlipperKitUserDefaultsPlugin (~> 0.27)
+  - FlipperKit/SKIOSNetworkPlugin (~> 0.27)
   - Folly (from `../node_modules/react-native/third-party-podspecs/Folly.podspec`)
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - "ledger-core-objc (from `../node_modules/@ledgerhq/react-native-ledger-core`)"
@@ -348,8 +401,17 @@ SPEC REPOS:
   trunk:
     - Analytics
     - boost-for-react-native
+    - CocoaAsyncSocket
+    - CocoaLibEvent
+    - Flipper
+    - Flipper-Folly
+    - Flipper-PeerTalk
+    - Flipper-RSocket
+    - FlipperKit
     - lottie-ios
+    - OpenSSL-Universal
     - Sentry
+    - YogaKit
 
 EXTERNAL SOURCES:
   djinni_objc:
@@ -460,15 +522,23 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Analytics: 77fd5fb102a4a5eedafa2c2b0245ceb7b7c15e45
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
+  CocoaAsyncSocket: eafaa68a7e0ec99ead0a7b35015e0bf25d2c8987
+  CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   djinni_objc: bfac00bd517b8c2c3a48174e304391b93e3733b5
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 68b6a76960fbd8ecd9fb7ce0aadd3329c3340a99
   FBReactNativeSpec: 5a764c60abdc3336a213e5310c40b74741f32839
+  Flipper: 8103c50b4bb4ee69693e78cd1641909b1f4efe1e
+  Flipper-Folly: bcae82405dafd18ac9f8d9d4902fd1c2ef2a7e77
+  Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
+  Flipper-RSocket: 1260a31c05c238eabfa9bb8a64e3983049048371
+  FlipperKit: bad8965ee4dc2900afae828381c3c19aa2105ff7
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   ledger-core-objc: 61e148f72688cc232526b5187593c40850616b8b
   lottie-ios: 496ac5cea1bbf1a7bd1f1f472f3232eb1b8d744b
   lottie-react-native: b123a79529cc732201091f585c62c89bb4747252
+  OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
   PasscodeAuth: 667f2bfb0e78f652c11db4793d8077c189ce300e
   RCTRequired: c639d59ed389cfb1f1203f65c2ea946d8ec586e2
   RCTTypeSafety: dc23fb655d6c77667c78e327bf661bc11e3b8aec
@@ -514,7 +584,8 @@ SPEC CHECKSUMS:
   SentryReactNative: 09d5cc89e8bb5d80cfaf3ae11ed2ecb0a47317d2
   TcpSockets: 14306fb79f9750ea7d2ddd02d8bed182abb01797
   Yoga: 14927e37bd25376d216b150ab2a561773d57911f
+  YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: 6b22e4f92a633a27f31d653752cdd3cdc4d3f15b
+PODFILE CHECKSUM: 51082bff579ff6b3197b1bd32b97ecb26523e6c1
 
 COCOAPODS: 1.8.4

--- a/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -591,6 +591,10 @@
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)/System/Library/Frameworks\"",
 				);
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DFB_SONARKIT_ENABLED=1",
+				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
 					"-lc++",
@@ -621,6 +625,10 @@
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/$(TARGET_NAME)/System/Library/Frameworks\"",
+				);
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DFB_SONARKIT_ENABLED=1",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -664,6 +672,10 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/Frameworks/x86_64";
 				LIBRARY_SEARCH_PATHS = "$(inherited)/**";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DFB_SONARKIT_ENABLED=1",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -711,6 +723,10 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @executable_path/Frameworks/x86_64";
 				LIBRARY_SEARCH_PATHS = "$(inherited)/**";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DFB_SONARKIT_ENABLED=1",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",

--- a/ios/ledgerlivemobile/AppDelegate.m
+++ b/ios/ledgerlivemobile/AppDelegate.m
@@ -18,11 +18,22 @@
 #import <React/RCTLinkingManager.h>
 #import "RNSplashScreen.h"
 
+#ifdef DEBUG
+  #import <FlipperKit/FlipperClient.h>
+  #import <FlipperKitLayoutPlugin/FlipperKitLayoutPlugin.h>
+  #import <FlipperKitLayoutPlugin/SKDescriptorMapper.h>
+  #import <FlipperKitUserDefaultsPlugin/FKUserDefaultsPlugin.h>
+  #import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+  #import <SKIOSNetworkPlugin/SKIOSNetworkAdapter.h>
+  #import <FlipperKitNetworkPlugin/FlipperKitNetworkPlugin.h>
+#endif
+
 @implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
-  
+  [self initializeFlipper:application];
+
   RCTBridge *bridge = [[RCTBridge alloc] initWithDelegate:self launchOptions:launchOptions];
   RCTRootView *rootView = [[RCTRootView alloc] initWithBridge:bridge
                                                    moduleName:@"ledgerlivemobile"
@@ -108,6 +119,17 @@
 #else
   return [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 #endif
+}
+
+- (void) initializeFlipper:(UIApplication *)application {
+  #ifdef DEBUG
+    FlipperClient *client = [FlipperClient sharedClient];
+    SKDescriptorMapper *layoutDescriptorMapper = [[SKDescriptorMapper alloc] initWithDefaults];
+    [client addPlugin: [[FlipperKitLayoutPlugin alloc] initWithRootNode: application withDescriptorMapper: layoutDescriptorMapper]];
+    [client addPlugin:[[FKUserDefaultsPlugin alloc] initWithSuiteName:nil]]; [client start];
+    [client addPlugin: [[FlipperKitNetworkPlugin alloc] initWithNetworkAdapter:[SKIOSNetworkAdapter new]]];
+    [client start];
+  #endif
 }
 
 @end

--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -6,6 +6,10 @@ cd $(dirname $0)/..
 
 rm -f 'node_modules/@segment/analytics-ios/.clang-format' 'third-party/glog-0.3.5/test-driver'
 
+# Had to remove the following because we already have the AsyncSocket lib as a dependency from Flipper 🐬
+# Why would anyone bundle an external lib available on CocoaPods anyway?
+rm -rf "node_modules/react-native-udp/ios/CocoaAsyncSocket" "node_modules/react-native-tcp/ios/CocoaAsyncSocket"
+
 rn-nodeify --hack
 
 # Create the dev .env file with APP_NAME if it doesn't exist


### PR DESCRIPTION
Integrating [Flipper](https://fbflipper.com/), to get some more debug informations.

![image](https://user-images.githubusercontent.com/13920153/70923013-69427d80-2027-11ea-9789-845e7523f75b.png)

Not as useful as I hoped for the time being, but at least we get the full network requests and responses from libcore on iOS 🎉

### Usage

- Install [Flipper](https://fbflipper.com/) on your computer
- Launch it 🚀
- Run Ledger Live Mobile in debug as usual

### Caveats

- I found nothing interesting we didn't already have with out current tools for Android, but Flipper for RN on Android lags a bit behind its iOS counterpart, so it might get better with time
- It's currently only compatible with the simulator on iOS

### Type

Debug tool integration

### Context

https://ledgerhq.atlassian.net/browse/LL-2081

### Parts of the app affected

App building, so native dependencies as well

### Test plan

Since I had to trick a bit some XRP lib dependencies in order to prevent them to bundle an old lib over the one Flipper is shipping (cf scripts/post.sh), we need to make sure that didn't break XRP (especially on iOS production build)
