### PR TITLE
LL-2422 

### DIFF
--- a/src/screens/Manager/AppsList/AppInstallProgress.js
+++ b/src/screens/Manager/AppsList/AppInstallProgress.js
@@ -44,25 +44,21 @@ export const InstallProgress = ({
           />
         </LText>
       </View>
-      {progress !== 1 && installing ? (
-        <ProgressBar
-          progressColor={colors.live}
-          style={styles.progressBar}
-          height={6}
-          progress={progress * 1e2}
-        />
-      ) : (
-        <InfiniteProgressBar
-          progressColor={colors.live}
-          style={styles.progressBar}
-          height={6}
-        />
-      )}
+      <ProgressBar
+        progressColor={colors.live}
+        style={styles.progressBar}
+        height={6}
+        progress={installing ? progress * 1e2 : 0}
+      />
     </View>
   );
 };
 
-export const UninstallProgress = () => {
+type UninstallProgressProps = {
+  uninstalling: boolean,
+};
+
+export const UninstallProgress = ({ uninstalling }: UninstallProgressProps) => {
   return (
     <View style={styles.progressContainer}>
       <View style={styles.progressLabel}>
@@ -74,11 +70,20 @@ export const UninstallProgress = () => {
           <Trans i18nKey="AppAction.uninstall.loading.button" />
         </LText>
       </View>
-      <InfiniteProgressBar
-        progressColor={colors.live}
-        style={styles.progressBar}
-        height={6}
-      />
+      {uninstalling ? (
+        <InfiniteProgressBar
+          progressColor={colors.live}
+          style={styles.progressBar}
+          height={6}
+        />
+      ) : (
+        <ProgressBar
+          progressColor={colors.live}
+          style={styles.progressBar}
+          height={6}
+          progress={0}
+        />
+      )}
     </View>
   );
 };

--- a/src/screens/Manager/AppsList/AppStateButton.js
+++ b/src/screens/Manager/AppsList/AppStateButton.js
@@ -71,7 +71,7 @@ const AppStateButton = ({
           />
         );
       case uninstalling:
-        return <UninstallProgress />;
+        return <UninstallProgress uninstalling={uninstallQueue[0] === name} />;
       case isInstalledView && isInstalled:
         return (
           <AppUninstallButton

--- a/src/screens/Manager/AppsList/index.js
+++ b/src/screens/Manager/AppsList/index.js
@@ -70,7 +70,7 @@ const AppsList = ({
 
   return (
     <VirtualizedList
-      style={{ height: viewHeight }}
+      style={{ height: viewHeight || 0 }}
       listKey={isInstalledView ? "Installed" : "Catalog"}
       data={apps}
       renderItem={renderRow}


### PR DESCRIPTION
(Manager): glitch on progress bar install issue

While several install and uninstalls are occurring the progress bar now triggers only on the active un/install progression.

### Type

UI Polish

### Context

LL-2422

### Parts of the app affected / Test plan

Manager screen
