### PR TITLE
LL-3585 LL-3584 Sync styles for tab navigation with Buy feature, fix overflow of landing

### DIFF
--- a/src/screens/Swap/FormOrHistory.js
+++ b/src/screens/Swap/FormOrHistory.js
@@ -10,10 +10,16 @@ import { ScreenName } from "../../const";
 import Swap from "./Swap";
 import History from "./History";
 import styles from "../../navigation/styles";
+import LText from "../../components/LText";
 
 type RouteParams = {
   defaultAccount: ?AccountLike,
   defaultParentAccount: ?Account,
+};
+
+type TabLabelProps = {
+  focused: boolean,
+  color: string,
 };
 
 export default ({ route }: { route: { params: RouteParams } }) => {
@@ -26,14 +32,28 @@ export default ({ route }: { route: { params: RouteParams } }) => {
     >
       <Tab.Screen
         name={ScreenName.SwapForm}
-        options={{ title: t("transfer.swap.form.tab") }}
+        options={{
+          title: t("exchange.buy.tabTitle"),
+          tabBarLabel: ({ focused, color }: TabLabelProps) => (
+            <LText style={{ width: "110%", color }} semiBold={focused}>
+              {t("transfer.swap.form.tab")}
+            </LText>
+          ),
+        }}
       >
         {props => <Swap {...props} {...route?.params} />}
       </Tab.Screen>
       <Tab.Screen
         name={ScreenName.SwapHistory}
         component={History}
-        options={{ title: t("transfer.swap.history.tab") }}
+        options={{
+          title: t("exchange.buy.tabTitle"),
+          tabBarLabel: ({ focused, color }: TabLabelProps) => (
+            <LText style={{ width: "110%", color }} semiBold={focused}>
+              {t("transfer.swap.history.tab")}
+            </LText>
+          ),
+        }}
       />
     </Tab.Navigator>
   );

--- a/src/screens/Swap/Landing.js
+++ b/src/screens/Swap/Landing.js
@@ -88,7 +88,7 @@ const styles = StyleSheet.create({
     marginLeft: 8,
     color: colors.darkBlue,
     fontSize: 13,
-    paddingRight: 16,
+    flex: 1,
   },
   wrapper: {
     flexGrow: 1,


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
![image](https://user-images.githubusercontent.com/4631227/95187822-e663fc80-07cb-11eb-9272-15e3862bc152.png)

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-3585
https://ledgerhq.atlassian.net/browse/LL-3584


### Test plan
Make sure that apart from the landing looking like the screenshot, there's no overflow of the disclaimer on the footer like it was happening on https://ledgerhq.atlassian.net/browse/LL3584 for iPhone 7 according to @cthepot-ledger 