### PR TITLE
LL-2416 

### DIFF
--- a/src/screens/Manager/AppsList/AppFilter.js
+++ b/src/screens/Manager/AppsList/AppFilter.js
@@ -66,6 +66,9 @@ const styles = StyleSheet.create({
   searchBarFilters: {
     width: 44,
     height: 44,
+    flexDirection: "row",
+    alignContent: "center",
+    justifyContent: "center",
   },
 });
 


### PR DESCRIPTION
(Manager): filter apps button icon not centered

### Type

UI Polish

### Context

LL-2416

### Parts of the app affected / Test plan

Manager screen filter apps button
![Screenshot_1589190930](https://user-images.githubusercontent.com/11752937/81549044-6d788a00-937e-11ea-9035-b03c4c3a20fc.png)

