### PR TITLE
Prevent goBack to Started page if it is already skipped

### DIFF
--- a/src/families/tron/Votes/index.js
+++ b/src/families/tron/Votes/index.js
@@ -115,13 +115,6 @@ const Delegation = ({ account, parentAccount, navigation }: Props) => {
     [accountId, navigation, parentId],
   );
 
-  const onManageVotes = useCallback(() => {
-    navigation.navigate("CastVote", {
-      accountId,
-      parentId,
-    });
-  }, [navigation, accountId, parentId]);
-
   const onDelegate = useCallback(() => {
     const screenName = lastVotedDate ? "VoteSelectValidator" : "VoteStarted";
     navigation.navigate(screenName, {
@@ -181,7 +174,7 @@ const Delegation = ({ account, parentAccount, navigation }: Props) => {
       {tronPower > 0 ? (
         formattedVotes.length > 0 ? (
           <>
-            <Header count={formattedVotes.length} onPress={onManageVotes} />
+            <Header count={formattedVotes.length} onPress={onDelegate} />
             <View style={[styles.container, styles.noPadding]}>
               {formattedVotes.map(
                 ({ validator, address, voteCount, isSR }, index) => (

--- a/src/families/tron/VotingFlow/index.js
+++ b/src/families/tron/VotingFlow/index.js
@@ -15,13 +15,6 @@ import VoteValidationSuccess from "./04-ValidationSuccess";
 
 const VoteFlow = createStackNavigator(
   {
-    VoteStarted: {
-      // $FlowFixMe
-      screen: VoteStarted,
-      navigationOptions: {
-        title: i18next.t("tron.voting.flow.started.title"),
-      },
-    },
     // $FlowFixMe
     VoteSelectValidator,
     CastVote,
@@ -29,6 +22,13 @@ const VoteFlow = createStackNavigator(
     VoteValidation,
     VoteValidationError,
     VoteValidationSuccess,
+    VoteStarted: {
+      // $FlowFixMe
+      screen: VoteStarted,
+      navigationOptions: {
+        title: i18next.t("tron.voting.flow.started.title"),
+      },
+    },
   },
   closableStackNavigatorConfig,
 );


### PR DESCRIPTION
If you try managing votes from an account that already voted
and then navigate back using native navigation
you should be redirected to the account page now instead of the Starter info one.