### PR TITLE
Fix infinite loop crash readonly iOS receive flow

### DIFF
--- a/src/screens/ReceiveFunds/02-ConnectDevice.js
+++ b/src/screens/ReceiveFunds/02-ConnectDevice.js
@@ -34,6 +34,7 @@ type Navigation = NavigationScreenProp<{
   params: {
     accountId: string,
     parentId: string,
+    title: string,
   },
 }>;
 
@@ -56,9 +57,10 @@ const ConnectDevice = ({
   parentAccount,
 }: Props) => {
   useEffect(() => {
-    if (readOnlyModeEnabled) {
+    const readOnlyTitle = "transfer.receive.titleReadOnly";
+    if (readOnlyModeEnabled && navigation.getParam("title") !== readOnlyTitle) {
       navigation.setParams({
-        title: "transfer.receive.titleReadOnly",
+        title: readOnlyTitle,
         headerRight: null,
       });
     }


### PR DESCRIPTION
Found this while going over the support tickets, it has affected quite a few users in readonly mode and hopefully this solves the issue.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2106

### Parts of the app affected / Test plan

Testing the app in read only mode in general but this affects the receive flow specifically. Clicking on the big Receive button in an account, crashed the app.