### PR TITLE
Fallback to USD when the user selected fiat counterValue is not supported

### DIFF
--- a/src/context/LedgerStore.js
+++ b/src/context/LedgerStore.js
@@ -10,6 +10,7 @@ import reducers from "../reducers";
 import { importSettings } from "../actions/settings";
 import { importStore as importAccounts } from "../actions/accounts";
 import { importBle } from "../actions/ble";
+import { INITIAL_STATE, supportedCountervalues } from "../reducers/settings";
 
 const createLedgerStore = () =>
   createStore(
@@ -55,6 +56,15 @@ export default class LedgerStoreProvider extends Component<
     store.dispatch(importBle(bleData));
 
     const settingsData = await db.get("settings");
+    if (
+      settingsData &&
+      settingsData.counterValue &&
+      !supportedCountervalues.find(
+        ({ ticker }) => ticker === settingsData.counterValue,
+      )
+    ) {
+      settingsData.counterValue = INITIAL_STATE.counterValue;
+    }
     store.dispatch(importSettings(settingsData));
 
     const accountsData = await db.get("accounts");

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -7,6 +7,7 @@ import {
   findCurrencyByTicker,
   getCryptoCurrencyById,
   getFiatCurrencyByTicker,
+  listSupportedFiats,
 } from "@ledgerhq/live-common/lib/currencies";
 import { getEnv, setEnvUnsafe } from "@ledgerhq/live-common/lib/env";
 import { createSelector } from "reselect";
@@ -24,6 +25,10 @@ import { currencySettingsDefaults } from "../helpers/CurrencySettingsDefaults";
 const bitcoin = getCryptoCurrencyById("bitcoin");
 const ethereum = getCryptoCurrencyById("ethereum");
 export const possibleIntermediaries = [bitcoin, ethereum];
+export const supportedCountervalues = [
+  ...listSupportedFiats(),
+  ...possibleIntermediaries,
+];
 export const intermediaryCurrency = (from: Currency, _to: Currency) => {
   if (from === ethereum || from.type === "TokenCurrency") return ethereum;
   return bitcoin;
@@ -70,7 +75,7 @@ export type SettingsState = {
   hideEmptyTokenAccounts: boolean,
 };
 
-const INITIAL_STATE: SettingsState = {
+export const INITIAL_STATE: SettingsState = {
   counterValue: "USD",
   counterValueExchange: null,
   privacy: null,

--- a/src/screens/Settings/General/CountervalueSettings.js
+++ b/src/screens/Settings/General/CountervalueSettings.js
@@ -1,16 +1,15 @@
 /* @flow */
 import { connect } from "react-redux";
-import { listSupportedFiats } from "@ledgerhq/live-common/lib/currencies";
 import i18next from "i18next";
 import { setCountervalue } from "../../../actions/settings";
 import {
   counterValueCurrencySelector,
-  possibleIntermediaries,
+  supportedCountervalues,
 } from "../../../reducers/settings";
 import type { State } from "../../../reducers";
 import makeGenericSelectScreen from "../../makeGenericSelectScreen";
 
-const items = [...listSupportedFiats(), ...possibleIntermediaries]
+const items = supportedCountervalues
   .map(cur => ({ value: cur.ticker, label: `${cur.name} (${cur.ticker})` }))
   .sort((a, b) => a.label.localeCompare(b.label));
 


### PR DESCRIPTION
### Description
This pr introduces the automatic fallback to using USD as a counter value when the currently selected counter value is not reported as supported. Without this, users who have selected a non-supported fiat counter value will see their total balances and graphs as broken.

### Type
Feature

### Context
Slack conversation, no Jira task as far as I know

Parts of the app affected / Test plan
- With the **desktop** application stopped and before this https://github.com/LedgerHQ/ledger-live-desktop/pull/2795 gets merged
- Edit your `app.json` and set the counter value to something not supported (but contemplated in https://github.com/LedgerHQ/ledger-live-common/blob/1a29a3bc5f533ee29e0a47c577a1a7e068546e0b/src/data/fiat.js#L23-L73. 
- Launch the app, open the console, and export the accounts/settings. You'll see a `BRIDGESTREAM_DATA` variable in the console.
- Copy that into your mobile's project `.env` file. 
- Launch the mobile app, go into the `Settings>Debug>Mock>Import` and import the settings. It should set the counter value to the invalid one from the desktop.
- Move to this branch if not here already, and relaunch the app. It should fix the broken portfolio graph and set the counter value to USD again.

For best results, use an `app.json` with a single account since large exports sometimes don't work with the emulator when it's an env.