### PR TITLE
ERC20 operation details: Back arrow icon is missing

### DIFF
--- a/src/components/OperationRow.js
+++ b/src/components/OperationRow.js
@@ -62,7 +62,7 @@ class OperationRow extends PureComponent<Props, *> {
       key: operation.id,
     };
 
-    navigation.navigate("OperationDetails", params);
+    navigation.push("OperationDetails", params);
   };
 
   render() {

--- a/src/screens/OperationDetails/index.js
+++ b/src/screens/OperationDetails/index.js
@@ -1,7 +1,7 @@
 /* @flow */
 import React, { PureComponent } from "react";
 import i18next from "i18next";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
 // $FlowFixMe
 import { SafeAreaView, ScrollView } from "react-navigation";
 import { HeaderBackButton } from "react-navigation-stack";
@@ -25,6 +25,7 @@ import Footer from "./Footer";
 import Content from "./Content";
 import colors from "../../colors";
 import HeaderBackImage from "../../components/HeaderBackImage";
+import Close from "../../icons/Close";
 
 const forceInset = { bottom: "always" };
 
@@ -44,12 +45,19 @@ type Navigation = NavigationScreenProp<{
 const BackButton = ({ navigation }: { navigation: Navigation }) => (
   <HeaderBackButton
     tintColor={colors.grey}
-    onPress={() => {
-      navigation.goBack();
-    }}
+    onPress={() => navigation.popToTop()}
   >
     <HeaderBackImage />
   </HeaderBackButton>
+);
+
+const CloseButton = ({ navigation }: { navigation: Navigation }) => (
+  <TouchableOpacity
+    onPress={() => navigation.goBack()}
+    style={{ padding: 16, marginHorizontal: 8 }}
+  >
+    <Close size={18} color={colors.grey} />
+  </TouchableOpacity>
 );
 
 class OperationDetails extends PureComponent<Props, *> {
@@ -62,13 +70,14 @@ class OperationDetails extends PureComponent<Props, *> {
       return {
         title: i18next.t("operationDetails.title"),
         headerLeft: <BackButton navigation={navigation} />,
-        headerRight: null,
+        headerRight: <CloseButton navigation={navigation} />,
       };
     }
 
     return {
       title: i18next.t("operationDetails.title"),
-      headerLeft: null,
+      headerLeft: <BackButton navigation={navigation} />,
+      headerRight: null,
     };
   };
 

--- a/src/screens/OperationDetails/index.js
+++ b/src/screens/OperationDetails/index.js
@@ -4,7 +4,6 @@ import i18next from "i18next";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
 // $FlowFixMe
 import { SafeAreaView, ScrollView } from "react-navigation";
-import { HeaderBackButton } from "react-navigation-stack";
 import { connect } from "react-redux";
 import { translate } from "react-i18next";
 import type {
@@ -43,17 +42,14 @@ type Navigation = NavigationScreenProp<{
 }>;
 
 const BackButton = ({ navigation }: { navigation: Navigation }) => (
-  <HeaderBackButton
-    tintColor={colors.grey}
-    onPress={() => navigation.popToTop()}
-  >
+  <TouchableOpacity style={{ padding: 14 }} onPress={() => navigation.goBack()}>
     <HeaderBackImage />
-  </HeaderBackButton>
+  </TouchableOpacity>
 );
 
 const CloseButton = ({ navigation }: { navigation: Navigation }) => (
   <TouchableOpacity
-    onPress={() => navigation.goBack()}
+    onPress={() => navigation.popToTop()}
     style={{ padding: 16, marginHorizontal: 8 }}
   >
     <Close size={18} color={colors.grey} />

--- a/src/screens/OperationDetails/index.js
+++ b/src/screens/OperationDetails/index.js
@@ -23,8 +23,8 @@ import { TrackScreen } from "../../analytics";
 import Footer from "./Footer";
 import Content from "./Content";
 import colors from "../../colors";
-import HeaderBackImage from "../../components/HeaderBackImage";
 import Close from "../../icons/Close";
+import ArrowLeft from "../../icons/ArrowLeft";
 
 const forceInset = { bottom: "always" };
 
@@ -42,15 +42,15 @@ type Navigation = NavigationScreenProp<{
 }>;
 
 const BackButton = ({ navigation }: { navigation: Navigation }) => (
-  <TouchableOpacity style={{ padding: 14 }} onPress={() => navigation.goBack()}>
-    <HeaderBackImage />
+  <TouchableOpacity style={{ padding: 16 }} onPress={() => navigation.goBack()}>
+    <ArrowLeft size={18} color={colors.grey} />
   </TouchableOpacity>
 );
 
 const CloseButton = ({ navigation }: { navigation: Navigation }) => (
   <TouchableOpacity
     onPress={() => navigation.popToTop()}
-    style={{ padding: 16, marginHorizontal: 8 }}
+    style={{ padding: 16 }}
   >
     <Close size={18} color={colors.grey} />
   </TouchableOpacity>


### PR DESCRIPTION
On operations details screen, back arrow is missing on sub accounts.

### Type
Bug Fix
### Context

issue LL-2125

### Parts of the app affected / Test plan

On Operations details the back arrow shows up on operations and sub operations view and navigates back to the account details page.

On sub operations screen a close icon is shown, closing the sub operation modal screen.
