### PR TITLE
[Cosmos] Add ScrollView to SelectAmount

### DIFF
--- a/src/components/DelegationDrawer.js
+++ b/src/components/DelegationDrawer.js
@@ -104,13 +104,17 @@ export default function DelegationDrawer({
           showsVerticalScrollIndicator={true}
         >
           {data.map((field, i) => (
-            <DataField {...field} isLast={i === data.length - 1} />
+            <DataField
+              {...field}
+              key={field.label}
+              isLast={i === data.length - 1}
+            />
           ))}
         </ScrollView>
 
         <View style={[styles.row, styles.actionsRow]}>
-          {actions.map(props => (
-            <ActionButton {...props} />
+          {actions.map(a => (
+            <ActionButton {...a} key={a.label} />
           ))}
         </View>
       </SafeAreaView>

--- a/src/families/cosmos/shared/02-SelectAmount.js
+++ b/src/families/cosmos/shared/02-SelectAmount.js
@@ -278,6 +278,7 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
+    minHeight: 150,
   },
   inputStyle: { textAlign: "center", fontSize: 40, fontWeight: "600" },
   ratioButtonContainer: {

--- a/src/families/cosmos/shared/02-SelectAmount.js
+++ b/src/families/cosmos/shared/02-SelectAmount.js
@@ -6,7 +6,8 @@ import {
   StyleSheet,
   Keyboard,
   TouchableOpacity,
-  ScrollView,
+  TouchableWithoutFeedback,
+  Dimensions,
 } from "react-native";
 import SafeAreaView from "react-native-safe-area-view";
 import { Trans } from "react-i18next";
@@ -30,6 +31,7 @@ import LText from "../../../components/LText";
 import Warning from "../../../icons/Warning";
 import Check from "../../../icons/Check";
 import KeyboardView from "../../../components/KeyboardView";
+import { useKeyboardVisible } from "../../../logic/keyboardVisible";
 
 type RouteParams = {
   accountId: string,
@@ -50,6 +52,8 @@ type Props = {
 };
 
 function DelegationAmount({ navigation, route }: Props) {
+  const isKeyBoardVisible = useKeyboardVisible();
+
   const { account } = useSelector(accountScreenSelector(route));
 
   invariant(
@@ -130,7 +134,7 @@ function DelegationAmount({ navigation, route }: Props) {
 
   return (
     <SafeAreaView style={styles.root}>
-      <ScrollView>
+      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
         <KeyboardView>
           <View style={styles.main}>
             <CurrencyInput
@@ -205,7 +209,14 @@ function DelegationAmount({ navigation, route }: Props) {
               </View>
             )}
             {max.gt(0) && !error && (
-              <View style={styles.labelContainer}>
+              <View
+                style={[
+                  styles.labelContainer,
+                  isKeyBoardVisible && Dimensions.get("window").height < 600
+                    ? styles.noPaddingBottom
+                    : undefined,
+                ]}
+              >
                 <LText style={styles.assetsRemaining}>
                   <Trans
                     i18nKey="cosmos.delegation.flow.steps.amount.assetsRemaining"
@@ -252,7 +263,7 @@ function DelegationAmount({ navigation, route }: Props) {
             />
           </View>
         </KeyboardView>
-      </ScrollView>
+      </TouchableWithoutFeedback>
     </SafeAreaView>
   );
 }
@@ -267,7 +278,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
-    minHeight: 150,
   },
   inputStyle: { textAlign: "center", fontSize: 40, fontWeight: "600" },
   ratioButtonContainer: {
@@ -300,7 +310,6 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
   },
   labelContainer: {
-    width: "100%",
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "center",
@@ -324,6 +333,9 @@ const styles = StyleSheet.create({
   },
   success: {
     color: colors.success,
+  },
+  noPaddingBottom: {
+    paddingBottom: 0,
   },
 });
 

--- a/src/families/cosmos/shared/02-SelectAmount.js
+++ b/src/families/cosmos/shared/02-SelectAmount.js
@@ -1,7 +1,13 @@
 // @flow
 import invariant from "invariant";
 import React, { useCallback, useState, useMemo } from "react";
-import { View, StyleSheet, Keyboard, TouchableOpacity } from "react-native";
+import {
+  View,
+  StyleSheet,
+  Keyboard,
+  TouchableOpacity,
+  ScrollView,
+} from "react-native";
 import SafeAreaView from "react-native-safe-area-view";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -124,125 +130,129 @@ function DelegationAmount({ navigation, route }: Props) {
 
   return (
     <SafeAreaView style={styles.root}>
-      <KeyboardView>
-        <View style={styles.main}>
-          <CurrencyInput
-            unit={unit}
-            value={value}
-            onChange={setValue}
-            inputStyle={styles.inputStyle}
-            hasError={error}
-            autoFocus
-          />
-          <View style={styles.ratioButtonContainer}>
-            {ratioButtons.map(({ label, value: v }) => (
-              <TouchableOpacity
-                key={label}
-                style={[
-                  styles.ratioButton,
-                  value.eq(v) ? styles.ratioPrimaryButton : null,
-                ]}
-                onPress={() => {
-                  Keyboard.dismiss();
-                  setValue(v);
-                }}
-              >
-                <LText
+      <ScrollView>
+        <KeyboardView>
+          <View style={styles.main}>
+            <CurrencyInput
+              unit={unit}
+              value={value}
+              onChange={setValue}
+              inputStyle={styles.inputStyle}
+              hasError={error}
+              autoFocus
+            />
+            <View style={styles.ratioButtonContainer}>
+              {ratioButtons.map(({ label, value: v }) => (
+                <TouchableOpacity
+                  key={label}
                   style={[
-                    styles.ratioLabel,
-                    value.eq(v) ? styles.ratioPrimaryLabel : null,
+                    styles.ratioButton,
+                    value.eq(v) ? styles.ratioPrimaryButton : null,
                   ]}
+                  onPress={() => {
+                    Keyboard.dismiss();
+                    setValue(v);
+                  }}
                 >
-                  {label}
-                </LText>
-              </TouchableOpacity>
-            ))}
+                  <LText
+                    style={[
+                      styles.ratioLabel,
+                      value.eq(v) ? styles.ratioPrimaryLabel : null,
+                    ]}
+                  >
+                    {label}
+                  </LText>
+                </TouchableOpacity>
+              ))}
+            </View>
           </View>
-        </View>
 
-        <View style={styles.footer}>
-          {error && !value.eq(0) && (
-            <View style={styles.labelContainer}>
-              <Warning size={16} color={colors.alert} />
-              <LText style={[styles.assetsRemaining, styles.error]}>
-                <Trans
-                  i18nKey={
-                    value.lt(min)
-                      ? "cosmos.delegation.flow.steps.amount.minAmount"
-                      : "cosmos.delegation.flow.steps.amount.incorrectAmount"
-                  }
-                  values={{
-                    min: formatCurrencyUnit(unit, min, {
-                      showCode: true,
-                      showAllDigits: true,
-                    }),
-                    max: formatCurrencyUnit(unit, initialMax, {
-                      showCode: true,
-                      showAllDigits: true,
-                    }),
-                  }}
-                >
-                  <LText semiBold>{""}</LText>
-                </Trans>
-              </LText>
-            </View>
-          )}
-          {max.isZero() && (
-            <View style={styles.labelContainer}>
-              <Check size={16} color={colors.success} />
-              <LText style={[styles.assetsRemaining, styles.success]}>
-                <Trans
-                  i18nKey={`cosmos.${mode}.flow.steps.amount.allAssetsUsed`}
-                />
-              </LText>
-            </View>
-          )}
-          {max.gt(0) && !error && (
-            <View style={styles.labelContainer}>
-              <LText style={styles.assetsRemaining}>
-                <Trans
-                  i18nKey="cosmos.delegation.flow.steps.amount.assetsRemaining"
-                  values={{
-                    amount: formatCurrencyUnit(unit, max, {
-                      showCode: true,
-                    }),
-                  }}
-                >
-                  <LText semiBold>{""}</LText>
-                </Trans>
-              </LText>
-            </View>
-          )}
-          {!error && redelegatedBalance.gt(0) && (
-            <View style={[styles.labelContainer, styles.labelSmall]}>
-              <LText style={[styles.assetsRemaining, styles.small]}>
-                <Trans
-                  i18nKey="cosmos.redelegation.flow.steps.amount.newRedelegatedBalance"
-                  values={{
-                    amount: formatCurrencyUnit(
-                      unit,
-                      redelegatedBalance.plus(value),
-                      {
+          <View style={styles.footer}>
+            {error && !value.eq(0) && (
+              <View style={styles.labelContainer}>
+                <Warning size={16} color={colors.alert} />
+                <LText style={[styles.assetsRemaining, styles.error]}>
+                  <Trans
+                    i18nKey={
+                      value.lt(min)
+                        ? "cosmos.delegation.flow.steps.amount.minAmount"
+                        : "cosmos.delegation.flow.steps.amount.incorrectAmount"
+                    }
+                    values={{
+                      min: formatCurrencyUnit(unit, min, {
                         showCode: true,
-                      },
-                    ),
-                    name: route.params.validator?.name ?? "",
-                  }}
-                >
-                  <LText semiBold>{""}</LText>
-                </Trans>
-              </LText>
-            </View>
-          )}
-          <Button
-            disabled={error}
-            event="Cosmos DelegationAmountContinueBtn"
-            onPress={onNext}
-            title={<Trans i18nKey="cosmos.delegation.flow.steps.amount.cta" />}
-            type="primary"
-          />
-        </View>
-      </KeyboardView>
+                        showAllDigits: true,
+                      }),
+                      max: formatCurrencyUnit(unit, initialMax, {
+                        showCode: true,
+                        showAllDigits: true,
+                      }),
+                    }}
+                  >
+                    <LText semiBold>{""}</LText>
+                  </Trans>
+                </LText>
+              </View>
+            )}
+            {max.isZero() && (
+              <View style={styles.labelContainer}>
+                <Check size={16} color={colors.success} />
+                <LText style={[styles.assetsRemaining, styles.success]}>
+                  <Trans
+                    i18nKey={`cosmos.${mode}.flow.steps.amount.allAssetsUsed`}
+                  />
+                </LText>
+              </View>
+            )}
+            {max.gt(0) && !error && (
+              <View style={styles.labelContainer}>
+                <LText style={styles.assetsRemaining}>
+                  <Trans
+                    i18nKey="cosmos.delegation.flow.steps.amount.assetsRemaining"
+                    values={{
+                      amount: formatCurrencyUnit(unit, max, {
+                        showCode: true,
+                      }),
+                    }}
+                  >
+                    <LText semiBold>{""}</LText>
+                  </Trans>
+                </LText>
+              </View>
+            )}
+            {!error && redelegatedBalance.gt(0) && (
+              <View style={[styles.labelContainer, styles.labelSmall]}>
+                <LText style={[styles.assetsRemaining, styles.small]}>
+                  <Trans
+                    i18nKey="cosmos.redelegation.flow.steps.amount.newRedelegatedBalance"
+                    values={{
+                      amount: formatCurrencyUnit(
+                        unit,
+                        redelegatedBalance.plus(value),
+                        {
+                          showCode: true,
+                        },
+                      ),
+                      name: route.params.validator?.name ?? "",
+                    }}
+                  >
+                    <LText semiBold>{""}</LText>
+                  </Trans>
+                </LText>
+              </View>
+            )}
+            <Button
+              disabled={error}
+              event="Cosmos DelegationAmountContinueBtn"
+              onPress={onNext}
+              title={
+                <Trans i18nKey="cosmos.delegation.flow.steps.amount.cta" />
+              }
+              type="primary"
+            />
+          </View>
+        </KeyboardView>
+      </ScrollView>
     </SafeAreaView>
   );
 }


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
The cta on SelectAmount screen is cut off on smaller devices like iPhone 5s. This PR will squeeze the height of the contents so that user can see all information on that screen. Plus, it adds functionality to click outside the keyboard to hide the keyboard.

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
- Select Amount screen on delegation/redelegation flow.