### PR TITLE
LL-2405

### DIFF
--- a/src/components/AccountDistribution/Row.js
+++ b/src/components/AccountDistribution/Row.js
@@ -55,7 +55,7 @@ export default function Row({
       ? accounts.find(a => a.id === account.parentId)
       : null;
   const color = getCurrencyColor(currency);
-  const percentage = (Math.floor(distribution * 10000) / 100).toFixed(2);
+  const percentage = Math.round(distribution * 1e4) / 1e2;
   const icon = <ParentCurrencyIcon currency={currency} size={18} />;
 
   return (

--- a/src/screens/Distribution/DistributionCard.js
+++ b/src/screens/Distribution/DistributionCard.js
@@ -33,7 +33,7 @@ export default function DistributionCard({
   highlighting = false,
 }: Props) {
   const color = getCurrencyColor(currency);
-  const percentage = (Math.floor(distribution * 10000) / 100).toFixed(2);
+  const percentage = Math.round(distribution * 1e4) / 1e2;
 
   return (
     <View style={[styles.root, highlighting ? { borderColor: color } : {}]}>


### PR DESCRIPTION
(AssetAllocation): percentage allocation rounding updated
100% should now show as 100% and no longer ~~100.00%~~

### Type

UI Polish

### Context

LL-2405

### Parts of the app affected / Test plan

Go into assets allocation with a 100% asset allocation to show the updated rounding
