### PR TITLE
LL-2171 Trancate long account name on asset allocation screen

### DIFF
--- a/src/components/AccountCard.js
+++ b/src/components/AccountCard.js
@@ -43,7 +43,6 @@ class AccountCard extends PureComponent<Props> {
               styles.accountNameText,
               { color: disabled ? colors.grey : colors.darkBlue },
             ]}
-            ellipsizeMode="tail"
           >
             {getAccountName(account)}
           </LText>

--- a/src/components/AccountDistribution/Row.js
+++ b/src/components/AccountDistribution/Row.js
@@ -75,7 +75,6 @@ const Row = ({
           <LText
             numberOfLines={1}
             semiBold
-            ellipsizeMode="tail"
             style={[styles.darkBlue, styles.bodyLeft]}
           >
             {getAccountName(account)}

--- a/src/components/AccountDistribution/Row.js
+++ b/src/components/AccountDistribution/Row.js
@@ -72,10 +72,15 @@ const Row = ({
       {icon}
       <View style={styles.content}>
         <View style={styles.row}>
-          <LText semiBold style={styles.darkBlue}>
+          <LText
+            numberOfLines={1}
+            semiBold
+            ellipsizeMode="tail"
+            style={[styles.darkBlue, styles.bodyLeft]}
+          >
             {getAccountName(account)}
           </LText>
-          <LText tertiary style={styles.darkBlue}>
+          <LText tertiary style={[styles.darkBlue, styles.bodyRight]}>
             <CurrencyUnitValue unit={currency.units[0]} value={amount} />
           </LText>
         </View>
@@ -155,6 +160,14 @@ const styles = StyleSheet.create({
     fontSize: 12,
     lineHeight: 18,
     color: colors.grey,
+  },
+  bodyLeft: {
+    flexGrow: 1,
+    flexShrink: 1,
+    height: 20,
+  },
+  bodyRight: {
+    paddingLeft: 4,
   },
 });
 

--- a/src/components/OperationRow.js
+++ b/src/components/OperationRow.js
@@ -113,7 +113,6 @@ class OperationRow extends PureComponent<Props, *> {
               <LText
                 numberOfLines={1}
                 semiBold
-                ellipsizeMode="tail"
                 style={[styles.bodyLeft, styles.topRow]}
               >
                 {multipleAccounts ? getAccountName(account) : text}
@@ -121,7 +120,6 @@ class OperationRow extends PureComponent<Props, *> {
               <LText
                 tertiary
                 numberOfLines={1}
-                ellipsizeMode="tail"
                 style={[styles.bodyRight, styles.topRow, { color: valueColor }]}
               >
                 <CurrencyUnitValue
@@ -176,12 +174,7 @@ class OperationRow extends PureComponent<Props, *> {
 }
 
 const OpCounterValue = ({ children }: { children: * }) => (
-  <LText
-    tertiary
-    numberOfLines={1}
-    ellipsizeMode="tail"
-    style={styles.bottomRow}
-  >
+  <LText tertiary numberOfLines={1} style={styles.bottomRow}>
     {children}
   </LText>
 );

--- a/src/components/StepHeader.js
+++ b/src/components/StepHeader.js
@@ -26,13 +26,7 @@ class StepHeader extends PureComponent<Props> {
       <TouchableWithoutFeedback onPress={this.onPress}>
         <View style={styles.root}>
           <LText style={styles.subtitle}>{subtitle}</LText>
-          <LText
-            semiBold
-            secondary
-            numberOfLines={1}
-            ellipsizeMode="tail"
-            style={styles.title}
-          >
+          <LText semiBold secondary numberOfLines={1} style={styles.title}>
             {title}
           </LText>
         </View>
@@ -59,7 +53,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default compose(
-  withNavigation,
-  translate(),
-)(StepHeader);
+export default compose(withNavigation, translate())(StepHeader);

--- a/src/components/StepHeader.js
+++ b/src/components/StepHeader.js
@@ -53,4 +53,7 @@ const styles = StyleSheet.create({
   },
 });
 
-export default compose(withNavigation, translate())(StepHeader);
+export default compose(
+  withNavigation,
+  translate(),
+)(StepHeader);

--- a/src/components/SubAccountRow.js
+++ b/src/components/SubAccountRow.js
@@ -41,12 +41,7 @@ class SubAccountRow extends PureComponent<Props> {
         <View accessible style={styles.innerContainer}>
           <CurrencyIcon size={24} currency={currency} />
           <View style={styles.inner}>
-            <LText
-              semiBold
-              numberOfLines={1}
-              ellipsizeMode="middle"
-              style={styles.accountNameText}
-            >
+            <LText semiBold numberOfLines={1} style={styles.accountNameText}>
               {name}
             </LText>
           </View>

--- a/src/families/tezos/AccountBodyHeader.js
+++ b/src/families/tezos/AccountBodyHeader.js
@@ -81,12 +81,7 @@ const styles = StyleSheet.create({
 });
 
 const OpCounterValue = ({ children }: *) => (
-  <LText
-    tertiary
-    numberOfLines={1}
-    ellipsizeMode="tail"
-    style={styles.counterValue}
-  >
+  <LText tertiary numberOfLines={1} style={styles.counterValue}>
     {children}
   </LText>
 );
@@ -141,12 +136,7 @@ const TezosAccountBodyHeader = ({
               <LText semiBold style={styles.delegatorName}>
                 {name}
               </LText>
-              <LText
-                tertiary
-                numberOfLines={1}
-                ellipsizeMode="tail"
-                style={styles.currencyValue}
-              >
+              <LText tertiary numberOfLines={1} style={styles.currencyValue}>
                 <CurrencyUnitValue showCode unit={unit} value={amount} />
               </LText>
             </View>

--- a/src/families/tezos/DelegationDetailsModal.js
+++ b/src/families/tezos/DelegationDetailsModal.js
@@ -260,7 +260,6 @@ const DelegationDetailsModal = ({
                 semiBold
                 style={styles.propertyValueText}
                 numberOfLines={1}
-                ellipsizeMode="tail"
               >
                 {baker.name}
               </LText>

--- a/src/screens/Account/AccountHeaderTitle.js
+++ b/src/screens/Account/AccountHeaderTitle.js
@@ -36,13 +36,7 @@ class AccountHeaderTitle extends Component<Props> {
               currency={getAccountCurrency(account)}
             />
           </View>
-          <LText
-            semiBold
-            secondary
-            numberOfLines={1}
-            ellipsizeMode="tail"
-            style={styles.title}
-          >
+          <LText semiBold secondary numberOfLines={1} style={styles.title}>
             {getAccountName(account)}
           </LText>
         </View>

--- a/src/screens/AccountSettings/AccountNameRow.js
+++ b/src/screens/AccountSettings/AccountNameRow.js
@@ -30,12 +30,7 @@ class AccountNameRow extends PureComponent<Props> {
           })
         }
       >
-        <LText
-          semiBold
-          numberOfLines={1}
-          ellipsizeMode="middle"
-          style={styles.accountName}
-        >
+        <LText semiBold numberOfLines={1} style={styles.accountName}>
           {account.name}
         </LText>
       </SettingsRow>

--- a/src/screens/Accounts/AccountRow.js
+++ b/src/screens/Accounts/AccountRow.js
@@ -101,7 +101,6 @@ class AccountRow extends PureComponent<Props, State> {
                   <LText
                     semiBold
                     numberOfLines={1}
-                    ellipsizeMode="middle"
                     style={styles.accountNameText}
                   >
                     {account.name}

--- a/src/screens/Manager/DeviceNameRow.js
+++ b/src/screens/Manager/DeviceNameRow.js
@@ -55,11 +55,7 @@ class DeviceNameRow extends PureComponent<Props> {
         compact
         top
       >
-        <LText
-          numberOfLines={1}
-          ellipsizeMode="tail"
-          style={styles.accountName}
-        >
+        <LText numberOfLines={1} style={styles.accountName}>
           {savedName}
         </LText>
       </Row>

--- a/src/screens/SendFunds/SummaryFromSection.js
+++ b/src/screens/SendFunds/SummaryFromSection.js
@@ -36,11 +36,7 @@ export default class SummaryFromSection extends PureComponent<Props> {
             <View style={styles.currencyIcon}>
               <CurrencyIcon size={14} currency={currency} />
             </View>
-            <LText
-              numberOfLines={1}
-              ellipsizeMode="tail"
-              style={styles.summaryRowText}
-            >
+            <LText numberOfLines={1} style={styles.summaryRowText}>
               {getAccountName(account)}
             </LText>
           </View>


### PR DESCRIPTION
## Result
<img width="504" alt="Screen Shot 2020-02-06 at 5 34 58 PM" src="https://user-images.githubusercontent.com/8398372/73957683-05418480-4907-11ea-80e2-465122f44854.png">
