### PR TITLE
LL-2340 : fix formattedBandwith calculation on TRX Account screen

### DIFF
--- a/src/families/tron/AccountBalanceSummaryFooter.js
+++ b/src/families/tron/AccountBalanceSummaryFooter.js
@@ -50,7 +50,11 @@ function AccountBalanceSummaryFooter({ account, t }: Props) {
   );
 
   const formattedBandwidth = useMemo(
-    () => freeLimit + gainedLimit - gainedUsed - freeUsed,
+    () =>
+      freeLimit
+        .plus(gainedLimit)
+        .minus(gainedUsed)
+        .minus(freeUsed),
     [freeLimit, gainedLimit, gainedUsed, freeUsed],
   );
 


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/LL-2340

Account Bandwidth was incorrect:

Before:
![actual](https://user-images.githubusercontent.com/13007150/77576652-d5116d80-6ed5-11ea-8b9f-b076661d6ee4.PNG)

Now:
![expected](https://user-images.githubusercontent.com/13007150/77576644-d2af1380-6ed5-11ea-9ce8-6a34825900dc.PNG)

### Type

Bug fix

### Context

TRX account with frozen amount.

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
