### PR TITLE
add new format to firmware hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@ledgerhq/hw-app-xrp": "5.22.0",
     "@ledgerhq/hw-transport": "5.22.0",
     "@ledgerhq/hw-transport-http": "5.22.0",
-    "@ledgerhq/live-common": "^14.1.7",
+    "@ledgerhq/live-common": "^14.1.8",
     "@ledgerhq/logs": "5.22.0",
     "@ledgerhq/react-native-hid": "5.22.0",
     "@ledgerhq/react-native-hw-transport-ble": "5.22.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@ledgerhq/hw-app-xrp": "5.22.0",
     "@ledgerhq/hw-transport": "5.22.0",
     "@ledgerhq/hw-transport-http": "5.22.0",
-    "@ledgerhq/live-common": "^14.1.4",
+    "@ledgerhq/live-common": "^14.1.7",
     "@ledgerhq/logs": "5.22.0",
     "@ledgerhq/react-native-hid": "5.22.0",
     "@ledgerhq/react-native-hw-transport-ble": "5.22.0",

--- a/src/screens/FirmwareUpdate/02-CheckId.js
+++ b/src/screens/FirmwareUpdate/02-CheckId.js
@@ -101,9 +101,12 @@ export default class FirmwareUpdateCheckId extends Component<Props, State> {
             />
           </LText>
           <View style={[styles.idContainer, { maxWidth: windowWidth - 40 }]}>
-            <LText style={styles.id} bold>
-              {osu && manager.formatHashName(osu.hash)}
-            </LText>
+            {osu &&
+              manager.formatHashName(osu.hash).map(hash => (
+                <LText key={hash} style={styles.id} bold>
+                  {hash}
+                </LText>
+              ))}
           </View>
 
           <View style={styles.footer}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1130,10 +1130,10 @@
     "@ledgerhq/errors" "^5.22.0"
     events "^3.2.0"
 
-"@ledgerhq/live-common@^14.1.4":
-  version "14.1.4"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-14.1.4.tgz#dd20904d998e5f8db95d043492982a7a2a6632b5"
-  integrity sha512-2ImPfbn58UUhZa5fcEwSVOuikBf6hNRHlB5DP9Obj9sGso2WrX3dC4VCBmAvukbSlKgOIhF05Jm8L7w9KHbsSA==
+"@ledgerhq/live-common@^14.1.7":
+  version "14.1.7"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-14.1.7.tgz#e6c5225ae405529788abaedb9ee096f49a188f44"
+  integrity sha512-IclBqQz67Qz5x304JCnc6EBkH8zeVoz06kYE0QhEDC/SC+ozDxAh3vWAjFHgmgYCnSGdDVX5IpGf7QxKjMwYaA==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1130,10 +1130,10 @@
     "@ledgerhq/errors" "^5.22.0"
     events "^3.2.0"
 
-"@ledgerhq/live-common@^14.1.7":
-  version "14.1.7"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-14.1.7.tgz#e6c5225ae405529788abaedb9ee096f49a188f44"
-  integrity sha512-IclBqQz67Qz5x304JCnc6EBkH8zeVoz06kYE0QhEDC/SC+ozDxAh3vWAjFHgmgYCnSGdDVX5IpGf7QxKjMwYaA==
+"@ledgerhq/live-common@^14.1.8":
+  version "14.1.8"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-14.1.8.tgz#19f78778687514b114ed1d45f4830c5f9d2841cf"
+  integrity sha512-s6AIl/mdnGZa5iG5TTY7IPr32tbZh9egxfbOpWAuAtzbfjc3RUcTYflgdA36h0JbKw43WiSGv84z7St9WCdu/A==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.22.0"


### PR DESCRIPTION
LL-3066
split FW hash to be displayed the same way nano S|X display them

We do not have the firmware update implemented on mobile yet, but as a safe guard, updating the component so it doesn't break

https://github.com/LedgerHQ/ledger-live-common/pull/842 waiting for it to be merged and live-common bumped