### PR TITLE
bump live-common 12.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ledgerhq/hw-app-xrp": "5.9.0",
     "@ledgerhq/hw-transport": "5.9.0",
     "@ledgerhq/hw-transport-http": "5.9.0",
-    "@ledgerhq/live-common": "^12.0.3",
+    "@ledgerhq/live-common": "^12.1.0",
     "@ledgerhq/logs": "5.9.0",
     "@ledgerhq/react-native-hid": "5.9.0",
     "@ledgerhq/react-native-hw-transport-ble": "5.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,10 +933,10 @@
     "@ledgerhq/errors" "^5.9.0"
     events "^3.1.0"
 
-"@ledgerhq/live-common@^12.0.3":
-  version "12.0.3"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.0.3.tgz#f030e14e3d3026d487514484925f15e8c33048d1"
-  integrity sha512-/z9LN4FPQHE77teAQxkTritNHXxFN+7aUkbW2n8VlYhA74jAAgrza3ZEBGSMAhIlSwLVFEdvlpV65ifoQeKZdQ==
+"@ledgerhq/live-common@^12.1.0":
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.1.0.tgz#7b8d86b41844a73d239a1e30c059e26c598e2bad"
+  integrity sha512-swNHIdQKgPklCnG0JQ8aVHHExBl/AXRdoogaojKZHXHxj/WW+O3zexUD4Qp9i+Gzbl80JGE2LufQbuc7R0+ImQ==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.9.0"


### PR DESCRIPTION
bump live-common  version 12.1.0

to be check all is good. we can focus the test on adding and sending one BTC tx. and also test one ERC20 for instance, and tezos. that should be enough coverage.