### PR TITLE
LL-2376 (Tron): vote modal focus input on modal open

### DIFF
--- a/src/families/tron/VotingFlow/02-VoteModal.js
+++ b/src/families/tron/VotingFlow/02-VoteModal.js
@@ -50,12 +50,18 @@ const VoteModal = ({
 
   const [useAllAmount, setUseAllAmount] = useState(false);
 
+  const inputRef = useRef();
+
   const { current: votesAvailable } = useRef(
     tronPower -
       votes
         .filter(v => v.address !== address)
         .reduce((sum, { voteCount }) => sum + voteCount, 0),
   );
+
+  const focusInput = useCallback(() => {
+    if (inputRef && inputRef.current) inputRef.current.focus();
+  }, [inputRef]);
 
   const handleChange = useCallback(
     text => {
@@ -85,7 +91,12 @@ const VoteModal = ({
   const error = value <= 0 || value > votesAvailable;
 
   return (
-    <BottomModal isOpened={!!vote} onClose={onClose} coverScreen>
+    <BottomModal
+      isOpened={!!vote}
+      onClose={onClose}
+      coverScreen
+      onModalShow={focusInput}
+    >
       <SafeAreaView>
         <KeyboardAvoidingView
           style={styles.rootKeyboard}
@@ -113,13 +124,13 @@ const VoteModal = ({
           </View>
           <View style={styles.wrapper}>
             <TextInput
+              ref={inputRef}
               allowFontScaling={false}
               hitSlop={{ top: 20, bottom: 20 }}
               onChangeText={handleChange}
               style={[styles.inputStyle, error ? styles.error : {}]}
               autoCorrect={false}
               value={`${value || ""}`}
-              autoFocus
               keyboardType="numeric"
               blurOnSubmit
               placeholder="0"


### PR DESCRIPTION
Focus input on vote edition modal on step 2 of the voting flow.

The autofocus was not reliable so moving to a more imperative approach using modalShow event.

### Type

UI Polish

### Context

LL-2376

### Parts of the app affected / Test plan

Tron voting flow step 2 on edition of votes modal.
