### PR TITLE
LL-2972 Add singular to Asset allocation screen

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -961,7 +961,8 @@
   "distribution": {
     "header": "Asset allocation",
     "list": "Asset allocation ({{count}})",
-    "assets": "assets",
+    "assets": "asset",
+    "assets_plural": "assets",
     "total": "Total balance:",
     "listAccount": "Account allocation ({{count}})"
   },

--- a/src/screens/Distribution/index.js
+++ b/src/screens/Distribution/index.js
@@ -94,7 +94,10 @@ class Distribution extends PureComponent<DistributionProps, *> {
                 {distribution.list.length}
               </LText>
               <LText tertiary style={styles.assets}>
-                <Trans i18nKey="distribution.assets" />
+                <Trans
+                  i18nKey="distribution.assets"
+                  count={distribution.list.length}
+                />
               </LText>
             </View>
           </View>


### PR DESCRIPTION

![Screen Shot 2020-08-04 at 14 57 47](https://user-images.githubusercontent.com/13920153/89296935-64d4de80-d663-11ea-8fc5-ca81fe29fa94.png)

![Screen Shot 2020-08-04 at 14 57 18](https://user-images.githubusercontent.com/13920153/89296954-6b635600-d663-11ea-9d8e-90899042a33b.png)


### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2972

### Parts of the app affected 

Asset allocation screen

### Test plan

- Be a maximalist
- Check there is no "s" on your one and only asset
