### PR TITLE
(Delta): arrow doesn't show on zero delta cases

### DIFF
--- a/src/components/Delta.js
+++ b/src/components/Delta.js
@@ -46,7 +46,11 @@ export default class Delta extends PureComponent<Props> {
 
     return (
       <View style={[styles.root, style]}>
-        {delta.isGreaterThanOrEqualTo(0) ? arrowUp : arrowDown}
+        {!delta.isZero()
+          ? delta.isGreaterThan(0)
+            ? arrowUp
+            : arrowDown
+          : null}
         <View style={styles.content}>
           <LText tertiary style={styles.text}>
             {unit ? (


### PR DESCRIPTION
Issue on graphs delta in zero case where the arrow up was showing
now theres no arrow in this case
**to confirm with design**

![Screenshot_2020-02-27-10-38-58-028_com ledger live debug](https://user-images.githubusercontent.com/11752937/75431969-f706e700-594d-11ea-83a5-cfe827e71a9b.jpg)


### Type

UI Polish

### Context

Graphs delta values

### Parts of the app affected / Test plan

Select an account or period with a variation delta of zero to see this