### PR TITLE
Fix to reset modal confirmation for blacklisting tokens

### DIFF
--- a/src/screens/Settings/Accounts/BlacklistTokenModal.js
+++ b/src/screens/Settings/Accounts/BlacklistTokenModal.js
@@ -51,10 +51,10 @@ const BlacklistTokenModal = ({
     onCloseModal();
   }, [onCloseModal, blacklistToken, token]);
 
-  return isOpened ? (
-    showConfirmation ? (
+  return (
+    <>
       <ConfirmationModal
-        isOpened
+        isOpened={isOpened && showConfirmation}
         onClose={onCloseModal}
         onConfirm={onBlacklistToken}
         confirmationTitle={
@@ -63,7 +63,7 @@ const BlacklistTokenModal = ({
         confirmationDesc={
           <Trans i18nKey="settings.accounts.blacklistedTokensModal.desc">
             {"1This action will hide all "}
-            <LText bold>{token.name}</LText>
+            <LText bold>{token && token.name}</LText>
             {" accounts, you can restore their visibility at any time from "}
             <LText bold>{"1Settings"}</LText>
           </Trans>
@@ -72,52 +72,53 @@ const BlacklistTokenModal = ({
           <Trans i18nKey="settings.accounts.blacklistedTokensModal.confirm" />
         }
       />
-    ) : (
       <BottomModal
         id="BlacklistModal"
-        isOpened
+        isOpened={isOpened && !showConfirmation}
         preventBackdropClick={false}
         onClose={onCloseModal}
       >
-        <SafeAreaView style={styles.modal}>
-          <View style={styles.header}>
-            <View style={{ marginRight: 12 }}>
-              <CurrencyIcon currency={token} size={24} />
+        {token ? (
+          <SafeAreaView style={styles.modal}>
+            <View style={styles.header}>
+              <View style={{ marginRight: 12 }}>
+                <CurrencyIcon currency={token} size={24} />
+              </View>
+              <LText>{token.name}</LText>
             </View>
-            <LText>{token.name}</LText>
-          </View>
-          <Touchable
-            hitSlop={hitSlop}
-            onPress={() => setShowConfirmation(true)}
-            style={styles.item}
-            event="blacklistToken"
-          >
-            <View style={{ marginRight: 8 }}>
-              <BanIcon size={18} color={colors.smoke} />
-            </View>
-            <LText tertiary>
-              <Trans i18nKey="settings.accounts.hideTokenCTA" />
-            </LText>
-          </Touchable>
-          {onShowContract ? (
             <Touchable
               hitSlop={hitSlop}
-              onPress={() => onShowContract(true)}
+              onPress={() => setShowConfirmation(true)}
               style={styles.item}
               event="blacklistToken"
             >
               <View style={{ marginRight: 8 }}>
-                <Icon name="file-text" size={18} color={colors.smoke} />
+                <BanIcon size={18} color={colors.smoke} />
               </View>
               <LText tertiary>
-                <Trans i18nKey="settings.accounts.showContractCTA" />
+                <Trans i18nKey="settings.accounts.hideTokenCTA" />
               </LText>
             </Touchable>
-          ) : null}
-        </SafeAreaView>
+            {onShowContract ? (
+              <Touchable
+                hitSlop={hitSlop}
+                onPress={() => onShowContract(true)}
+                style={styles.item}
+                event="blacklistToken"
+              >
+                <View style={{ marginRight: 8 }}>
+                  <Icon name="file-text" size={18} color={colors.smoke} />
+                </View>
+                <LText tertiary>
+                  <Trans i18nKey="settings.accounts.showContractCTA" />
+                </LText>
+              </Touchable>
+            ) : null}
+          </SafeAreaView>
+        ) : null}
       </BottomModal>
-    )
-  ) : null;
+    </>
+  );
 };
 
 export default connect(

--- a/src/screens/Settings/Accounts/BlacklistTokenModal.js
+++ b/src/screens/Settings/Accounts/BlacklistTokenModal.js
@@ -41,16 +41,21 @@ const BlacklistTokenModal = ({
 }) => {
   const [showConfirmation, setShowConfirmation] = useState(false);
 
+  const onCloseModal = useCallback(() => {
+    setShowConfirmation(false);
+    onClose();
+  }, [onClose]);
+
   const onBlacklistToken = useCallback(() => {
     blacklistToken(token.id);
-    onClose();
-  }, [onClose, blacklistToken, token]);
+    onCloseModal();
+  }, [onCloseModal, blacklistToken, token]);
 
   return isOpened ? (
     showConfirmation ? (
       <ConfirmationModal
         isOpened
-        onClose={onClose}
+        onClose={onCloseModal}
         onConfirm={onBlacklistToken}
         confirmationTitle={
           <Trans i18nKey="settings.accounts.blacklistedTokensModal.title" />
@@ -72,7 +77,7 @@ const BlacklistTokenModal = ({
         id="BlacklistModal"
         isOpened
         preventBackdropClick={false}
-        onClose={onClose}
+        onClose={onCloseModal}
       >
         <SafeAreaView style={styles.modal}>
           <View style={styles.header}>


### PR DESCRIPTION
This pr resets the state of the blacklist modal every time it's closed, before it will only show the first step the first time.