### PR TITLE
LL-2318 [Android] Fix Nano X on USB detected as Nano S in manager

### DIFF
--- a/src/components/DeviceJob/steps.js
+++ b/src/components/DeviceJob/steps.js
@@ -190,7 +190,7 @@ export const listApps: Step = {
     ),
   run: meta =>
     withDevice(meta.deviceId)(transport =>
-      listAppsTransport(transport, meta.deviceInfo),
+      listAppsTransport(transport, meta.deviceInfo, meta.modelId),
     ).pipe(
       map((e: *) => ({
         ...meta,


### PR DESCRIPTION
Leverage LedgerHQ/ledger-live-common#586 to fix the issue. Won't work until that PR is merged and live-common is bumped.

![image](https://user-images.githubusercontent.com/13920153/78073074-7ef26d80-73a0-11ea-9024-bbbbc543c8f0.png)

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2318
LedgerHQ/ledger-live-common#586

### Parts of the app affected / Test plan

Plug a Nano X via USB OTG on Android and open manager.
