### PR TITLE
Disable hermes

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -86,7 +86,7 @@ import com.android.build.OutputFile
 
 project.ext.react = [
     entryFile: "index.js",
-    enableHermes: true,  // clean and rebuild if changing
+    enableHermes: false,  // clean and rebuild if changing
     // bundleInDebug: true, // Uncomment this to debug java without having to deal with JS dev server (metro)
 ]
 project.ext.sentryCli = [


### PR DESCRIPTION
Due to a crash at launch detected by @Arnaud97234 on the emulator for Android v9 we are disabling this for now.

### Type

Bug
