### PR TITLE
LL-2883 (Cosmos): Add delegation disabled when not enough balance

### DIFF
--- a/src/families/cosmos/Delegations/LabelRight.js
+++ b/src/families/cosmos/Delegations/LabelRight.js
@@ -1,22 +1,46 @@
 // @flow
-import React from "react";
+import React, { useState, useCallback } from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 import { useTranslation } from "react-i18next";
 import LText from "../../../components/LText";
+import InfoModal from "../../../modals/Info";
 import colors from "../../../colors";
 
 type Props = {
+  disabled?: boolean,
   onPress: () => void,
 };
 
-export default function DelegationLabelRight({ onPress }: Props) {
+export default function DelegationLabelRight({ onPress, disabled }: Props) {
   const { t } = useTranslation();
 
+  const [disabledModalOpen, setDisabledModalOpen] = useState(false);
+
+  const onClick = useCallback(() => {
+    if (disabled) setDisabledModalOpen(true);
+    else onPress();
+  }, [onPress, disabled]);
+
+  const onCloseModal = useCallback(() => setDisabledModalOpen(false), []);
+
   return (
-    <TouchableOpacity onPress={onPress}>
-      <LText semiBold style={styles.actionColor}>
+    <TouchableOpacity onPress={onClick}>
+      <LText
+        semiBold
+        style={[styles.actionColor, disabled ? { color: colors.grey } : {}]}
+      >
         {t("account.delegation.addDelegation")}
       </LText>
+      <InfoModal
+        isOpened={!!disabledModalOpen}
+        onClose={onCloseModal}
+        data={[
+          {
+            title: t("cosmos.info.delegationUnavailable.title"),
+            description: t("cosmos.info.delegationUnavailable.description"),
+          },
+        ]}
+      />
     </TouchableOpacity>
   );
 }

--- a/src/families/cosmos/Delegations/index.js
+++ b/src/families/cosmos/Delegations/index.js
@@ -23,7 +23,10 @@ import type {
   CosmosMappedUnbonding,
 } from "@ledgerhq/live-common/lib/families/cosmos/types";
 import type { Account } from "@ledgerhq/live-common/lib/types";
-import { mapUnbondings } from "@ledgerhq/live-common/lib/families/cosmos/logic";
+import {
+  mapUnbondings,
+  canDelegate,
+} from "@ledgerhq/live-common/lib/families/cosmos/logic";
 import AccountDelegationInfo from "../../../components/AccountDelegationInfo";
 import IlluRewards from "../../../components/IlluRewards";
 import { urls } from "../../../config/urls";
@@ -261,6 +264,8 @@ export default function Delegations({ account }: Props) {
       : [];
   }, [t, onRedelegate, onCollectRewards, onUndelegate, delegation]);
 
+  const delegationDisabled = delegations.length <= 0 || !canDelegate(account);
+
   return (
     <View style={styles.root}>
       <DelegationDrawer
@@ -325,7 +330,12 @@ export default function Delegations({ account }: Props) {
         <View style={styles.wrapper}>
           <AccountSectionLabel
             name={t("account.delegation.sectionLabel")}
-            RightComponent={<DelegationLabelRight onPress={onDelegate} />}
+            RightComponent={
+              <DelegationLabelRight
+                disabled={delegationDisabled}
+                onPress={onDelegate}
+              />
+            }
           />
           {delegations.map((d, i) => (
             <View key={d.validatorAddress} style={styles.delegationsWrapper}>

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1727,6 +1727,10 @@
       "undelegating": {
         "title": "Undelegating",
         "description": "Undelegated assets are in a timelock of 21 days, before being available."
+      },
+      "delegationUnavailable": {
+        "title": "Delegation unavailable",
+        "description": "Not enough available balance in your account to start a new delegation."
       }
     },
     "delegation": {


### PR DESCRIPTION
Delegation flow is locked from the start with some info when user can delegate more with an account.

![Screenshot_2020-08-10-18-29-06-405_com ledger live debug](https://user-images.githubusercontent.com/11752937/89806853-f2b73a80-db37-11ea-99f8-cbee88b8457c.jpg)

### Type

Bug Fix

### Context

LL-2883

### Parts of the app affected / Test plan

Cosmos accounts with less than 0.16 ATOM to be able to start delegating
