### PR TITLE
Hide the total section on the send flow when it equals the amount

### DIFF
--- a/src/screens/SendFunds/04-Summary.js
+++ b/src/screens/SendFunds/04-Summary.js
@@ -140,12 +140,16 @@ export default function SendSummary({ navigation, route }: Props) {
           transaction={transaction}
           navigation={navigation}
         />
-        <SectionSeparator lineColor={colors.lightFog} />
-        <SummaryTotalSection
-          account={account}
-          parentAccount={parentAccount}
-          amount={totalSpent}
-        />
+        {!amount.eq(totalSpent) ? (
+          <>
+            <SectionSeparator lineColor={colors.lightFog} />
+            <SummaryTotalSection
+              account={account}
+              parentAccount={parentAccount}
+              amount={totalSpent}
+            />
+          </>
+        ) : null}
       </NavigationScrollView>
       <View style={styles.footer}>
         <LText style={styles.error}>


### PR DESCRIPTION
Same as https://github.com/LedgerHQ/ledger-live-desktop/pull/2949 but for mobile, I'm moving the Jira task back to dev review since it was grouped for both.
![image](https://user-images.githubusercontent.com/4631227/83625448-361f8680-a594-11ea-95e0-c6405fc2415b.png)

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2590
### Parts of the app affected / Test plan

Sending a token, make sure that we dont show the total to debit if the amount and the total are the same.