### PR TITLE
Made the cta/description for portfolio empty state plural

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -694,9 +694,9 @@
       "noAppsTitle": "Install an app on my device",
       "noAppsDesc": "You need to install apps on your device to add accounts in Ledger Live. Go to the manager and install apps on your device.",
       "noAccountsTitle": "You don’t have any accounts…",
-      "noAccountsDesc": "Click on “Add account” to start adding accounts in Ledger Live",
+      "noAccountsDesc": "Click on “Add accounts” to start adding accounts in Ledger Live",
       "buttons": {
-        "import": "Add account",
+        "import": "Add accounts",
         "manager": "Install apps",
         "managerSecondary": "Install apps on my device"
       }


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/84769442-1fd2eb00-afd6-11ea-9b6c-c3862bc6f4c3.png)

>_Adding the HODL label until chris clears the second point on the jira task_

### Type

UI Polish/Wording

### Context

https://ledgerhq.atlassian.net/browse/LL-2539

### Parts of the app affected / Test plan

On a portfolio screen with no accounts, the CTA and description should both be in plural.
