### PR TITLE
Bump live-common with latest socket implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@ledgerhq/hw-app-xrp": "5.7.0",
     "@ledgerhq/hw-transport": "5.7.0",
     "@ledgerhq/hw-transport-http": "5.7.0",
-    "@ledgerhq/live-common": "^11.3.0",
+    "@ledgerhq/live-common": "^11.4.0-beta.0",
     "@ledgerhq/logs": "5.6.0",
     "@ledgerhq/react-native-hid": "5.7.0",
     "@ledgerhq/react-native-hw-transport-ble": "5.7.0",

--- a/src/live-common-setup.js
+++ b/src/live-common-setup.js
@@ -6,7 +6,6 @@ import { listen } from "@ledgerhq/logs";
 import HIDTransport from "@ledgerhq/react-native-hid";
 import withStaticURLs from "@ledgerhq/hw-transport-http";
 import { setNetwork } from "@ledgerhq/live-common/lib/network";
-import { logs } from "@ledgerhq/live-common/lib/api/socket";
 import { retry } from "@ledgerhq/live-common/lib/promise";
 import { setEnv } from "@ledgerhq/live-common/lib/env";
 import { setSupportedCurrencies } from "@ledgerhq/live-common/lib/currencies";
@@ -53,12 +52,6 @@ if (Config.VERBOSE) {
     } else {
       console.log(`${type}: ${message || ""}`); // eslint-disable-line no-console
     }
-  });
-}
-
-if (Config.DEBUG_SOCKET) {
-  logs.subscribe(e => {
-    console.log(e); // eslint-disable-line no-console
   });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1032,10 +1032,10 @@
     "@ledgerhq/errors" "^5.7.0"
     events "^3.1.0"
 
-"@ledgerhq/live-common@^11.3.0":
-  version "11.3.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-11.3.0.tgz#c7112d0c75fa6b90f04dc4bec60be51d9984763c"
-  integrity sha512-CXGd3Ogsnh/+TBIuOX4lmuJYONmSPdZKj7sTX2IjRQ0Tbon6tqjtLCnNKPwZrkhO2j+Eic1/7cZLnELGT1+4WA==
+"@ledgerhq/live-common@^11.4.0-beta.0":
+  version "11.4.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-11.4.0-beta.0.tgz#911bc15207c7ce5ea45b7551a1ac2edeb7d10f00"
+  integrity sha512-zxIwLnFmCrK++auWSwiwvcNN3DUuvdoPM17++sQ7PjxzaIdwkiYOUboqOjMEUQdf/zNgeNFnJxkntoNj1NJ4HA==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.7.0"


### PR DESCRIPTION
For the test plan, Please refer to
https://github.com/LedgerHQ/lld-v2/pull/164

it will be similar but we need to test in both iOS and Android because known implementation difference we noticed in the past.