### PR TITLE
LL-2686 (BuyCrypto): minor style polishes

### DIFF
--- a/src/components/RootNavigator/ExchangeNavigator.js
+++ b/src/components/RootNavigator/ExchangeNavigator.js
@@ -6,6 +6,12 @@ import { ScreenName } from "../../const";
 import styles from "../../navigation/styles";
 import Buy from "../../screens/Exchange/Buy";
 import History from "../../screens/Exchange/History";
+import LText from "../LText";
+
+type TabLabelProps = {
+  focused: boolean,
+  color: string,
+};
 
 export default function CryptoAssetsSettingsNavigator() {
   const { t } = useTranslation();
@@ -19,12 +25,27 @@ export default function CryptoAssetsSettingsNavigator() {
       <Tab.Screen
         name={ScreenName.ExchangeBuy}
         component={Buy}
-        options={{ title: t("exchange.buy.tabTitle") }}
+        options={{
+          title: t("exchange.buy.tabTitle"),
+          tabBarLabel: ({ focused, color }: TabLabelProps) => (
+            /** width has to be a little bigger to accomodate the switch in size between semibold to regular */
+            <LText style={{ width: "110%", color }} semiBold={focused}>
+              {t("exchange.buy.tabTitle")}
+            </LText>
+          ),
+        }}
       />
       <Tab.Screen
         name={ScreenName.ExchangeHistory}
         component={History}
-        options={{ title: t("exchange.history.tabTitle") }}
+        options={{
+          title: t("exchange.history.tabTitle"),
+          tabBarLabel: ({ focused, color }: TabLabelProps) => (
+            <LText style={{ width: "110%", color }} semiBold={focused}>
+              {t("exchange.history.tabTitle")}
+            </LText>
+          ),
+        }}
       />
     </Tab.Navigator>
   );

--- a/src/screens/Exchange/Buy.js
+++ b/src/screens/Exchange/Buy.js
@@ -29,7 +29,9 @@ export default function ExchangeScreen() {
         <View style={styles.iconContainer}>
           <ExchangeIcon size={22} color={colors.live} />
         </View>
-        <LText style={styles.title}>{t("exchange.buy.title")}</LText>
+        <LText style={styles.title} semiBold>
+          {t("exchange.buy.title")}
+        </LText>
         <LText style={styles.description}>
           {t("exchange.buy.description")}
         </LText>


### PR DESCRIPTION
Buy crypto screen:
- tab title label should not be in uppercase anymore
- tab title should be semi bold when tab active
- "Buy crypto via our partners" should be semi bold

![Screenshot_1592832789](https://user-images.githubusercontent.com/11752937/85293490-b4898d00-b49d-11ea-9fe1-ae5bf0f018e6.png)


### Type

UI Polish

### Context

LL-2686

### Parts of the app affected / Test plan

Open the buy crypto page
