### PR TITLE
LL-2691 Center headers on buy crypto flow

### DIFF
--- a/src/components/RootNavigator/ExchangeBuyFlowNavigator.js
+++ b/src/components/RootNavigator/ExchangeBuyFlowNavigator.js
@@ -24,29 +24,17 @@ export default function ExchangeNavigator() {
       <Stack.Screen
         name={ScreenName.ExchangeSelectCurrency}
         component={ExchangeSelectCurrency}
-        options={{
-          headerTitle: () => (
-            <StepHeader title={t("exchange.buy.selectCurrency")} />
-          ),
-        }}
+        options={{ title: t("exchange.buy.selectCurrency") }}
       />
       <Stack.Screen
         name={ScreenName.ExchangeSelectAccount}
         component={ExchangeSelectAccount}
-        options={{
-          headerTitle: () => (
-            <StepHeader title={t("exchange.buy.selectAccount")} />
-          ),
-        }}
+        options={{ title: t("exchange.buy.selectAccount") }}
       />
       <Stack.Screen
         name={ScreenName.ExchangeConnectDevice}
         component={ExchangeConnectDevice}
-        options={{
-          headerTitle: () => (
-            <StepHeader title={t("exchange.buy.connectDevice")} />
-          ),
-        }}
+        options={{ title: t("exchange.buy.connectDevice") }}
       />
       <Stack.Screen
         name={ScreenName.ExchangeCoinifyWidget}

--- a/src/components/RootNavigator/ExchangeBuyFlowNavigator.js
+++ b/src/components/RootNavigator/ExchangeBuyFlowNavigator.js
@@ -9,7 +9,6 @@ import ExchangeConnectDevice from "../../screens/Exchange/ConnectDevice";
 import ExchangeCoinifyWidget from "../../screens/Exchange/CoinifyWidgetScreen";
 import { closableStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import AddAccountsHeaderRightClose from "../../screens/AddAccounts/AddAccountsHeaderRightClose";
-import StepHeader from "../StepHeader";
 
 export default function ExchangeNavigator() {
   const { t } = useTranslation();

--- a/src/screens/Exchange/Buy.js
+++ b/src/screens/Exchange/Buy.js
@@ -15,7 +15,7 @@ import Button from "../../components/Button";
 
 const forceInset = { bottom: "always" };
 
-export default function ExchangeScreen() {
+export default function Buy() {
   const { t } = useTranslation();
   const navigation = useNavigation();
 

--- a/src/screens/Exchange/History.js
+++ b/src/screens/Exchange/History.js
@@ -9,7 +9,7 @@ import CoinifyWidget from "./CoinifyWidget";
 
 const forceInset = { bottom: "always" };
 
-export default function ExchangeScreen() {
+export default function History() {
   return (
     <SafeAreaView style={[styles.root]} forceInset={forceInset}>
       <TrackScreen category="ExchangeHistory" />

--- a/src/screens/Exchange/SelectAccount.js
+++ b/src/screens/Exchange/SelectAccount.js
@@ -99,7 +99,7 @@ export default function SelectAccount({ navigation, route }: Props) {
         <View style={styles.iconContainer}>
           <InfoIcon size={22} color={colors.live} />
         </View>
-        <LText style={styles.title}>
+        <LText semiBold style={styles.title}>
           {t("exchange.buy.emptyState.title", { currency: currency.name })}
         </LText>
         <LText style={styles.description}>
@@ -210,6 +210,7 @@ const styles = StyleSheet.create({
   },
   description: {
     textAlign: "center",
+    paddingHorizontal: 16,
     color: colors.smoke,
     fontSize: 14,
   },


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/84775500-9a543880-afdf-11ea-9e65-9125345fe5e7.png)

![image](https://user-images.githubusercontent.com/4631227/84776317-747b6380-afe0-11ea-918a-c9fc1d5c557d.png)

Following up on a conversation with design and Chris (who doesnt seem to have a github account) we agreed that the steps are dropped so we don't use the step title. Just good old centering.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2692
https://ledgerhq.atlassian.net/browse/LL-2691

### Parts of the app affected / Test plan

Test that the header titles of the buy crypto flow are centered and that the empty placeholder is. using a bold text.