### PR TITLE
new scripts to make it easier to release from local machines

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,13 +30,26 @@ lane :internal_release do
     next
   end
 
-  system "yarn"
+  system "yarn --frozen-lockfile"
 
   ensure_git_status_clean
 
   Fastlane::LaneManager.cruise_lane('ios', 'beta', nil, 'production')
   Fastlane::LaneManager.cruise_lane('android', 'beta')
 
+end
+
+lane :beta do
+  ensure_git_status_clean
+  ensure_git_branch(
+    branch: 'develop'
+  )
+  git_pull
+
+  system "yarn --frozen-lockfile"
+
+  Fastlane::LaneManager.cruise_lane('ios', 'beta', nil, 'production')
+  Fastlane::LaneManager.cruise_lane('android', 'beta')
 end
 
 platform :ios do
@@ -81,17 +94,6 @@ platform :ios do
         }
       )
     end
-
-  end
-
-  desc "private: upload to Testflight"
-  private_lane :upload_beta do
-    pilot(
-      skip_submission: true,
-      app_identifier: "com.ledger.live",
-      skip_waiting_for_build_processing: true,
-      ipa: 'ios/ledgerlivemobile.ipa'
-    )
   end
 
   desc "private: bump build number"
@@ -116,6 +118,16 @@ platform :ios do
       sign: true
     )
     push_to_git_remote
+  end
+
+  desc "upload to Testflight"
+  lane :upload_beta do
+    pilot(
+      skip_submission: true,
+      app_identifier: "com.ledger.live",
+      skip_waiting_for_build_processing: true,
+      ipa: 'ios/ledgerlivemobile.ipa'
+    )
   end
 
   desc "build and push to TestFlight"
@@ -193,22 +205,24 @@ platform :android do
     push_to_git_remote
   end
 
-  desc "build and upload beta to Google Play Store"
-  lane :beta do
-    prepare_android_internal
-    build(type: "Release")
+  desc "upload to Play Store"
+  lane :upload_beta do
     upload_to_play_store(
       track: 'internal',
       package_name: 'com.ledger.live'
     )
   end
 
+  desc "build and upload beta to Google Play Store"
+  lane :beta do
+    prepare_android_internal
+    build(type: "Release")
+    upload_beta
+  end
+
   desc "rebuild and upload beta to Google Play Store"
   lane :redo_beta do
     build(type: "Release")
-    upload_to_play_store(
-      track: 'internal',
-      package_name: 'com.ledger.live'
-    )
+    upload_beta
   end
 end

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "android:import": "./scripts/android-import.sh",
     "android:staging": "cd android && ./gradlew assembleStagingRelease",
     "android:mock": "cd android && ENVFILE=.env.mock ./gradlew assembleStagingRelease",
+    "android:upload": "bundle exec fastlane android upload_beta",
     "android:release": "./scripts/android-release.sh",
     "android:install": "./scripts/install-and-run-apk.sh",
     "ios": "react-native run-ios",
     "ios:internal": "bundle exec fastlane ios redo_beta --env production",
     "ios:ipa": "bundle exec fastlane ios build_ipa --env production",
+    "ios:upload": "bundle exec fastlane ios upload_beta",
     "preios:internal": "bundle install",
     "ios:staging": "ENVFILE=.env.staging react-native run-ios --configuration Release",
     "staging-android": "yarn android:staging && yarn android:install",
@@ -30,6 +32,8 @@
     "debugSVG": "sh scripts/debugsvg.sh | node_modules/.bin/prettier --parser flow > src/screens/DebugSVG.js",
     "internal": "FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=30 FASTLANE_XCODEBUILD_SETTINGS_RETRIES=5 bundle exec fastlane internal_release",
     "preinternal": "bundle install",
+    "beta": "FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT=30 FASTLANE_XCODEBUILD_SETTINGS_RETRIES=5 bundle exec fastlane beta",
+    "prebeta": "bundle install",
     "pod": "cd ios && bundle exec pod install"
   },
   "jest": {


### PR DESCRIPTION
Make release easier from our devs machine (the other workflow was made for Jenkins CI)

### Type

Improvement

### Context

LL-2372

### Parts of the app affected / Test plan

CI

In this PR I've added a few scripts to make it easier to release from our own local computers.

- `yarn beta`: is almost like `yarn internal` but with lesser checks so easier to run local. this script _should_ release both iOS and Android (starting with iOS)
- `yarn ios:upload` and `yarn android:upload`: make it easier to just start an upload (does not recomple the apps, will just start the upload process)