### PR TITLE
bump live-common v12.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@ledgerhq/hw-app-xrp": "5.12.0",
     "@ledgerhq/hw-transport": "5.12.0",
     "@ledgerhq/hw-transport-http": "5.12.0",
-    "@ledgerhq/live-common": "12.9.0",
+    "@ledgerhq/live-common": "12.11.2",
     "@ledgerhq/logs": "5.11.0",
     "@ledgerhq/react-native-hid": "5.12.0",
     "@ledgerhq/react-native-hw-transport-ble": "5.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -942,10 +942,10 @@
     "@ledgerhq/errors" "^5.12.0"
     events "^3.1.0"
 
-"@ledgerhq/live-common@12.9.0":
-  version "12.9.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.9.0.tgz#d7ef916c0d6e23f840cb967808d6f5a632435647"
-  integrity sha512-3hTUtSBWtNcxnYLENvJHjpJUDQbTXZeWq2tISrIFyCbiAGvZPvg6IdvL/uTFhjAfQvfB8rhXEgnpMBYySFiKOA==
+"@ledgerhq/live-common@12.11.2":
+  version "12.11.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.11.2.tgz#98dffbf6813f53c3e8a589e7f5778b87710d07d5"
+  integrity sha512-ScSWiAcy2OKXWn+qBk3q6Ajp2GAq9SKilvaZuaMTiluJqE9FRyKZFRNXrsm8r5wh4YHfuJL9fY8A0RTBEf8ANg==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.12.0"


### PR DESCRIPTION
bump live-common version to [12.11.2](https://github.com/LedgerHQ/ledger-live-common/releases/tag/v12.11.1)

