### PR TITLE
(Tron): fix account actions read-only mode issue

### DIFF
--- a/src/screens/Account/AccountActions.js
+++ b/src/screens/Account/AccountActions.js
@@ -61,7 +61,7 @@ const AccountActions = ({
         account,
         parentAccount,
         onNavigate,
-        style: styles.scrollBtn,
+        style: !readOnlyModeEnabled ? styles.scrollBtn : styles.btn,
       })) ||
     null;
 
@@ -73,8 +73,10 @@ const AccountActions = ({
     onNavigate("ReceiveConnectDevice");
   }, [onNavigate]);
 
-  const Container = manageAction ? ScrollViewContainer : View;
-  const btnStyle = manageAction ? styles.scrollBtn : styles.btn;
+  const Container =
+    !readOnlyModeEnabled && manageAction ? ScrollViewContainer : View;
+  const btnStyle =
+    !readOnlyModeEnabled && manageAction ? styles.scrollBtn : styles.btn;
 
   return (
     <Container style={styles.root}>


### PR DESCRIPTION
(Tron): fix issue on tron accounts action buttons having scroll on read-only mode when its not necessary

### Type

Ui Fix

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

Tron accounts page actions when using read-only mode
