### PR TITLE
LL-3096 (Account): account header title ellipsis issue fixed

### DIFF
--- a/src/screens/Account/AccountHeaderTitle.js
+++ b/src/screens/Account/AccountHeaderTitle.js
@@ -37,11 +37,12 @@ export default function AccountHeaderTitle() {
 const styles = StyleSheet.create({
   title: {
     fontSize: 16,
+    paddingRight: 32,
   },
   headerContainer: {
     flexDirection: "row",
     alignItems: "center",
-    marginHorizontal: 24,
+    marginHorizontal: 32,
     paddingVertical: 5,
   },
   iconContainer: {


### PR DESCRIPTION
Account header title ellipsis issue on long account names

![Screenshot_2020-08-28-14-12-21-733_com ledger live debug](https://user-images.githubusercontent.com/11752937/91559754-f10fb400-e938-11ea-8d7f-e18df461a3e8.jpg)


### Type

UI Polish

### Context

LL-3096
### Parts of the app affected / Test plan

Open any account and rename it with a very long name.
The header title should no longer overlap with the settings icon in the header.
