### PR TITLE
Fix enabled Continue button when address is empty

### DIFF
--- a/src/screens/SendFunds/02-SelectRecipient.js
+++ b/src/screens/SendFunds/02-SelectRecipient.js
@@ -188,7 +188,7 @@ const SendSelectRecipient = ({
               event="SendRecipientContinue"
               type="primary"
               title={<Trans i18nKey="common.continue" />}
-              disabled={bridgePending || !!error}
+              disabled={bridgePending || !!status.errors.recipient}
               pending={bridgePending}
               onPress={onPressContinue}
             />


### PR DESCRIPTION

![android screencap 2020-02-26 18:29:04](https://user-images.githubusercontent.com/13920153/75370780-ee6ace00-58c5-11ea-9628-18cdcbe2e8da.png)


### Type

Bug fix

### Parts of the app affected / Test plan

Send funds
