### PR TITLE
LL-2459 Modals glitch issue

### DIFF
--- a/src/components/DelegationDrawer.js
+++ b/src/components/DelegationDrawer.js
@@ -4,7 +4,6 @@ import React from "react";
 import type { ComponentType } from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import type { ViewStyleProp } from "react-native/Libraries/StyleSheet/StyleSheet";
-import SafeAreaView from "react-native-safe-area-view";
 import {
   getAccountCurrency,
   getAccountUnit,
@@ -62,7 +61,7 @@ export default function DelegationDrawer({
       isOpened={isOpen}
       onClose={onClose}
     >
-      <SafeAreaView style={styles.root} forceInset={{ bottom: "always" }}>
+      <View style={styles.root}>
         <Touchable
           event="DelegationDetailsModalClose"
           onPress={onClose}
@@ -113,7 +112,7 @@ export default function DelegationDrawer({
             <ActionButton {...props} />
           ))}
         </View>
-      </SafeAreaView>
+      </View>
     </BottomModal>
   );
 }

--- a/src/components/ModalBottomAction.js
+++ b/src/components/ModalBottomAction.js
@@ -1,11 +1,8 @@
 /* @flow */
 import React, { Component } from "react";
 import { View, StyleSheet } from "react-native";
-import SafeAreaView from "react-native-safe-area-view";
 import LText from "./LText";
 import colors from "../colors";
-
-const forceInset = { bottom: "always" };
 
 export default class ModalBottomAction extends Component<{
   icon?: *,
@@ -16,7 +13,7 @@ export default class ModalBottomAction extends Component<{
   render() {
     const { icon, title, description, footer } = this.props;
     return (
-      <SafeAreaView forceInset={forceInset} style={styles.root}>
+      <View style={styles.root}>
         {icon && <View style={styles.icon}>{icon}</View>}
         {title ? (
           <LText semiBold style={styles.title}>
@@ -29,7 +26,7 @@ export default class ModalBottomAction extends Component<{
           )}
           <View style={styles.footer}>{footer}</View>
         </View>
-      </SafeAreaView>
+      </View>
     );
   }
 }

--- a/src/components/RequireTerms.js
+++ b/src/components/RequireTerms.js
@@ -9,7 +9,6 @@ import {
   Linking,
   ActivityIndicator,
 } from "react-native";
-import SafeAreaView from "react-native-safe-area-view";
 import colors from "../colors";
 import { useTerms, useTermsAccept, url } from "../logic/terms";
 import getWindowDimensions from "../logic/getWindowDimensions";
@@ -22,8 +21,6 @@ import CheckBox from "./CheckBox";
 import Touchable from "./Touchable";
 import GenericErrorView from "./GenericErrorView";
 import RetryButton from "./RetryButton";
-
-const forceInset = { bottom: "always" };
 
 const styles = StyleSheet.create({
   modal: {},
@@ -82,7 +79,7 @@ const RequireTermsModal = () => {
       style={styles.modal}
       preventBackdropClick
     >
-      <SafeAreaView style={styles.root} forceInset={forceInset}>
+      <View style={styles.root}>
         <View style={styles.header}>
           <LText semiBold style={styles.title}>
             <Trans i18nKey="Terms.title" />
@@ -133,7 +130,7 @@ const RequireTermsModal = () => {
             title={<Trans i18nKey="common.confirm" />}
           />
         </View>
-      </SafeAreaView>
+      </View>
     </BottomModal>
   );
 };
@@ -161,7 +158,7 @@ export const TermModals = ({
       style={styles.modal}
       preventBackdropClick
     >
-      <SafeAreaView style={styles.root} forceInset={forceInset}>
+      <View style={styles.root}>
         <View style={styles.header}>
           <LText semiBold style={styles.title}>
             <Trans i18nKey="Terms.title" />
@@ -200,7 +197,7 @@ export const TermModals = ({
             title={<Trans i18nKey="common.close" />}
           />
         </View>
-      </SafeAreaView>
+      </View>
     </BottomModal>
   );
 };

--- a/src/families/tezos/DelegationDetailsModal.js
+++ b/src/families/tezos/DelegationDetailsModal.js
@@ -3,7 +3,6 @@
 import React, { useCallback } from "react";
 import { Trans } from "react-i18next";
 import { StyleSheet, View, Linking } from "react-native";
-import SafeAreaView from "react-native-safe-area-view";
 import { useNavigation } from "@react-navigation/native";
 import { differenceInCalendarDays } from "date-fns";
 import {
@@ -44,8 +43,6 @@ type Props = {
   parentAccount: ?Account,
   delegation: Delegation,
 };
-
-const forceInset = { bottom: "always" };
 
 const styles = StyleSheet.create({
   modal: {
@@ -230,7 +227,7 @@ export default function DelegationDetailsModal({
       onClose={onClose}
       style={styles.modal}
     >
-      <SafeAreaView style={styles.root} forceInset={forceInset}>
+      <View style={styles.root}>
         <Touchable
           event="DelegationDetailsModalClose"
           style={styles.close}
@@ -376,7 +373,7 @@ export default function DelegationDetailsModal({
             />
           </View>
         )}
-      </SafeAreaView>
+      </View>
     </BottomModal>
   );
 }

--- a/src/modals/Create.js
+++ b/src/modals/Create.js
@@ -1,7 +1,6 @@
 /* @flow */
 
 import React, { useCallback } from "react";
-import SafeAreaView from "react-native-safe-area-view";
 import { useNavigation } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
@@ -15,8 +14,6 @@ import BottomModal from "../components/BottomModal";
 import BottomModalChoice from "../components/BottomModalChoice";
 import type { Props as ModalProps } from "../components/BottomModal";
 import { readOnlyModeEnabledSelector } from "../reducers/settings";
-
-const forceInset = { bottom: "always" };
 
 export default function CreateModal({ isOpened, onClose }: ModalProps) {
   const navigation = useNavigation();
@@ -56,28 +53,24 @@ export default function CreateModal({ isOpened, onClose }: ModalProps) {
 
   return (
     <BottomModal id="CreateModal" isOpened={isOpened} onClose={onClose}>
-      <SafeAreaView forceInset={forceInset}>
-        <BottomModalChoice
-          event="TransferSend"
-          title={t("transfer.send.title")}
-          onPress={
-            accountsCount > 0 && !readOnlyModeEnabled ? onSendFunds : null
-          }
-          Icon={IconSend}
-        />
-        <BottomModalChoice
-          event="TransferReceive"
-          title={t("transfer.receive.title")}
-          onPress={accountsCount > 0 ? onReceiveFunds : null}
-          Icon={IconReceive}
-        />
-        <BottomModalChoice
-          event="TransferExchange"
-          title={t("transfer.exchange.title")}
-          Icon={IconExchange}
-          onPress={onExchange}
-        />
-      </SafeAreaView>
+      <BottomModalChoice
+        event="TransferSend"
+        title={t("transfer.send.title")}
+        onPress={accountsCount > 0 && !readOnlyModeEnabled ? onSendFunds : null}
+        Icon={IconSend}
+      />
+      <BottomModalChoice
+        event="TransferReceive"
+        title={t("transfer.receive.title")}
+        onPress={accountsCount > 0 ? onReceiveFunds : null}
+        Icon={IconReceive}
+      />
+      <BottomModalChoice
+        event="TransferExchange"
+        title={t("transfer.exchange.title")}
+        Icon={IconExchange}
+        onPress={onExchange}
+      />
     </BottomModal>
   );
 }

--- a/src/screens/Accounts/AccountOrderModal.js
+++ b/src/screens/Accounts/AccountOrderModal.js
@@ -3,13 +3,10 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import { Trans } from "react-i18next";
-import SafeAreaView from "react-native-safe-area-view";
 import MenuTitle from "../../components/MenuTitle";
 import OrderOption from "./OrderOption";
 import BottomModal from "../../components/BottomModal";
 import Button from "../../components/Button";
-
-const forceInset = { bottom: "always" };
 
 const choices = ["balance|desc", "balance|asc", "name|asc", "name|desc"];
 
@@ -21,22 +18,20 @@ type Props = {
 export default function AccountOrderModal({ onClose, isOpened }: Props) {
   return (
     <BottomModal id="AccountOrderModal" onClose={onClose} isOpened={isOpened}>
-      <SafeAreaView forceInset={forceInset}>
-        <MenuTitle>
-          <Trans i18nKey="common.sortBy" />
-        </MenuTitle>
-        {choices.map(id => (
-          <OrderOption key={id} id={id} />
-        ))}
-        <View style={styles.buttonContainer}>
-          <Button
-            event="AccountOrderModalDone"
-            type="primary"
-            onPress={onClose}
-            title={<Trans i18nKey="common.done" />}
-          />
-        </View>
-      </SafeAreaView>
+      <MenuTitle>
+        <Trans i18nKey="common.sortBy" />
+      </MenuTitle>
+      {choices.map(id => (
+        <OrderOption key={id} id={id} />
+      ))}
+      <View style={styles.buttonContainer}>
+        <Button
+          event="AccountOrderModalDone"
+          type="primary"
+          onPress={onClose}
+          title={<Trans i18nKey="common.done" />}
+        />
+      </View>
     </BottomModal>
   );
 }


### PR DESCRIPTION
 Removal of potentially lagging and unnecessary SafeAreaViews from the bottom modals causing glitches.

To reproduce the glitch before you could try and refresh the portfolio and immediately opening the transfer modal in the bottom tab bar to see that an unnecessary padding was added then removed with a lag.

Any throttling of the app would trigger that.

### Type

Bug Fix

### Context

LL-2459

### Parts of the app affected / Test plan

The modals updated are:

- Transfer on the bottom tab menu
- Require and read terms
- Every modal action ( delete an account)
- the sort accounts modal
- Delegation details modal for tezos and cosmos