### PR TITLE
LL-2104 Add a placeholder text for assets without settings

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -808,7 +808,8 @@
       "rateProviderDesc": "Choose the provider of the rate between {{currencyTicker}} and Bitcoin",
       "confirmationNb": "Number of confirmations",
       "confirmationNbDesc": "Number of network confirmations to mark a transaction as confirmed.",
-      "currencySettingsTitle": "{{currencyName}} Settings"
+      "currencySettingsTitle": "{{currencyName}} Settings",
+      "placeholder": "No settings for this asset",
     },
     "rates": {
       "header": "Rates",

--- a/src/screens/Settings/CryptoAssets/Currencies/CurrencySettings.js
+++ b/src/screens/Settings/CryptoAssets/Currencies/CurrencySettings.js
@@ -2,7 +2,7 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { compose } from "redux";
-import { translate } from "react-i18next";
+import { Trans, translate } from "react-i18next";
 import { View, StyleSheet } from "react-native";
 import Slider from "react-native-slider";
 import type { NavigationScreenProp } from "react-navigation";
@@ -84,7 +84,7 @@ class EachCurrencySettings extends Component<Props, LocalState> {
           name="Currency"
           currency={currency.id}
         />
-        {defaults.confirmationsNb && (
+        {defaults.confirmationsNb ? (
           <View style={styles.sliderContainer}>
             <SettingsRow
               event="CurrencyConfirmationsNb"
@@ -130,6 +130,12 @@ class EachCurrencySettings extends Component<Props, LocalState> {
               </View>
             </View>
           </View>
+        ) : (
+          <View style={styles.placeholer}>
+            <LText semiBold style={styles.placeholderText}>
+              <Trans i18nKey="settings.currencies.placeholder" />
+            </LText>
+          </View>
         )}
       </View>
     );
@@ -173,8 +179,21 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
     minHeight: 200,
   },
+  placeholer: {
+    backgroundColor: colors.white,
+    padding: 16,
+    paddingVertical: 24,
+  },
+  placeholderText:{
+    fontSize: 16,
+    color: colors.darkBlue,
+  },
   confirmationNbValue: {
     fontSize: 16,
+  },
+  titleContainer: {
+    flexDirection: "row",
+    alignItems: "center",
   },
 });
 


### PR DESCRIPTION
When accessing the settings for a currency without any options we will now display a placeholder text according to the issue.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-2104

### Parts of the app affected / Test plan

Looking at XRP for example, go to `settings/crypto assets/currencies/xrp`