### PR TITLE
(TRX): fix navigation issue after freeze success

### DIFF
--- a/src/screens/FreezeFunds/04-ValidationSuccess.js
+++ b/src/screens/FreezeFunds/04-ValidationSuccess.js
@@ -52,6 +52,7 @@ const ValidationSuccess = ({ account, navigation }: Props) => {
 
   const goToVote = useCallback(() => {
     const screenName = lastVotedDate ? "VoteSelectValidator" : "VoteStarted";
+    navigation.dismiss();
     navigation.navigate(screenName, {
       accountId,
       parentId: undefined,


### PR DESCRIPTION
Fixed navigation issue after freeze success to vote then close after vote success

###Type

Bug Fix

### Parts of the app affected / Test plan

Freeze tron assets 
wait 60 seconds
Vote
Go till the end of the voting process
on the success vote page when clicking on close you should be redirected to the accounts page

