### PR TITLE
LL-2708 (AssetAllocation): fix balance centered

### DIFF
--- a/src/screens/Asset/index.js
+++ b/src/screens/Asset/index.js
@@ -307,6 +307,6 @@ const styles = StyleSheet.create({
   },
   balanceContainer: {
     marginLeft: 16,
-    alignItems: "flex-end",
+    alignItems: "center",
   },
 });


### PR DESCRIPTION
In Asset allocation screen the balance countervalues were not centered

![Screenshot_1595507050](https://user-images.githubusercontent.com/11752937/88285951-429ca180-ccf0-11ea-9d1a-14d7ff627713.png)


### Type

UI Polish

### Context

LL-2708

### Parts of the app affected / Test plan

Go to the asset allocation then long press on a currency to go to the correct page.
