### PR TITLE
LL-2318 [Android] Fix Nano X on USB detected as Nano S in manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@ledgerhq/hw-transport-http": "5.12.0",
     "@ledgerhq/live-common": "12.9.0",
     "@ledgerhq/logs": "5.11.0",
-    "@ledgerhq/react-native-hid": "5.12.0",
+    "@ledgerhq/react-native-hid": "5.12.3",
     "@ledgerhq/react-native-hw-transport-ble": "5.12.0",
     "@ledgerhq/react-native-ledger-core": "^4.7.1",
     "@ledgerhq/react-native-passcode-auth": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,10 +988,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.11.0.tgz#9ad2aefceeef48cf9d77972f67e63ba478dd04cc"
   integrity sha512-NiFDdxLU/z1VGQy0/cbpv7UScMDQ/rU8SznqILSHYTnhK2xvvNFTUkd1W2mpmf9E/hzXFI0UAOieLQ44qovX3w==
 
-"@ledgerhq/react-native-hid@5.12.0":
-  version "5.12.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-hid/-/react-native-hid-5.12.0.tgz#8377bc31f169c64d039cf61b58a4dae776db1d70"
-  integrity sha512-PVj3At+Mhjs0E+cmDcWcRciIrC3pDru7nU/2rI2BJsnriRRM4HISlLrTU5r8pqs/8KuXFm98Md1H4vo7Y+PBjw==
+"@ledgerhq/react-native-hid@5.12.3":
+  version "5.12.3"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-hid/-/react-native-hid-5.12.3.tgz#4794f524bf083e40937bf509c93ad48cc8187ec9"
+  integrity sha512-f6+2Be/rqdpICcSniSI6eyAkzNs2UkdCJP7sdXDdPsaJRXBA9zEmXdvySLRTulGM+PDmXemAP+jyKXNaScd3jA==
   dependencies:
     "@ledgerhq/devices" "^5.12.0"
     "@ledgerhq/errors" "^5.12.0"


### PR DESCRIPTION
Changed strategy from previous PR, and fixed the issue in LedgerHQ/ledgerjs#483 rather than live-common.
This PR bumps `@ledgerhq/react-native-hid` to have the above fix in.

![image](https://user-images.githubusercontent.com/13920153/78073074-7ef26d80-73a0-11ea-9024-bbbbc543c8f0.png)

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2318
LedgerHQ/ledgerjs#483

### Parts of the app affected / Test plan

Plug a Nano X via USB OTG on Android and open manager.
