### PR TITLE
LL-2695 Fix styling for devicejob error bottom modals

### DIFF
--- a/src/components/DeviceJob/StepRenders.js
+++ b/src/components/DeviceJob/StepRenders.js
@@ -71,6 +71,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
     paddingBottom: 16,
+    marginHorizontal: 16,
   },
   retryButton: {
     alignSelf: "stretch",


### PR DESCRIPTION

![Group](https://user-images.githubusercontent.com/4631227/84877875-561d7280-b089-11ea-8645-a1dead7dc3fd.png)

Added some padding for the error bottom modal for devicejobs and increased the margin to follow the design guidelines, the descriptions should stop narrower than the button, we tend to forget this.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2695

### Parts of the app affected / Test plan

Try to access a device and force a disconnect on the manager, or any other flow that tries to connect to the device. On the screenshots there are two of the options, but there are more cases, all should look good and not like on the linked issue.
