### PR TITLE
add error and CTA to buy ETH when NotEnoughGas

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -71,7 +71,8 @@
       "days_plural": "{{time}} days ago"
     },
     "seeMore": "See more",
-    "moreInfo": "More info"
+    "moreInfo": "More info",
+    "buyEth": "Buy Ethereum"
   },
   "errors": {
     "AccountAwaitingSendPendingOperations": {

--- a/src/screens/SendFunds/04-Summary.js
+++ b/src/screens/SendFunds/04-Summary.js
@@ -114,7 +114,8 @@ export default function SendSummary({ navigation, route }: Props) {
 
   if (!account || !transaction || !transaction.recipient) return null; // FIXME why is recipient sometimes empty?
   const { amount, totalSpent, errors } = status;
-  const { transaction: transactionError, gasPrice } = errors;
+  const { transaction: transactionError } = errors;
+  const error = status.errors[Object.keys(status.errors)[0]];
   const mainAccount = getMainAccount(account, parentAccount);
 
   // console.log({ transaction, status, bridgePending });
@@ -148,13 +149,13 @@ export default function SendSummary({ navigation, route }: Props) {
           transaction={transaction}
           navigation={navigation}
         />
-        {gasPrice && gasPrice instanceof NotEnoughGas ? (
+        {error ? (
           <View style={styles.gasPriceError}>
             <View style={{ padding: 4 }}>
               <Info size={12} color={colors.alert} />
             </View>
             <LText style={[styles.error, styles.gasPriceErrorText]}>
-              <TranslatedError error={gasPrice} />
+              <TranslatedError error={error} />
             </LText>
           </View>
         ) : null}
@@ -173,7 +174,7 @@ export default function SendSummary({ navigation, route }: Props) {
         <LText style={styles.error}>
           <TranslatedError error={transactionError} />
         </LText>
-        {gasPrice && gasPrice instanceof NotEnoughGas ? (
+        {error && error instanceof NotEnoughGas ? (
           <Button
             event="SummaryBuyEth"
             type="primary"


### PR DESCRIPTION
Provide a way to go to Buy whenever parent ETH account does not have enough funds to pay for the fees of the ERC20 transaction

### Type

Feat

### Context

LL-2684

### Parts of the app affected / Test plan

Send Summary

![IMG_1E97102EB118-1](https://user-images.githubusercontent.com/671786/89544686-bbc4ea00-d802-11ea-91c1-7cb2e7bb4390.jpeg)

