### PR TITLE
LL-3463 (Portfolio): operation row balance no longer ellipsis

### DIFF
--- a/src/components/OperationRow.js
+++ b/src/components/OperationRow.js
@@ -250,8 +250,8 @@ const styles = StyleSheet.create({
     alignItems: "flex-end",
     flexDirection: "column",
     justifyContent: "flex-start",
-    flexShrink: 1,
-    paddingLeft: 10,
+    flexShrink: 0,
+    paddingLeft: 6,
   },
   spinner: {
     height: 14,


### PR DESCRIPTION


<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(Portfolio): OperationRow balance should not shrink and ellipsis anymore

![Screenshot_2020-10-06-14-08-50-734_com ledger live debug](https://user-images.githubusercontent.com/11752937/95200038-03093000-07de-11eb-86b8-271ddd68e8c0.jpg)


### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI Polish
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-3463
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Portfolio page and operation rows with big account names and balance digits
