### PR TITLE
LL-2107 Fix freeze when opening Live QR on Android

### DIFF
--- a/src/screens/BenchmarkQRStream.js
+++ b/src/screens/BenchmarkQRStream.js
@@ -89,58 +89,68 @@ export default class BenchmarkQRStream extends PureComponent<
           captureAudio={false}
           style={[styles.camera, cameraDimensions]}
         >
-          <View style={wrapperStyle}>
-            <View style={[styles.darken, styles.centered, styles.topCell]}>
-              <LText semiBold style={styles.text}>
-                {"ledger-live-tools.netlify.com/qrstreambenchmark"}
-              </LText>
-            </View>
+          {({ status }) =>
+            status === "READY" ? (
+              <View style={wrapperStyle}>
+                <View style={[styles.darken, styles.centered, styles.topCell]}>
+                  <LText semiBold style={styles.text}>
+                    {"ledger-live-tools.netlify.com/qrstreambenchmark"}
+                  </LText>
+                </View>
 
-            <View style={styles.row}>
-              <View style={styles.darken} />
-              <View style={{ width: viewFinderSize, height: viewFinderSize }}>
-                <View style={styles.innerRow}>
+                <View style={styles.row}>
+                  <View style={styles.darken} />
                   <View
-                    style={[styles.border, styles.borderLeft, styles.borderTop]}
-                  />
-                  <View style={styles.border} />
-                  <View
-                    style={[
-                      styles.border,
-                      styles.borderRight,
-                      styles.borderTop,
-                    ]}
-                  />
+                    style={{ width: viewFinderSize, height: viewFinderSize }}
+                  >
+                    <View style={styles.innerRow}>
+                      <View
+                        style={[
+                          styles.border,
+                          styles.borderLeft,
+                          styles.borderTop,
+                        ]}
+                      />
+                      <View style={styles.border} />
+                      <View
+                        style={[
+                          styles.border,
+                          styles.borderRight,
+                          styles.borderTop,
+                        ]}
+                      />
+                    </View>
+                    <View style={styles.innerRow} />
+                    <View style={styles.innerRow}>
+                      <View
+                        style={[
+                          styles.border,
+                          styles.borderLeft,
+                          styles.borderBottom,
+                        ]}
+                      />
+                      <View style={styles.border} />
+                      <View
+                        style={[
+                          styles.border,
+                          styles.borderRight,
+                          styles.borderBottom,
+                        ]}
+                      />
+                    </View>
+                  </View>
+                  <View style={styles.darken} />
                 </View>
-                <View style={styles.innerRow} />
-                <View style={styles.innerRow}>
-                  <View
-                    style={[
-                      styles.border,
-                      styles.borderLeft,
-                      styles.borderBottom,
-                    ]}
-                  />
-                  <View style={styles.border} />
-                  <View
-                    style={[
-                      styles.border,
-                      styles.borderRight,
-                      styles.borderBottom,
-                    ]}
-                  />
+                <View style={[styles.darken, styles.centered]}>
+                  <View style={styles.centered}>
+                    <LText semiBold style={styles.text}>
+                      {summary}
+                    </LText>
+                  </View>
                 </View>
               </View>
-              <View style={styles.darken} />
-            </View>
-            <View style={[styles.darken, styles.centered]}>
-              <View style={styles.centered}>
-                <LText semiBold style={styles.text}>
-                  {summary}
-                </LText>
-              </View>
-            </View>
-          </View>
+            ) : null
+          }
         </RNCamera>
       </View>
     );

--- a/src/screens/DebugWSImport.js
+++ b/src/screens/DebugWSImport.js
@@ -55,7 +55,11 @@ class DebugWSImport extends Component<
           ratio="16:9"
           style={[styles.camera]}
         >
-          <CameraScreen width={200} height={200} />
+          {({ status }) =>
+            status === "READY" ? (
+              <CameraScreen width={200} height={200} />
+            ) : null
+          }
         </RNCamera>
       </SafeAreaView>
     );

--- a/src/screens/ImportAccounts/Scan.js
+++ b/src/screens/ImportAccounts/Scan.js
@@ -132,12 +132,16 @@ class Scan extends PureComponent<
           style={[styles.camera, cameraDimensions]}
           notAuthorizedView={<FallBackCamera navigation={navigation} />}
         >
-          <CameraScreen
-            liveQrCode
-            width={width}
-            height={height}
-            progress={progress}
-          />
+          {({ status }) =>
+            status === "READY" ? (
+              <CameraScreen
+                liveQrCode
+                width={width}
+                height={height}
+                progress={progress}
+              />
+            ) : null
+          }
         </RNCamera>
         <GenericErrorBottomModal error={error} onClose={this.onCloseError} />
       </View>

--- a/src/screens/SendFunds/ScanRecipient.js
+++ b/src/screens/SendFunds/ScanRecipient.js
@@ -128,7 +128,11 @@ class ScanRecipient extends PureComponent<Props, State> {
           style={[styles.camera, cameraDimensions]}
           notAuthorizedView={<FallBackCamera navigation={navigation} />}
         >
-          <CameraScreen width={width} height={height} />
+          {({ status }) =>
+            status === "READY" ? (
+              <CameraScreen width={width} height={height} />
+            ) : null
+          }
         </RNCamera>
       </View>
     );


### PR DESCRIPTION
In the latest version of LLM, the app sometimes freezes when opening Live QR Import screen (and maybe when scanning a recipient address) on Android (probably because of one or several lib bump we did recently (React Native, React Navigation and React Native Camera specifically)).

This should fix that.

### Caveat

The video feedback from the camera now lags a bit behind the mounting of the screen, so it's black during the transition animation (modal slide up).

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2107

### Parts of the app affected / Test plan

- Live QR import
- Recipient QR address scan
