### PR TITLE
LL-2778 Hide portfolio's sticky header if placeholder

### DIFF
--- a/src/screens/Portfolio/index.js
+++ b/src/screens/Portfolio/index.js
@@ -134,13 +134,18 @@ export default function PortfolioScreen({ navigation }: Props) {
     withSubAccounts: true,
   });
 
+  const showingPlaceholder =
+    accounts.length === 0 || accounts.every(isAccountEmpty);
+
   return (
     <SafeAreaView style={[styles.root, { paddingTop: extraStatusBarPadding }]}>
-      <StickyHeader
-        scrollY={scrollY}
-        portfolio={portfolio}
-        counterValueCurrency={counterValueCurrency}
-      />
+      {!showingPlaceholder ? (
+        <StickyHeader
+          scrollY={scrollY}
+          portfolio={portfolio}
+          counterValueCurrency={counterValueCurrency}
+        />
+      ) : null}
 
       <RequireTerms />
 


### PR DESCRIPTION
When the portfolio screen is showing a placeholder (+banner, or on small screens that make it scrollable) disable the sticky header that shows the total balance since it makes no sense.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-2778

### Parts of the app affected / Test plan

With a small screen device, or forcing the "buy banner" to appear, on an empty state app (no accounts or no movements), scroll down until the sticky header would be showing. Make sure it doesn't show. If it shows, this pr is invalid and should not pass qa.
