### PR TITLE
LL-3387 (Storage): increase operation retention storage from 100 -> 500

### DIFF
--- a/src/logic/accountModel.js
+++ b/src/logic/accountModel.js
@@ -20,7 +20,7 @@ export const opRetentionStategy = (maxDaysOld: number, keepFirst: number) => (
 ): boolean =>
   index < keepFirst || Date.now() - op.date < 1000 * 60 * 60 * 24 * maxDaysOld;
 
-const opRetentionFilter = opRetentionStategy(366, 100);
+const opRetentionFilter = opRetentionStategy(366, 500);
 
 const accountModel: DataModel<AccountRaw, Account> = createDataModel({
   migrations: [],


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
LL-3387 (Storage): increase operation retention storage from 100 -> 500
### Type

Improvement

### Context

LL-3387

### Parts of the app affected / Test plan

Accounts with more than 100 operations should now be stored on the client with a max of 500 operations
