### PR TITLE
bump live-common version to 12.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ledgerhq/hw-app-xrp": "5.12.0",
     "@ledgerhq/hw-transport": "5.12.0",
     "@ledgerhq/hw-transport-http": "5.12.0",
-    "@ledgerhq/live-common": "12.7.2",
+    "@ledgerhq/live-common": "12.9.0",
     "@ledgerhq/logs": "5.11.0",
     "@ledgerhq/react-native-hid": "5.12.0",
     "@ledgerhq/react-native-hw-transport-ble": "5.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,10 +942,10 @@
     "@ledgerhq/errors" "^5.12.0"
     events "^3.1.0"
 
-"@ledgerhq/live-common@12.7.2":
-  version "12.7.2"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.7.2.tgz#adef00fcc46ed7dedfd8efd6b049e092945b8776"
-  integrity sha512-rLLLMR/wIzcifWugycvS/eNtRaqwbYwX8ycH/sZlufJ0cDSjPbDKwUFzTo9tpRsmDs1mJr1bDIqQuL30b9KlQg==
+"@ledgerhq/live-common@12.9.0":
+  version "12.9.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.9.0.tgz#d7ef916c0d6e23f840cb967808d6f5a632435647"
+  integrity sha512-3hTUtSBWtNcxnYLENvJHjpJUDQbTXZeWq2tISrIFyCbiAGvZPvg6IdvL/uTFhjAfQvfB8rhXEgnpMBYySFiKOA==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.12.0"


### PR DESCRIPTION
Bump live-common version to [12.9.0](https://github.com/LedgerHQ/ledger-live-common/releases/tag/v12.9.0)

- :deciduous_tree: send max + operation number of confirmation fixes
- some special eth accounts fixed (no need to confirm that, but confirm that all is fine for ETH can be good, our tests confirm it anyway and it only impact the sync)
