### PR TITLE
LL-2112 react native hid version 5.6.0 -> 5.6.2 

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@ledgerhq/hw-transport-http": "5.6.0",
     "@ledgerhq/live-common": "^11.1.1",
     "@ledgerhq/logs": "5.6.0",
-    "@ledgerhq/react-native-hid": "5.6.0",
+    "@ledgerhq/react-native-hid": "5.6.2",
     "@ledgerhq/react-native-hw-transport-ble": "5.6.0",
     "@ledgerhq/react-native-ledger-core": "^4.7.0",
     "@ledgerhq/react-native-passcode-auth": "^2.1.0",

--- a/src/screens/Distribution/index.js
+++ b/src/screens/Distribution/index.js
@@ -28,7 +28,6 @@ import { counterValueCurrencySelector } from "../../reducers/settings";
 import colors from "../../colors";
 import RingChart from "./RingChart";
 import CurrencyUnitValue from "../../components/CurrencyUnitValue";
-import globalSyncRefreshControl from "../../components/globalSyncRefreshControl";
 import { calculateCountervalueSelector } from "../../actions/general";
 
 const forceInset = { bottom: "always" };
@@ -80,7 +79,7 @@ class Distribution extends PureComponent<Props, *> {
 
   onHighlightChange = index => {
     this.setState({ highlight: index });
-    if(this.flatListRef.current){
+    if (this.flatListRef.current) {
       this.flatListRef.current.scrollToIndex({ index }, true);
     }
   };

--- a/src/screens/Settings/CryptoAssets/Currencies/CurrencySettings.js
+++ b/src/screens/Settings/CryptoAssets/Currencies/CurrencySettings.js
@@ -184,7 +184,7 @@ const styles = StyleSheet.create({
     padding: 16,
     paddingVertical: 24,
   },
-  placeholderText:{
+  placeholderText: {
     fontSize: 16,
     color: colors.darkBlue,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,10 +1073,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.6.0.tgz#04277b3c90bee43bb2bd8a5489c5a8aac022687b"
   integrity sha512-pzJ8tQCTqMFaEFmfBcHuqA97gkxLgGb6ztysUCnWsBlG3dczQ0dbz4BRZswDkBkLIh0j8RzM4Ez2uRedxZCJ4w==
 
-"@ledgerhq/react-native-hid@5.6.0":
-  version "5.6.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-hid/-/react-native-hid-5.6.0.tgz#c06c15d7b3f3815669651c87c015a1fd2c6e13d5"
-  integrity sha512-N52vZJhLYK4VyitcY3JjgZTRZ/wxlaRgIRKs9P1F+VekviLp9TuE8yYSD3l3+RPNXPyO3ltBS4mdllPo2YNhCg==
+"@ledgerhq/react-native-hid@5.6.2":
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-hid/-/react-native-hid-5.6.2.tgz#42163ac500477ed1265cf70ba659120e32d424d9"
+  integrity sha512-zN0zTbTLGL5+8B5II8Kris9rkU8kXcfQ5Jd9u+onI1gYwGUgsA3qBOXEOBJJNUZVr9X874F72pPRprMW/zo6fw==
   dependencies:
     "@ledgerhq/devices" "^5.6.0"
     "@ledgerhq/errors" "^5.6.0"


### PR DESCRIPTION
bump react-native-hid version
for usb communication issues on older android devices

### Type

Bug fix

### Context

LL-2112

### Parts of the app affected / Test plan

Usb device communication on android
