### PR TITLE
LL-2447

### DIFF
--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -116,7 +116,7 @@ export const screen = (
   name: ?string,
   properties: ?Object,
 ) => {
-  const title = category + (name ? " " + name : "");
+  const title = `Page ${category + (name ? ` ${name}` : "")}`;
   Sentry.captureBreadcrumb({
     message: title,
     category: "screen",
@@ -129,7 +129,7 @@ export const screen = (
   if (ANALYTICS_LOGS)
     console.log("analytics:screen", category, name, properties);
   if (!token) return;
-  analytics.screen(
+  analytics.track(
     title,
     {
       ...extraProperties(storeInstance),


### PR DESCRIPTION
(Analytics): track screen events as pure events with same formatting as LLD

### Type

Analytics

### Context

LL-2447

### Parts of the app affected / Test plan

All screen analytics should now be tracked as events maybe see with @aramab for details as how to test this.
