### PR TITLE
LL-3527 Introduce the swap banner replacing the buy banner

### DIFF
--- a/src/components/banners/SwapBanner.js
+++ b/src/components/banners/SwapBanner.js
@@ -1,0 +1,97 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { useTranslation } from "react-i18next";
+import { RectButton } from "react-native-gesture-handler";
+import { useNavigation } from "@react-navigation/native";
+import { NavigatorName } from "../../const";
+
+import LText from "../LText";
+import colors from "../../colors";
+import { useBanner } from "./hooks";
+import SwapIcon from "../../icons/Swap";
+import CloseIcon from "../../icons/Close";
+
+export function SwapBanner() {
+  const { t } = useTranslation();
+  const navigation = useNavigation();
+
+  const [isDismissed, dismiss] = useBanner("EXCHANGE_SWAP_BANNER");
+
+  if (isDismissed) {
+    return null;
+  }
+
+  return (
+    <View style={styles.banner}>
+      <RectButton style={styles.closeButton} onPress={dismiss}>
+        <CloseIcon size={18} color={colors.grey} />
+      </RectButton>
+      <RectButton
+        style={styles.innerContainer}
+        onPress={() => navigation.navigate(NavigatorName.Swap)}
+      >
+        <View style={styles.iconContainer}>
+          <SwapIcon size={22} color={colors.live} />
+        </View>
+        <View style={styles.contentContainer}>
+          <LText style={styles.title} bold>
+            {t("banner.swap.title")}
+          </LText>
+          <LText semiBold style={styles.description}>
+            {t("banner.swap.description")}
+          </LText>
+        </View>
+      </RectButton>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    margin: 16,
+    position: "relative",
+    borderRadius: 4,
+    overflow: "hidden",
+    backgroundColor: colors.darkBlue,
+    marginBottom: 8,
+  },
+  innerContainer: {
+    padding: 16,
+    flexDirection: "row",
+    borderRadius: 4,
+  },
+  title: {
+    color: colors.grey,
+    fontSize: 10,
+    lineHeight: 15,
+    marginRight: 90,
+    marginBottom: 4,
+  },
+  contentContainer: {},
+  iconContainer: {
+    width: 56,
+    height: 56,
+    borderRadius: 50,
+    backgroundColor: colors.white,
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    marginRight: 10,
+  },
+  description: {
+    color: colors.white,
+    fontSize: 13,
+    lineHeight: 19,
+    marginRight: 90,
+  },
+  closeButton: {
+    position: "absolute",
+    top: 0,
+    zIndex: 999,
+    right: 0,
+    width: 36,
+    height: 36,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -2428,6 +2428,10 @@
     "exchangeBuyCrypto": {
       "title": "BUY CRYPTO",
       "description": "Purchase crypto assets via Coinify and receive your coins directly in your Ledger account."
+    },
+    "swap": {
+      "title": "SWAP CRYPTO",
+      "description": "Swap crypto assets directly from your Ledger accounts through Changelly!"
     }
   }
 }

--- a/src/screens/Portfolio/index.js
+++ b/src/screens/Portfolio/index.js
@@ -36,7 +36,7 @@ import NoOperationFooter from "../../components/NoOperationFooter";
 import MigrateAccountsBanner from "../MigrateAccounts/Banner";
 import RequireTerms from "../../components/RequireTerms";
 import { useScrollToTop } from "../../navigation/utils";
-import { BuyCryptoBanner } from "../../components/banners/BuyCryptoBanner";
+import { SwapBanner } from "../../components/banners/SwapBanner";
 
 export { default as PortfolioTabIcon } from "./TabIcon";
 
@@ -71,7 +71,7 @@ export default function PortfolioScreen({ navigation }: Props) {
   function ListHeaderComponent() {
     return (
       <>
-        <BuyCryptoBanner />
+        <SwapBanner />
         <GraphCardContainer
           counterValueCurrency={counterValueCurrency}
           portfolio={portfolio}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/95185748-663c9780-07c9-11eb-93b1-5c6c47bb44a0.png)


### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-3527

### Parts of the app affected / Test plan

Loading the app should no longer show the Buy banner and should show the swap one. 
This banner should be dismissible as usual. Clicking on the banner should take the user to the swap feature.
