### PR TITLE
LL-1927 (AccountDistribution): navigation issue fixed

### DIFF
--- a/src/components/AccountDistribution/Row.js
+++ b/src/components/AccountDistribution/Row.js
@@ -47,7 +47,7 @@ export default function Row({
         parentId: parentAccount ? parentAccount.id : undefined,
       });
     },
-    [account, navigation],
+    [account.id, navigation],
   );
 
   const parentAccount =

--- a/src/components/RootNavigator/BaseNavigator.js
+++ b/src/components/RootNavigator/BaseNavigator.js
@@ -30,10 +30,13 @@ import PasswordAddFlowNavigator from "./PasswordAddFlowNavigator";
 import PasswordModifyFlowNavigator from "./PasswordModifyFlowNavigator";
 import MigrateAccountsFlowNavigator from "./MigrateAccountsFlowNavigator";
 import { closableStackNavigatorConfig } from "../../navigation/navigatorConfig";
+import Account from "../../screens/Account";
 import TransparentHeaderNavigationOptions from "../../navigation/TransparentHeaderNavigationOptions";
 import colors from "../../colors";
 import HeaderRightClose from "../HeaderRightClose";
 import StepHeader from "../StepHeader";
+import AccountHeaderTitle from "../../screens/Account/AccountHeaderTitle";
+import AccountHeaderRight from "../../screens/Account/AccountHeaderRight";
 
 export default function BaseNavigator() {
   const { t } = useTranslation();
@@ -180,6 +183,17 @@ export default function BaseNavigator() {
           headerTitle: () => <HeaderTitle />,
           headerRight: null,
         }}
+      />
+      <Stack.Screen
+        name={ScreenName.Account}
+        component={Account}
+        options={({ route, navigation }) => ({
+          headerLeft: () => (
+            <BackButton navigation={navigation} route={route} />
+          ),
+          headerTitle: () => <AccountHeaderTitle />,
+          headerRight: () => <AccountHeaderRight />,
+        })}
       />
       <Stack.Screen
         name={ScreenName.ScanRecipient}


### PR DESCRIPTION
Navigation back on an account page when coming from asset distribution should now go back to the previous page and not the accounts list page.

### Type

UI Polish

### Context

LL-1927

### Parts of the app affected / Test plan

Account page navigation when coming from asset distribution flow.
