### PR TITLE
LL-2295 Android: fixes app to freeze at boot due to SQLite limit reached (2 MB) – change our db to store per account

### DIFF
--- a/src/components/DBSave.js
+++ b/src/components/DBSave.js
@@ -1,61 +1,78 @@
 // @flow
-import { Component } from "react";
-import throttle from "lodash/throttle";
-import { connect } from "react-redux";
-import db from "../db";
+import { useRef, useEffect, useMemo } from "react";
+import identity from "lodash/identity";
+import throttleFn from "lodash/throttle";
+import { useSelector } from "react-redux";
 import type { State } from "../reducers";
 
-const instances = [];
-
-export const flushAll = () => Promise.all(instances.map(i => i.save.flush()));
-
-class DBSave extends Component<{
-  dbKey: string,
-  state: State,
-  hasChanged: (next: State, prev: State) => boolean,
-  lense: (s: State) => any,
+type Props<Data, Stats> = {
   throttle: number,
-}> {
-  componentDidUpdate({ state }) {
-    if (this.props.hasChanged(state, this.props.state)) {
-      this.save();
-    }
-  }
+  lense: (s: State) => Data,
+  getChangesStats: (next: State, prev: State) => Stats,
+  save: (data: Data, changedStats: Stats) => Promise<void>,
+};
 
-  componentWillMount() {
-    instances.push(this);
-  }
+const DBSave = <D, S>({
+  lense,
+  throttle = 500,
+  save,
+  getChangesStats,
+}: Props<D, S>) => {
+  const state: State = useSelector(identity);
+  const lastSavedState = useRef(state);
 
-  componentWillUnmount() {
-    this.save.cancel();
-    const i = instances.indexOf(this);
-    if (i !== -1) {
-      instances.splice(i, 1);
-    }
-  }
+  // we keep an updated version of current props in "latestProps" ref
+  const latestProps = useRef({ lense, save, state, getChangesStats });
 
-  save = throttle(() => {
-    const startTime = Date.now();
-    const { lense, dbKey, state } = this.props;
-    return db.save(dbKey, lense(state)).then(
-      () => {
-        if (__DEV__) {
-          /* eslint-disable no-console */
-          console.log(
-            `${dbKey} DB saved in ${(Date.now() - startTime).toFixed(0)} ms`,
-          );
-          /* eslint-enable no-console */
-        }
-      },
-      e => {
-        console.error(e);
-      },
-    );
-  }, this.props.throttle || 500);
+  const checkForSave = useMemo(
+    () =>
+      // throttle allow to not spam lense and save too much because they are costly
+      // nb it does not prevent race condition here. save must be idempotent and atomic
+      throttleFn(async () => {
+        const { lense, save, state, getChangesStats } = latestProps.current;
+        const changedStats = getChangesStats(lastSavedState.current, state); // we compare last saved with latest state
+        if (!changedStats) return; // if it's falsy, it means there is no changes
+        await save(lense(state), changedStats); // we save it for real
+        lastSavedState.current = state; // for the next round, we will be able to compare with latest successful state
+      }, throttle),
+    [throttle],
+  );
 
-  render() {
-    return null;
-  }
+  useFlushMechanism(checkForSave);
+
+  // each time a prop changes, we will checkForSave
+  useEffect(() => {
+    latestProps.current = { lense, save, state, getChangesStats };
+    checkForSave();
+  }, [lense, save, state, checkForSave, getChangesStats]);
+
+  return null;
+};
+
+export default DBSave;
+
+const flushes = [];
+export const flushAll = () => Promise.all(flushes.map(flush => flush()));
+function useFlushMechanism({
+  flush,
+  cancel,
+}: {
+  flush: () => void,
+  cancel: () => void,
+}) {
+  const cancelRef = useRef(cancel);
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return () => cancelRef.current();
+  }, [cancelRef]);
+
+  useEffect(() => {
+    flushes.push(flush);
+    return () => {
+      const i = flushes.indexOf(flush);
+      if (i !== -1) {
+        flushes.splice(i, 1);
+      }
+    };
+  }, [flush]);
 }
-
-export default connect(state => ({ state }))(DBSave);

--- a/src/context/LedgerStore.js
+++ b/src/context/LedgerStore.js
@@ -4,7 +4,7 @@ import React, { Component } from "react";
 import { Provider } from "react-redux";
 import thunk from "redux-thunk";
 import { createStore, applyMiddleware, compose } from "redux";
-import db from "../db";
+import { getAccounts, getCountervalues, getSettings, getBle } from "../db";
 import CounterValues from "../countervalues";
 import reducers from "../reducers";
 import { importSettings } from "../actions/settings";
@@ -52,10 +52,10 @@ export default class LedgerStoreProvider extends Component<
   async init() {
     const { store } = this.state;
 
-    const bleData = await db.get("ble");
+    const bleData = await getBle();
     store.dispatch(importBle(bleData));
 
-    const settingsData = await db.get("settings");
+    const settingsData = await getSettings();
     if (
       settingsData &&
       settingsData.counterValue &&
@@ -67,13 +67,10 @@ export default class LedgerStoreProvider extends Component<
     }
     store.dispatch(importSettings(settingsData));
 
-    /** check accounts data and migrate if needed  */
-    await db.migrateAccounts();
-
-    const accountsData = await db.get("accounts");
+    const accountsData = await getAccounts();
     store.dispatch(importAccounts(accountsData));
 
-    const countervaluesData = await db.get("countervalues");
+    const countervaluesData = await getCountervalues();
     store.dispatch(CounterValues.importAction(countervaluesData));
 
     this.setState({ ready: true }, () => {

--- a/src/context/LedgerStore.js
+++ b/src/context/LedgerStore.js
@@ -7,6 +7,7 @@ import { createStore, applyMiddleware, compose } from "redux";
 import { getAccounts, getCountervalues, getSettings, getBle } from "../db";
 import CounterValues from "../countervalues";
 import reducers from "../reducers";
+import { refreshAccountsOrdering } from "../actions/general";
 import { importSettings } from "../actions/settings";
 import { importStore as importAccounts } from "../actions/accounts";
 import { importBle } from "../actions/ble";
@@ -69,6 +70,8 @@ export default class LedgerStoreProvider extends Component<
 
     const accountsData = await getAccounts();
     store.dispatch(importAccounts(accountsData));
+
+    store.dispatch(refreshAccountsOrdering());
 
     const countervaluesData = await getCountervalues();
     store.dispatch(CounterValues.importAction(countervaluesData));

--- a/src/context/LedgerStore.js
+++ b/src/context/LedgerStore.js
@@ -67,6 +67,9 @@ export default class LedgerStoreProvider extends Component<
     }
     store.dispatch(importSettings(settingsData));
 
+    /** check accounts data and migrate if needed  */
+    await db.migrateAccounts();
+
     const accountsData = await db.get("accounts");
     store.dispatch(importAccounts(accountsData));
 

--- a/src/context/LedgerStore.js
+++ b/src/context/LedgerStore.js
@@ -7,7 +7,6 @@ import { createStore, applyMiddleware, compose } from "redux";
 import { getAccounts, getCountervalues, getSettings, getBle } from "../db";
 import CounterValues from "../countervalues";
 import reducers from "../reducers";
-import { refreshAccountsOrdering } from "../actions/general";
 import { importSettings } from "../actions/settings";
 import { importStore as importAccounts } from "../actions/accounts";
 import { importBle } from "../actions/ble";
@@ -70,8 +69,6 @@ export default class LedgerStoreProvider extends Component<
 
     const accountsData = await getAccounts();
     store.dispatch(importAccounts(accountsData));
-
-    store.dispatch(refreshAccountsOrdering());
 
     const countervaluesData = await getCountervalues();
     store.dispatch(CounterValues.importAction(countervaluesData));

--- a/src/context/Reboot.js
+++ b/src/context/Reboot.js
@@ -1,7 +1,7 @@
 // @flow
 import React, { Fragment } from "react";
 import hoistNonReactStatic from "hoist-non-react-statics";
-import db from "../db";
+import { clearDb } from "../db";
 import clearLibcore from "../helpers/clearLibcore";
 
 // $FlowFixMe
@@ -28,9 +28,7 @@ export default class RebootProvider extends React.Component<
       rebootId: state.rebootId + 1,
     }));
     if (resetData) {
-      await clearLibcore(() =>
-        db.delete(["settings", "accounts", "countervalues", "ble"]),
-      );
+      await clearLibcore(clearDb);
     }
     if (onRebootEnd) onRebootEnd();
   };

--- a/src/db.js
+++ b/src/db.js
@@ -1,116 +1,153 @@
 // @flow
+import { log } from "@ledgerhq/logs";
 import store from "react-native-simple-store";
+import { atomicQueue } from "@ledgerhq/live-common/lib/promise";
+import type { AccountRaw } from "@ledgerhq/live-common/lib/types";
 
 const ACCOUNTS_KEY = "accounts";
 const ACCOUNTS_DB_PREFIX = "accounts.active.";
 
-export default class DB {
-  static get(key: string | any[]): Promise<any> {
-    /** handle accounts case */
-    if (key === ACCOUNTS_KEY) return DB.getAccounts();
-    return store.get(key);
+export async function clearDb() {
+  await store.delete(["settings", "accounts", "countervalues", "ble"]);
+}
+
+export async function getUser(): Promise<{ id: string }> {
+  const user = await store.get("user");
+  return user;
+}
+
+export async function setUser(user: { id: string }): Promise<void> {
+  await store.update("user", user);
+}
+
+export async function getSettings(): Promise<*> {
+  const settings = await store.get("settings");
+  return settings;
+}
+
+export async function saveSettings(obj: *): Promise<void> {
+  await store.save("settings", obj);
+}
+
+export async function getCountervalues(): Promise<*> {
+  const countervalues = await store.get("countervalues");
+  return countervalues;
+}
+
+export async function saveCountervalues(obj: *): Promise<void> {
+  await store.save("countervalues", obj);
+}
+
+export async function getBle(): Promise<*> {
+  const ble = await store.get("ble");
+  return ble;
+}
+
+export async function saveBle(obj: *): Promise<void> {
+  await store.save("ble", obj);
+}
+
+const formatAccountDBKey = (id: string): string => `${ACCOUNTS_DB_PREFIX}${id}`;
+
+/** get Db accounts keys */
+function getAccountsKeys(): Promise<Array<string>> {
+  return store.keys().then(keys => {
+    /** filter through them to get only the accounts ones */
+    return keys.filter(key => key.indexOf(ACCOUNTS_DB_PREFIX) === 0);
+  });
+}
+
+// get accounts specific method to aggregate all account keys into the correct format
+async function unsafeGetAccounts(): Promise<{ active: AccountRaw[] }> {
+  await migrateAccountsIfNecessary();
+
+  const accountKeys = await getAccountsKeys();
+
+  // if some account keys, we retrieve them and return
+  if (accountKeys && accountKeys.length > 0) {
+    const active = await store.get(accountKeys);
+    return { active };
   }
 
-  static save(key: string | any[], value: any): Promise<any> {
-    /** handle accounts case */
-    if (key === ACCOUNTS_KEY) return DB.saveAccounts(value);
-    return store.save(key, value);
-  }
+  // fallback to empty state
+  return { active: [] };
+}
 
-  static update(key: string, value: any): Promise<any> {
-    return store.update(key, value);
-  }
-
-  static keys(): Promise<any> {
-    return store.keys();
-  }
-
-  static delete(key: string | any[]): Promise<any> {
-    return store.delete(key);
-  }
-
-  static push(key: string, value: any): Promise<any> {
-    return store.push(key, value);
-  }
-
-  /** format account id to its account DB key */
-  static formatAccountDBKey = (id: string): string =>
-    `${ACCOUNTS_DB_PREFIX}${id}`;
-
-  /** save accounts method between SQLite db and redux store persist */
-  static saveAccounts({
+/** save accounts method between SQLite db and redux store persist */
+async function unsafeSaveAccounts(
+  {
     active: newAccounts,
   }: {
     active: any[],
-  }): Promise<any> {
-    return DB.getAccountsKeys().then(currentAccountKeys => {
-      /** format data for DB persist */
-      const dbData = newAccounts.map(({ data }) => [
-        DB.formatAccountDBKey(data.id),
-        { data, version: 1 },
-      ]);
+  },
+  stats?: ?{
+    changed: string[],
+  },
+): Promise<void> {
+  log("db", "saving accounts...");
+  const currentAccountKeys = await getAccountsKeys();
+  /** format data for DB persist */
+  const dbData = newAccounts.map(({ data }) => [
+    formatAccountDBKey(data.id),
+    { data, version: 1 },
+  ]);
 
-      /** Find current DB accounts keys diff with app state to remove them */
-      const deletedKeys =
-        currentAccountKeys && currentAccountKeys.length
-          ? currentAccountKeys.filter(key =>
-              dbData.every(([accountKey]) => accountKey !== key),
-            )
-          : [];
+  /** Find current DB accounts keys diff with app state to remove them */
+  const deletedKeys =
+    currentAccountKeys && currentAccountKeys.length
+      ? currentAccountKeys.filter(key =>
+          dbData.every(([accountKey]) => accountKey !== key),
+        )
+      : [];
 
-      /** persist store data to DB */
-      return store.save(dbData).then(() => {
-        /** then delete potential removed keys */
-        if (deletedKeys.length > 0) return DB.delete(deletedKeys);
+  // we only save those who effectively changed
+  const dbDataWithOnlyChanges = !stats
+    ? dbData
+    : dbData.filter(([_key, { data }]) => stats.changed.includes(data.id));
 
-        return Promise.resolve(true);
-      });
-    });
+  /** persist store data to DB */
+  await store.save(dbDataWithOnlyChanges);
+
+  /** then delete potential removed keys */
+  if (deletedKeys.length > 0) {
+    await store.delete(deletedKeys);
   }
+  log(
+    "db",
+    "saved " +
+      dbDataWithOnlyChanges.length +
+      " accounts" +
+      (deletedKeys.length ? " and deleted " + deletedKeys.length : ""),
+  );
+}
 
-  /** get Db accounts keys */
-  static getAccountsKeys(): Promise<Array<string>> {
-    return DB.keys().then(keys => {
-      /** filter through them to get only the accounts ones */
-      return keys.filter(key => key.indexOf(ACCOUNTS_DB_PREFIX) === 0);
-    });
-  }
+export const getAccounts: typeof unsafeGetAccounts = atomicQueue(
+  unsafeGetAccounts,
+);
+export const saveAccounts: typeof unsafeSaveAccounts = atomicQueue(
+  unsafeSaveAccounts,
+);
 
-  /** get accounts specific method to agregate all account keys into the correct format */
-  static getAccounts(): Promise<any> {
-    /** fetch all DB keys */
-    return DB.getAccountsKeys().then(accountKeys => {
-      /** if present return them */
-      if (accountKeys && accountKeys.length > 0)
-        return store.get(accountKeys).then(active => ({ active }));
+/** migrate accounts data if necessary */
+async function migrateAccountsIfNecessary(): Promise<void> {
+  const keys = await store.keys();
 
-      /** else return empty state data */
-      return Promise.resolve({ active: [] });
-    });
-  }
+  /** check if old data is present */
+  const hasOldAccounts = keys.includes(ACCOUNTS_KEY);
+  if (hasOldAccounts) {
+    log("db", "should migrateAccountsIfNecessary");
+    /** fetch old accounts db data */
+    const oldAccounts = await store.get(ACCOUNTS_KEY);
+    /** format old data to be saved on an account based key */
+    const accountsData = (oldAccounts && oldAccounts.active) || [];
 
-  /** migrate accounts data if necessary */
-  static migrateAccounts(): Promise<any> {
-    return DB.keys().then(keys => {
-      /** check if old data is present */
-      const hasOldAccounts = keys.includes(ACCOUNTS_KEY);
-      if (hasOldAccounts) {
-        /** fetch old accounts db data */
-        return store.get(ACCOUNTS_KEY).then(oldAccounts => {
-          /** format old data to be saved on an account based key */
-          const accountsData = (oldAccounts && oldAccounts.active) || [];
-
-          const newDBData = accountsData.map(({ data }) => [
-            DB.formatAccountDBKey(data.id),
-            { data, version: 1 },
-          ]);
-          /** save new formatted data then remove old data from DB */
-          return store.save(newDBData).then(() => DB.delete(ACCOUNTS_KEY));
-        });
-      }
-
-      /** no need to migrate if no old accounts data present */
-      return Promise.resolve(true);
-    });
+    const newDBData = accountsData.map(({ data }) => [
+      formatAccountDBKey(data.id),
+      { data, version: 1 },
+    ]);
+    /** save new formatted data then remove old data from DB */
+    await store.save(newDBData);
+    await store.delete(ACCOUNTS_KEY);
+    log("db", "done migrateAccountsIfNecessary");
   }
 }

--- a/src/db.js
+++ b/src/db.js
@@ -149,8 +149,15 @@ async function migrateAccountsIfNecessary(): Promise<void> {
   const hasOldAccounts = keys.includes(ACCOUNTS_KEY);
   if (hasOldAccounts) {
     log("db", "should migrateAccountsIfNecessary");
-    /** fetch old accounts db data */
-    const oldAccounts = await store.get(ACCOUNTS_KEY);
+
+    let oldAccounts = null;
+    try {
+      /** fetch old accounts db data */
+      oldAccounts = await store.get(ACCOUNTS_KEY);
+    } catch (e) {
+      /** catch possible "Row too big to fit into CursorWindow" */
+      console.error(e);
+    }
     /** format old data to be saved on an account based key */
     const accountsData = (oldAccounts && oldAccounts.active) || [];
 

--- a/src/db.js
+++ b/src/db.js
@@ -1,4 +1,116 @@
 // @flow
 import store from "react-native-simple-store";
 
-export default store;
+const ACCOUNTS_KEY = "accounts";
+const ACCOUNTS_DB_PREFIX = "accounts.active.";
+
+export default class DB {
+  static get(key: string | any[]): Promise<any> {
+    /** handle accounts case */
+    if (key === ACCOUNTS_KEY) return DB.getAccounts();
+    return store.get(key);
+  }
+
+  static save(key: string | any[], value: any): Promise<any> {
+    /** handle accounts case */
+    if (key === ACCOUNTS_KEY) return DB.saveAccounts(value);
+    return store.save(key, value);
+  }
+
+  static update(key: string, value: any): Promise<any> {
+    return store.update(key, value);
+  }
+
+  static keys(): Promise<any> {
+    return store.keys();
+  }
+
+  static delete(key: string | any[]): Promise<any> {
+    return store.delete(key);
+  }
+
+  static push(key: string, value: any): Promise<any> {
+    return store.push(key, value);
+  }
+
+  /** format account id to its account DB key */
+  static formatAccountDBKey = (id: string): string =>
+    `${ACCOUNTS_DB_PREFIX}${id}`;
+
+  /** save accounts method between SQLite db and redux store persist */
+  static saveAccounts({
+    active: newAccounts,
+  }: {
+    active: any[],
+  }): Promise<any> {
+    return DB.getAccountsKeys().then(currentAccountKeys => {
+      /** format data for DB persist */
+      const dbData = newAccounts.map(({ data }) => [
+        DB.formatAccountDBKey(data.id),
+        { data, version: 1 },
+      ]);
+
+      /** Find current DB accounts keys diff with app state to remove them */
+      const deletedKeys =
+        currentAccountKeys && currentAccountKeys.length
+          ? currentAccountKeys.filter(key =>
+              dbData.every(([accountKey]) => accountKey !== key),
+            )
+          : [];
+
+      /** persist store data to DB */
+      return store.save(dbData).then(() => {
+        /** then delete potential removed keys */
+        if (deletedKeys.length > 0) return DB.delete(deletedKeys);
+
+        return Promise.resolve(true);
+      });
+    });
+  }
+
+  /** get Db accounts keys */
+  static getAccountsKeys(): Promise<Array<string>> {
+    return DB.keys().then(keys => {
+      /** filter through them to get only the accounts ones */
+      return keys.filter(key => key.indexOf(ACCOUNTS_DB_PREFIX) === 0);
+    });
+  }
+
+  /** get accounts specific method to agregate all account keys into the correct format */
+  static getAccounts(): Promise<any> {
+    /** fetch all DB keys */
+    return DB.getAccountsKeys().then(accountKeys => {
+      /** if present return them */
+      if (accountKeys && accountKeys.length > 0)
+        return store.get(accountKeys).then(active => ({ active }));
+
+      /** else return empty state data */
+      return Promise.resolve({ active: [] });
+    });
+  }
+
+  /** migrate accounts data if necessary */
+  static migrateAccounts(): Promise<any> {
+    return DB.keys().then(keys => {
+      /** check if old data is present */
+      const hasOldAccounts = keys.includes(ACCOUNTS_KEY);
+      if (hasOldAccounts) {
+        /** fetch old accounts db data */
+        return store.get(ACCOUNTS_KEY).then(oldAccounts => {
+          /** format old data to be saved on an account based key */
+          const accountsData = (oldAccounts && oldAccounts.active) || [];
+
+          const newDBData = accountsData.map(({ data }) => [
+            DB.formatAccountDBKey(data.id),
+            { data, version: 1 },
+          ]);
+          /** save new formatted data then remove old data from DB */
+          return store.save(newDBData).then(() => DB.delete(ACCOUNTS_KEY));
+        });
+      }
+
+      /** no need to migrate if no old accounts data present */
+      return Promise.resolve(true);
+    });
+  }
+}

--- a/src/db.js
+++ b/src/db.js
@@ -8,7 +8,8 @@ const ACCOUNTS_KEY = "accounts";
 const ACCOUNTS_DB_PREFIX = "accounts.active.";
 
 export async function clearDb() {
-  await store.delete(["settings", "accounts", "countervalues", "ble"]);
+  const list = await store.keys();
+  await store.delete(list.filter(k => k !== "user"));
 }
 
 export async function getUser(): Promise<{ id: string }> {

--- a/src/screens/Accounts/AccountOrder.js
+++ b/src/screens/Accounts/AccountOrder.js
@@ -10,11 +10,7 @@ import RefreshAccountsOrdering from "../../components/RefreshAccountOrdering";
 
 // update at boot and each time focus or open state changes
 const RefreshAccounts = withNavigationFocus(({ isFocused, isOpened }) => (
-  <RefreshAccountsOrdering
-    onMount
-    onUpdate
-    nonce={`${isFocused}_${isOpened}`}
-  />
+  <RefreshAccountsOrdering onUpdate nonce={`${isFocused}_${isOpened}`} />
 ));
 
 class AccountOrder extends PureComponent<{}, { isOpened: boolean }> {

--- a/src/screens/Settings/Debug/GenerateMockAccounts.js
+++ b/src/screens/Settings/Debug/GenerateMockAccounts.js
@@ -4,12 +4,12 @@ import sample from "lodash/sample";
 import { genAccount } from "@ledgerhq/live-common/lib/mock/account";
 import SettingsRow from "../../../components/SettingsRow";
 import accountModel from "../../../logic/accountModel";
-import db from "../../../db";
+import { saveAccounts } from "../../../db";
 import { withReboot } from "../../../context/Reboot";
 import { listCryptoCurrencies } from "../../../cryptocurrencies";
 
 async function injectMockAccountsInDB(count) {
-  await db.save("accounts", {
+  await saveAccounts({
     active: Array(count)
       .fill(null)
       .map(() =>

--- a/src/user.js
+++ b/src/user.js
@@ -1,18 +1,18 @@
 // @flow
 
 import uuid from "uuid/v4";
-import db from "./db";
+import { getUser, setUser } from "./db";
 
 // a user is an anonymous way to identify a same instance of the app
 let user;
 
 export default async () => {
   if (!user) {
-    user = await db.get("user");
+    user = await getUser();
   }
   if (!user) {
     user = { id: uuid() };
-    await db.update("user", user);
+    await setUser(user);
     return { user, created: true };
   }
   return { user, created: false };


### PR DESCRIPTION
(DB): updated accounts storage saving process to split the data by account key and not grouped

SQLite accounts data is now stored by account keys thus removing certain limitation of storage we can have on android

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug Fix

### Context

LL-2295

### Parts of the app affected / Test plan

**Surface:** on iOS and Android, everything related to the app data is touched. Especially and mainly the accounts data that have been optimized and that fixes a limit getting reach when you have high number of accounts loaded.

**Compatibility:** coming from an old app version TO this PR version should properly migrate your accounts in a way that it is totally smoothless for you to see this happening. **However** moving back to old version (of develop) is NOT supported and you need to reset your app, something that can never be done on store as we never go backward.

**New users:** coming from scratch without existing accounts obviously should be correctly working.

**Removing accounts** need to be tested a bit because the code have logic for it to properly work (typically you should never see again the account you have deleted)

**Interruption of the app / Restart of the app** is something that should be tested because it's the way you stop the save() and read() again from the db.  Note that interrupting the app JUST after an action like editing the account IS NOT guaranteed to have been saved but things must not break when you come back and in practice the device is fast enough to have time to save things. (we still have implemented throttled but it's under 1s)

**account ordering** should be preserved.

**clear cache** should be intact.

more info on the main issue
