### PR TITLE
LL-2413

### DIFF
--- a/src/components/ParentCurrencyIcon.js
+++ b/src/components/ParentCurrencyIcon.js
@@ -34,7 +34,10 @@ export default class ParentCurrencyIcon extends PureComponent<Props> {
 
 const styles = StyleSheet.create({
   tokenIconWrapper: {
-    marginLeft: 3,
+    flexDirection: "row",
+    justifyContent: "center",
+    alignContent: "center",
+    marginLeft: 0,
     marginTop: -6,
     borderWidth: 2,
     borderColor: colors.white,


### PR DESCRIPTION
(ParentCurrencyIcon): token icon clipping issue
issue on token icon in asset allocation view

![Screenshot_1589194421](https://user-images.githubusercontent.com/11752937/81554320-dcf27780-9386-11ea-9435-23847fd484a2.png)


### Type

UI Polish

### Context

LL-2413

### Parts of the app affected / Test plan

Token currency icons should no longer clip the token letter.
