### PR TITLE
fix tokens unit on validate on device

### DIFF
--- a/src/components/ValidateOnDevice.js
+++ b/src/components/ValidateOnDevice.js
@@ -12,6 +12,7 @@ import type {
 import {
   getMainAccount,
   getAccountUnit,
+  findSubAccountById,
 } from "@ledgerhq/live-common/lib/account";
 
 import { getDeviceTransactionConfig } from "@ledgerhq/live-common/lib/transaction";
@@ -41,13 +42,20 @@ function AmountField({
   parentAccount,
   status,
   field,
+  transaction,
 }: FieldComponentProps) {
   let unit;
   if (account.type === "TokenAccount") {
     unit = getAccountUnit(account);
   } else {
     const mainAccount = getMainAccount(account, parentAccount);
-    unit = getAccountUnit(mainAccount);
+    if (transaction.subAccountId) {
+      const subAccount = findSubAccountById(
+        mainAccount,
+        transaction.subAccountId,
+      );
+      unit = getAccountUnit(subAccount || mainAccount);
+    } else unit = getAccountUnit(mainAccount);
   }
   return (
     <DataRowUnitValue label={field.label} unit={unit} value={status.amount} />


### PR DESCRIPTION
(ValidateOnDevice): fix edge case where amount unit was set to parent unit instead of tx subAccount one

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug Fix

### Context

Slack

### Parts of the app affected / Test plan

Try sending tokens (ERC20...) the amount on device validation step should be in the correct unit now