### PR TITLE
LL-3100 (ETH): summary gas price and max fees updated

### DIFF
--- a/src/families/ethereum/EthereumFeeRow.js
+++ b/src/families/ethereum/EthereumFeeRow.js
@@ -81,7 +81,7 @@ export default function EthereumFeeRow({
             ? toggleNetworkFeeHelpModal
             : extraInfoFees
         }
-        title={<Trans i18nKey="send.fees.title" />}
+        title={<Trans i18nKey="send.summary.gasPrice" />}
         additionalInfo={
           <View>
             <InfoIcon size={12} color={colors.grey} />
@@ -103,6 +103,28 @@ export default function EthereumFeeRow({
               {t("common.edit")}
             </LText>
           </View>
+        </View>
+      </SummaryRow>
+      <EthereumGasLimit
+        account={account}
+        parentAccount={parentAccount}
+        transaction={transaction}
+      />
+      <SummaryRow title={<Trans i18nKey="send.summary.maxFees" />}>
+        <View style={{ alignItems: "flex-end" }}>
+          <View style={styles.accountContainer}>
+            {gasPrice ? (
+              <LText style={styles.valueText}>
+                <CurrencyUnitValue
+                  unit={mainAccount.unit}
+                  value={
+                    gasPrice &&
+                    gasPrice.times(gasLimit || estimatedGasLimit || 0)
+                  }
+                />
+              </LText>
+            ) : null}
+          </View>
           <LText style={styles.countervalue}>
             <CounterValue
               before="≈ "
@@ -114,11 +136,6 @@ export default function EthereumFeeRow({
           </LText>
         </View>
       </SummaryRow>
-      <EthereumGasLimit
-        account={account}
-        parentAccount={parentAccount}
-        transaction={transaction}
-      />
     </>
   );
 }

--- a/src/families/ethereum/ScreenEditFee.js
+++ b/src/families/ethereum/ScreenEditFee.js
@@ -13,7 +13,7 @@ import EditFeeUnitEthereum from "./EditFeeUnitEthereum";
 const forceInset = { bottom: "always" };
 
 const options = {
-  title: i18n.t("send.fees.title"),
+  title: i18n.t("send.summary.gasPrice"),
   headerLeft: null,
 };
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1266,6 +1266,8 @@
       "infoTotalTitle": "Total to spend",
       "infoTotalDesc": "Includes transaction amount and the selected network fees",
       "gasLimit": "Gas Limit",
+      "gasPrice": "Gas Price",
+      "maxFees": "Max fees",
       "validateGasLimit": "Validate Gas Limit",
       "memo": {
         "title": "Memo",


### PR DESCRIPTION
(ETH): summary gas price and max fees updated with correct values

![Screenshot_2020-09-14-12-28-20-800_com ledger live debug](https://user-images.githubusercontent.com/11752937/93075277-db62f400-f685-11ea-9e0d-68a6cd0a0638.jpg)


### Type

UI Polish

### Context

LL-3100

### Parts of the app affected / Test plan

Do an ethereum transaction and check the summary part.
