### PR TITLE
bump libcore version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@ledgerhq/logs": "5.9.0",
     "@ledgerhq/react-native-hid": "5.9.0",
     "@ledgerhq/react-native-hw-transport-ble": "5.9.0",
-    "@ledgerhq/react-native-ledger-core": "^4.7.1",
+    "@ledgerhq/react-native-ledger-core": "^4.9.0",
     "@ledgerhq/react-native-passcode-auth": "^2.1.0",
     "@react-native-community/art": "^1.0.3",
     "@react-native-community/async-storage": "^1.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1000,10 +1000,10 @@
     rxjs "^6.5.4"
     uuid "^3.4.0"
 
-"@ledgerhq/react-native-ledger-core@^4.7.1":
-  version "4.7.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-4.7.1.tgz#47de6a004b2437fa1067270fd475ec08f266b5bc"
-  integrity sha512-1cZdFNlb5qqD+uXQnn64R+1qAGpe7n72+p0YVFp3m/TNmgxWrU3KPCwVKPruCnJhndbdYNIM1YdNcg4K5elBbg==
+"@ledgerhq/react-native-ledger-core@^4.9.0":
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-4.9.0.tgz#b894238e36facd31e5d757c77bfa6a1d41b11d96"
+  integrity sha512-tQWQtpHROOT5q9MQiopFEyRjJl7WAsd64ku/knqrtZacWO1e7xydw9GIJbtXrTU/RYJttTcb4/AW8QYKYqdMaw==
 
 "@ledgerhq/react-native-passcode-auth@^2.1.0":
   version "2.1.0"


### PR DESCRIPTION
Everything should work normally on scan accounts and send.

this bumps same libcore version as in https://github.com/LedgerHQ/ledger-live-desktop/pull/2652

(it's generally good to be in sync on the same libcore version on both mobile and desktop)