### PR TITLE
add text and title to NotEnoughGas error

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -328,6 +328,10 @@
       "title": "Oops, insufficient balance",
       "description": "Make sure the account to debit has sufficient balance"
     },
+    "NotEnoughGas": {
+      "title": "Insufficient ETH for network fee",
+      "description": "Please send some ETH to your account to pay for ERC20 token transactions."
+    },
     "NotEnoughBalanceToDelegate": {
       "title": "Insufficient balance to delegate"
     },


### PR DESCRIPTION
We were missing the NotEnoughGas translation in our files, thus resulting in a strangely generic error wirth "NotEnoughGas" as title error.

We fix this mistake right here, right now

### Type

Error Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2649

### Parts of the app affected / Test plan

![IMG_7FE446012252-1](https://user-images.githubusercontent.com/671786/85568011-9eacd100-b631-11ea-888a-b06472143940.jpeg)

