### PR TITLE
bump react native bindings 4.15.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@ledgerhq/logs": "5.22.0",
     "@ledgerhq/react-native-hid": "5.22.0",
     "@ledgerhq/react-native-hw-transport-ble": "5.22.0",
-    "@ledgerhq/react-native-ledger-core": "4.15.8",
+    "@ledgerhq/react-native-ledger-core": "4.15.9",
     "@ledgerhq/react-native-passcode-auth": "^2.1.0",
     "@react-native-community/art": "^1.1.2",
     "@react-native-community/async-storage": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,10 +1207,10 @@
     rxjs "^6.6.2"
     uuid "^3.4.0"
 
-"@ledgerhq/react-native-ledger-core@4.15.8":
-  version "4.15.8"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-4.15.8.tgz#62189164cb9c4bd03bcf33d36d7eed93e9d7e736"
-  integrity sha512-/uaWiWlHbfDVwjPauD1IbN+5QvIBacccDmgCBxoA6xIoaTTOIEG1KF0248nmxSIVtKVXIEBWDqSDjfH0diocxQ==
+"@ledgerhq/react-native-ledger-core@4.15.9":
+  version "4.15.9"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-4.15.9.tgz#be715c9877113b85b123f36b8600f1b85ff0df9f"
+  integrity sha512-VVvdhBWYUrJ7AZToKrFBCZPVcvDnGTSDfIdC4LdxTU9h4Vy2RRl17Mftt8QBkcWIacUPMm+OLZX21rLGIY1EzA==
 
 "@ledgerhq/react-native-passcode-auth@^2.1.0":
   version "2.1.0"


### PR DESCRIPTION
Upgrade react native bindings 4.15.9
should fix algo sync issues when no network.