### PR TITLE
LL-2837 Use #6490f1 for active tab icon/text color

### DIFF
--- a/src/components/RootNavigator/CryptoAssetsSettingsNavigator.js
+++ b/src/components/RootNavigator/CryptoAssetsSettingsNavigator.js
@@ -3,9 +3,16 @@ import React from "react";
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import { useTranslation } from "react-i18next";
 import { ScreenName } from "../../const";
+import colors from "../../colors";
+import LText from "../LText";
 import styles from "../../navigation/styles";
 import RatesList from "../../screens/Settings/CryptoAssets/Rates/RatesList";
 import CurrenciesList from "../../screens/Settings/CryptoAssets/Currencies/CurrenciesList";
+
+type TabLabelProps = {
+  focused: boolean,
+  color: string,
+};
 
 export default function CryptoAssetsSettingsNavigator() {
   const { t } = useTranslation();
@@ -14,17 +21,36 @@ export default function CryptoAssetsSettingsNavigator() {
     <Tab.Navigator
       tabBarOptions={{
         headerStyle: styles.headerNoShadow,
+        indicatorStyle: {
+          backgroundColor: colors.live,
+        },
       }}
     >
       <Tab.Screen
         name={ScreenName.RatesList}
         component={RatesList}
-        options={{ title: t("settings.rates.header") }}
+        options={{
+          title: t("settings.rates.header"),
+          tabBarLabel: ({ focused, color }: TabLabelProps) => (
+            /** width has to be a little bigger to accomodate the switch in size between semibold to regular */
+            <LText style={{ width: "110%", color }} semiBold={focused}>
+              {t("settings.rates.header")}
+            </LText>
+          ),
+        }}
       />
       <Tab.Screen
         name={ScreenName.CurrenciesList}
         component={CurrenciesList}
-        options={{ title: t("settings.currencies.header") }}
+        options={{
+          title: t("settings.currencies.header"),
+          tabBarLabel: ({ focused, color }: TabLabelProps) => (
+            /** width has to be a little bigger to accomodate the switch in size between semibold to regular */
+            <LText style={{ width: "110%", color }} semiBold={focused}>
+              {t("settings.currencies.header")}
+            </LText>
+          ),
+        }}
       />
     </Tab.Navigator>
   );

--- a/src/components/RootNavigator/ExchangeNavigator.js
+++ b/src/components/RootNavigator/ExchangeNavigator.js
@@ -3,6 +3,7 @@ import React from "react";
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import { useTranslation } from "react-i18next";
 import { ScreenName } from "../../const";
+import colors from "../../colors";
 import styles from "../../navigation/styles";
 import Buy from "../../screens/Exchange/Buy";
 import History from "../../screens/Exchange/History";
@@ -20,6 +21,9 @@ export default function CryptoAssetsSettingsNavigator() {
     <Tab.Navigator
       tabBarOptions={{
         headerStyle: styles.headerNoShadow,
+        indicatorStyle: {
+          backgroundColor: colors.live,
+        },
       }}
     >
       <Tab.Screen

--- a/src/components/RootNavigator/MainNavigator.js
+++ b/src/components/RootNavigator/MainNavigator.js
@@ -8,6 +8,7 @@ import ManagerNavigator, { ManagerTabIcon } from "./ManagerNavigator";
 import SettingsNavigator from "./SettingsNavigator";
 import styles from "../../navigation/styles";
 import TabIcon from "../TabIcon";
+import colors from "../../colors";
 import AccountsIcon from "../../icons/Accounts";
 import SettingsIcon from "../../icons/Settings";
 
@@ -19,6 +20,7 @@ export default function MainNavigator() {
       tabBarOptions={{
         style: styles.bottomTabBar,
         showLabel: false,
+        activeTintColor: colors.live,
       }}
     >
       <Tab.Screen


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/86374548-fb893680-bc84-11ea-847f-fb5f011e1c3e.png)

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2837

### Parts of the app affected / Test plan

Check that the active state of the bottom navigation tabs uses the correct color.
Also for the Buy crypto  and Settings/crypto assets screens the bottom indicator underline should use the correct blue now.