### PR TITLE
LL-2877 Cosmos polish

### DIFF
--- a/src/families/cosmos/AccountBalanceSummaryFooter.js
+++ b/src/families/cosmos/AccountBalanceSummaryFooter.js
@@ -42,56 +42,62 @@ function AccountBalanceSummaryFooter({ account }: Props) {
   );
 
   return (
-    <ScrollView
-      horizontal
-      showsHorizontalScrollIndicator={false}
-      style={styles.root}
-    >
-      <InfoModal
-        isOpened={!!infoName}
-        onClose={onCloseModal}
-        data={infoName ? info[infoName] : []}
-      />
+    (delegatedBalance.gt(0) || unbondingBalance.gt(0)) && (
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={styles.root}
+      >
+        <InfoModal
+          isOpened={!!infoName}
+          onClose={onCloseModal}
+          data={infoName ? info[infoName] : []}
+        />
 
-      <InfoItem
-        title={t("account.availableBalance")}
-        onPress={onPressInfoCreator("available")}
-        value={
-          <CurrencyUnitValue
-            unit={unit}
-            value={spendableBalance}
-            disableRounding
+        <InfoItem
+          title={t("account.availableBalance")}
+          onPress={onPressInfoCreator("available")}
+          value={
+            <CurrencyUnitValue
+              unit={unit}
+              value={spendableBalance}
+              disableRounding
+            />
+          }
+        />
+        {delegatedBalance.gt(0) && (
+          <InfoItem
+            title={t("account.delegatedAssets")}
+            onPress={onPressInfoCreator("delegated")}
+            value={
+              <CurrencyUnitValue
+                unit={unit}
+                value={delegatedBalance}
+                disableRounding
+              />
+            }
           />
-        }
-      />
-      <InfoItem
-        title={t("account.delegatedAssets")}
-        onPress={onPressInfoCreator("delegated")}
-        value={
-          <CurrencyUnitValue
-            unit={unit}
-            value={delegatedBalance}
-            disableRounding
+        )}
+        {unbondingBalance.gt(0) && (
+          <InfoItem
+            title={t("account.undelegating")}
+            onPress={onPressInfoCreator("undelegating")}
+            value={
+              <CurrencyUnitValue
+                unit={unit}
+                value={unbondingBalance}
+                disableRounding
+              />
+            }
           />
-        }
-      />
-      <InfoItem
-        title={t("account.undelegating")}
-        onPress={onPressInfoCreator("undelegating")}
-        value={
-          <CurrencyUnitValue
-            unit={unit}
-            value={unbondingBalance}
-            disableRounding
-          />
-        }
-      />
-    </ScrollView>
+        )}
+      </ScrollView>
+    )
   );
 }
 
 export default function AccountBalanceFooter({ account }: Props) {
-  if (!account.cosmosResources) return null;
+  if (!account.cosmosResources || account.balance.lte(0)) return null;
 
   return <AccountBalanceSummaryFooter account={account} />;
 }


### PR DESCRIPTION
(Cosmos): account balance footer remove unecessary info when balances at zero
![Screenshot_2020-08-27-11-42-01-423_com ledger live debug](https://user-images.githubusercontent.com/11752937/91424693-6bb5d200-e85a-11ea-9045-74502d803b85.jpg)

![Screenshot_2020-08-27-11-41-23-045_com ledger live debug](https://user-images.githubusercontent.com/11752937/91424684-68224b00-e85a-11ea-84e4-8e218615310f.jpg)


<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type
UI Polish

### Context

Ll-2877

### Parts of the app affected / Test plan

Cosmos accounts with no delegation or no undelegations
