### PR TITLE
LL-3568 Swap - Allow the destination account to be selected before the source

### DIFF
--- a/src/screens/Swap/Form/SelectAccount/01-SelectCrypto.js
+++ b/src/screens/Swap/Form/SelectAccount/01-SelectCrypto.js
@@ -74,11 +74,18 @@ export default function SwapFormSelectCrypto({ route, navigation }: Props) {
 
       if (isCurrencyOK(status, target)) {
         if (target === "from") {
+          // NB Clear toAccount only if it will collide with the selected currency
+          const toAccount =
+            exchange.toAccount &&
+            getAccountCurrency(exchange.toAccount).id === currencyOrToken.id
+              ? undefined
+              : exchange.toAccount;
+
           navigation.navigate(ScreenName.SwapFormSelectAccount, {
             exchange: {
               ...exchange,
               fromAccount: null,
-              toAccount: null,
+              toAccount,
             },
             selectedCurrency: currencyOrToken,
             target,


### PR DESCRIPTION
In the swap flow, allow the user to select a currency / account pair for the destination of a swap before the source pair. This selection should no longer be cleared when selecting the source.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-3568

### Parts of the app affected / Test plan

#### Same currency should be available when selecting FROM after TO
- Go into the swap flow
- Select a destination account from for example BTC
- Select a source account from BTC too (this should be possible, but not the other way around)
- The destination should be cleared.

#### Same currency should **not** be available when selecting TO after FROM
- Go into the swap flow
- Select a source account from for example BTC
- Try to select a destination account from BTC, this should not be possible.

#### Selection should **not** be cleared when it's still valid
- Select a destination account from for example BTC
- Select a source account from ETH.
- The destination should still be the selected BTC account.
