### PR TITLE
LL-2378 (TRX): percentage votes used flooring fixed

### DIFF
--- a/src/components/ProgressCircle.js
+++ b/src/components/ProgressCircle.js
@@ -52,7 +52,7 @@ export default ({
       y={CENTER + 6}
       textAnchor="middle"
     >
-      {Number(progress * 1e2).toFixed(0)}%
+      {Math.floor(progress * 1e2)}%
     </Text>
   </Svg>
 );


### PR DESCRIPTION
Issue on votes used flooring

![Screenshot_1586440653](https://user-images.githubusercontent.com/11752937/78902986-d799c880-7a7a-11ea-93f8-a764d5f0cbe4.png)

### Type

UI Polish

### Context

LL-2378

### Parts of the app affected / Test plan

Use almost all of your TRX votes
You will then see the banner telling you you used 99% of your votes at maximum
