### PR TITLE
LL-3116 Use the 'clearAccount' helper for CLEAN_CACHE

### DIFF
--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -11,6 +11,7 @@ import {
   importAccountsReduce,
   isUpToDateAccount,
   withoutToken,
+  clearAccount,
 } from "@ledgerhq/live-common/lib/account";
 import accountModel from "../logic/accountModel";
 
@@ -69,12 +70,7 @@ const handlers: Object = {
   }),
 
   CLEAN_CACHE: (state: AccountsState): AccountsState => ({
-    active: state.active.map(account => ({
-      ...account,
-      lastSyncDate: new Date(0),
-      operations: [],
-      pendingOperations: [],
-    })),
+    active: state.active.map(clearAccount),
   }),
 
   BLACKLIST_TOKEN: (


### PR DESCRIPTION
We were not making use of the helper from live-common, resulting in a partial clear cache since subAccounts were not affected. The linked Jira tasks says erc20 were being flushed but I don't see how that's possible. As a side note, on a few occasions I had to clear cache **twice** in order to see this "No operations" screen, but this can't be related to this bug, and is perhaps a good thing to take a look into as a separate bug.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-3116

### Parts of the app affected / Test plan

- Import Tron, Algorand, and Ethereum accounts with subAccounts
- Turn OFF network connection
- Clear the application cache
- Go to Portfolio page