### PR TITLE
LL-2066 SubAccounts header on operation details

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -610,6 +610,7 @@
     "sending": "Sending...",
     "receiving": "Receiving...",
     "tokenOperations": "Token operations",
+    "subAccountOperations": "Subaccount operations",
     "internalOperations": "Internal operations",
     "tokenModal": {
       "desc": "This operation is related to the following token operations"

--- a/src/screens/OperationDetails/Content.js
+++ b/src/screens/OperationDetails/Content.js
@@ -18,6 +18,7 @@ import uniq from "lodash/uniq";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";
 import { Trans } from "react-i18next";
+import { listTokenTypesForCryptoCurrency } from "@ledgerhq/live-common/lib/data/tokens";
 import { localeIds } from "../../languages";
 import LText from "../../components/LText";
 import OperationIcon from "../../components/OperationIcon";
@@ -88,6 +89,8 @@ class Content extends PureComponent<Props, State> {
   render() {
     const { account, parentAccount, operation, currencySettings } = this.props;
     const mainAccount = getMainAccount(account, parentAccount);
+    const isToken =
+      listTokenTypesForCryptoCurrency(mainAccount.currency).length > 0;
     const unit = getAccountUnit(account);
     const parentUnit = getAccountUnit(mainAccount);
     const currency = getAccountCurrency(account);
@@ -184,15 +187,23 @@ class Content extends PureComponent<Props, State> {
           <>
             <View style={[styles.section, styles.infoContainer]}>
               <LText style={styles.sectionSeparator} semiBold>
-                <Trans i18nKey="operationDetails.tokenOperations" />
+                <Trans
+                  i18nKey={
+                    isToken
+                      ? "operationDetails.tokenOperations"
+                      : "operationDetails.subAccountOperations"
+                  }
+                />
               </LText>
-              <Touchable
-                style={styles.info}
-                onPress={this.onPressInfo}
-                event="TokenOperationsInfo"
-              >
-                <Info size={12} color={colors.grey} />
-              </Touchable>
+              {isToken ? (
+                <Touchable
+                  style={styles.info}
+                  onPress={this.onPressInfo}
+                  event="TokenOperationsInfo"
+                >
+                  <Info size={12} color={colors.grey} />
+                </Touchable>
+              ) : null}
             </View>
             {subOperations.map((op, i) => {
               const opAccount = (account.subAccounts || []).find(


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/73656419-5d228600-4690-11ea-9971-17a893e437f1.png)

Since the information circle triggered a modal that was aimed at erc20 tokens specifically I removed it until we have a better solution or different link/content for subaccounts. Ping @aramab 

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2066<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

On the operation details page of an operation containing subaccount operations (think Tezos) the section that is shown above as "Subaccount operations" would read "Token operations".
