### PR TITLE
Prevent double operation details

### DIFF
--- a/src/components/OperationRow.js
+++ b/src/components/OperationRow.js
@@ -16,6 +16,7 @@ import type {
   AccountLike,
 } from "@ledgerhq/live-common/lib/types";
 
+import debounce from "lodash/debounce";
 import LText from "./LText";
 import CurrencyUnitValue from "./CurrencyUnitValue";
 import CounterValue from "./CounterValue";
@@ -46,24 +47,28 @@ class OperationRow extends PureComponent<Props, *> {
     displayCurrencyLogo: false,
   };
 
-  goToOperationDetails = () => {
-    const {
-      navigation,
-      account,
-      parentAccount,
-      operation,
-      isSubOperation,
-    } = this.props;
-    const params = {
-      accountId: account.id,
-      parentId: parentAccount && parentAccount.id,
-      operation, // FIXME we should pass a operationId instead because data can changes over time.
-      isSubOperation,
-      key: operation.id,
-    };
+  goToOperationDetails = debounce(
+    () => {
+      const {
+        navigation,
+        account,
+        parentAccount,
+        operation,
+        isSubOperation,
+      } = this.props;
+      const params = {
+        accountId: account.id,
+        parentId: parentAccount && parentAccount.id,
+        operation, // FIXME we should pass a operationId instead because data can changes over time.
+        isSubOperation,
+        key: operation.id,
+      };
 
-    navigation.push("OperationDetails", params);
-  };
+      navigation.push("OperationDetails", params);
+    },
+    500,
+    { leading: true, trailing: false },
+  );
 
   render() {
     const {


### PR DESCRIPTION
> This is a hack.

We originally had this https://github.com/LedgerHQ/ledger-live-mobile/blob/develop/src/components/OperationRow.js#L65 with `push` and changed it to `navigate` to prevent a user from clicking twice on the row and opening the operation details twice (or more times). However, this introduced the unwanted behavior of operation details from suboperations navigating out of the stack of screen and back to the operations list when clicking back.

So while https://github.com/LedgerHQ/ledger-live-mobile/commit/1117dd70e2881714bf909763bb6fd2ec0a5ac009#diff-03ac037e21831f274f9b74aeb88db9b0R65 fixed the ERC20 UX issue it brought back from the dead [LL-1888](https://ledgerhq.atlassian.net/browse/LL-1888)

The current solution I added is a debounce of the operation row click but it's rather ugly so if someone else wants to take a stab at it feel free. 

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1888

