### PR TITLE
Fixes iOS crashes (optimistically)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - boost-for-react-native (1.63.0)
   - CocoaAsyncSocket (7.6.4)
   - CocoaLibEvent (1.0.0)
-  - djinni_objc (4.16.0)
+  - djinni_objc (4.16.3)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.61.2)
   - FBReactNativeSpec (0.61.2):
@@ -67,7 +67,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - ledger-core-objc (4.16.0):
+  - ledger-core-objc (4.16.3):
     - djinni_objc
   - lottie-ios (3.1.8)
   - lottie-react-native (3.3.2):
@@ -321,7 +321,7 @@ PODS:
     - React
   - RNKeychain (5.0.0):
     - React
-  - RNLibLedgerCore (4.16.0):
+  - RNLibLedgerCore (4.16.3):
     - ledger-core-objc
     - React
   - RNOS (1.2.6):
@@ -548,7 +548,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
-  djinni_objc: 61afebb38f636dc8820c3cc12f888ac9e0e2ee6e
+  djinni_objc: f04ed3e34aeabad13c48893d48cd72c9e2275dbd
   DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 68b6a76960fbd8ecd9fb7ce0aadd3329c3340a99
   FBReactNativeSpec: 5a764c60abdc3336a213e5310c40b74741f32839
@@ -561,7 +561,7 @@ SPEC CHECKSUMS:
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
   glog: 1f3da668190260b06b429bb211bfbee5cd790c28
-  ledger-core-objc: 2125244bdfa7c9357ae7e4f13a0c35f493bfcb0f
+  ledger-core-objc: 2b7223951d4bcdb999b1c5c75e2359169031e2ba
   lottie-ios: 48fac6be217c76937e36e340e2d09cf7b10b7f5f
   lottie-react-native: 2a1a82bb326ae51331a5520de0cf706733c6db69
   OpenSSL-Universal: 8b48cc0d10c1b2923617dfe5c178aa9ed2689355
@@ -604,7 +604,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 76c40a1d41c3e2535df09246a2b5487f04de0814
   RNGestureHandler: dde546180bf24af0b5f737c8ad04b6f3fa51609a
   RNKeychain: 589a5504ba18b854fb8c2ba6402387b9529da959
-  RNLibLedgerCore: c88a8973e7b0fa052a64ed18d986584e2d9105c4
+  RNLibLedgerCore: 4574c3750d377ef7493c6e9be4344ac185de01b9
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
   RNReanimated: 031fe8d9ea93c2bd689a40f05320ef9d96f74d7f
   RNScreens: 812b79d384e2bea7eebc4ec981469160d4948fd5

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@ledgerhq/logs": "5.23.0",
     "@ledgerhq/react-native-hid": "5.23.0",
     "@ledgerhq/react-native-hw-transport-ble": "5.23.0",
-    "@ledgerhq/react-native-ledger-core": "4.16.0",
+    "@ledgerhq/react-native-ledger-core": "4.16.3",
     "@ledgerhq/react-native-passcode-auth": "^2.1.0",
     "@react-native-community/art": "^1.1.2",
     "@react-native-community/async-storage": "^1.8.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1232,10 +1232,10 @@
     rxjs "^6.6.3"
     uuid "^3.4.0"
 
-"@ledgerhq/react-native-ledger-core@4.16.0":
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-4.16.0.tgz#942d56fcc80ab71437682dbde481aa886eee22d5"
-  integrity sha512-2K9XteMUQU9LmQ8zXu68WJyPNoHDN9HD2RpGjfUCwK+3IH4T1UVhgcsvvYmmPD/MeS4li7AXW0xsRlnFlYVwpA==
+"@ledgerhq/react-native-ledger-core@4.16.3":
+  version "4.16.3"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-4.16.3.tgz#5199734029df9a25b77d15af2e21a98812a73b77"
+  integrity sha512-MqqkEHmYYNuElGZc0GTdKB0M0i80KHqE5fTrJivuuiVADUw9PEo9nrOXTNzGW8cA3MCP4YqhgRYyTWr4t6KD0w==
 
 "@ledgerhq/react-native-passcode-auth@^2.1.0":
   version "2.1.0"


### PR DESCRIPTION
contains work of https://github.com/LedgerHQ/lib-ledger-core-react-native-bindings/pull/72

the plan is to confirm there is no feature regression of this on iOS, basically on some libcore stuff (sending a btc account for instance)

the way we will then proceed is send to testflight for further testing.