### PR TITLE
LL-3570 Swap - Auto update swap status on history/op details

### DIFF
--- a/src/screens/Swap/OperationDetails.js
+++ b/src/screens/Swap/OperationDetails.js
@@ -8,6 +8,8 @@ import {
 } from "@ledgerhq/live-common/lib/account/helpers";
 import Icon from "react-native-vector-icons/dist/Ionicons";
 import { Trans } from "react-i18next";
+import { useSelector } from "react-redux";
+import { accountsSelector } from "../../reducers/accounts";
 import CurrencyUnitValue from "../../components/CurrencyUnitValue";
 import LText from "../../components/LText";
 import SectionSeparator from "../../components/SectionSeparator";
@@ -30,13 +32,17 @@ const OperationDetails = ({ route }: Props) => {
   const {
     swapId,
     provider,
-    fromAccount,
     toAccount,
     fromAmount,
     toAmount,
-    status,
     operation,
   } = swapOperation;
+
+  const accounts = useSelector(accountsSelector);
+  const fromAccount = accounts.find(a => a.id === swapOperation.fromAccount.id);
+  const swap = fromAccount.swapHistory.find(s => s.swapId === swapId);
+  const status = swap.status;
+
   const fromCurrency = getAccountCurrency(fromAccount);
   const toCurrency = getAccountCurrency(toAccount);
   const statusColor = getStatusColor(status);

--- a/src/screens/Swap/SwapStatusIndicator.js
+++ b/src/screens/Swap/SwapStatusIndicator.js
@@ -3,18 +3,21 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import IconAD from "react-native-vector-icons/dist/AntDesign";
+import { operationStatusList } from "@ledgerhq/live-common/lib/swap";
 import IconSwap from "../../icons/Swap";
 import colors, { rgba } from "../../colors";
 
 export const getStatusColor = (status: string) => {
-  return (
-    {
-      sending: colors.green,
-      finished: colors.green,
-      new: colors.grey,
-      failed: colors.alert,
-    }[status] || colors.grey
-  );
+  if (operationStatusList.pending.includes(status)) {
+    return colors.grey;
+  }
+  if (operationStatusList.finishedOK.includes(status)) {
+    return colors.green;
+  }
+  if (operationStatusList.finishedKO.includes(status)) {
+    return colors.alert;
+  }
+  return colors.grey;
 };
 
 const SwapStatusIndicator = ({
@@ -25,7 +28,6 @@ const SwapStatusIndicator = ({
   small?: boolean,
 }) => {
   const statusColor = getStatusColor(status);
-  const showPendingIcon = status.endsWith("ing");
   const sizeDependantStyles = {
     backgroundColor: rgba(statusColor, 0.1),
     width: small ? 38 : 54,
@@ -35,7 +37,7 @@ const SwapStatusIndicator = ({
   return (
     <View style={[styles.status, sizeDependantStyles]}>
       <IconSwap color={statusColor} size={small ? 16 : 26} />
-      {showPendingIcon ? (
+      {operationStatusList.pending.includes(status) ? (
         <View style={styles.pending}>
           <IconAD
             size={small ? 10 : 14}


### PR DESCRIPTION
Similar to what we did for LLD, introduce an auto update for swap operation status that will update both the History and the operation details if we are currently viewing a particular swap. This is done by polling the endpoint every 10 seconds until the status reaches an end (finished, canceled, refunded).

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-3570

### Parts of the app affected / Test plan

- Either manually modify the app state to have a pending swap, or create a new swap.
- Go into the swap history
- Go into the swap details for that swap
- Wait until the swap status changes to finished.

I kept the pull to refresh on the history screen which manually triggers the update but it doesn't affect the automatic polling.
