### PR TITLE
LL-3366 Wrap the value on the confirmation screen if needed

### DIFF
--- a/src/components/ValidateOnDeviceDataRow.js
+++ b/src/components/ValidateOnDeviceDataRow.js
@@ -16,6 +16,7 @@ const styles = StyleSheet.create({
     backgroundColor: colors.lightGrey,
     alignItems: "center",
     flexDirection: "row",
+    flexWrap: "wrap",
   },
   dataColumn: {
     padding: 12,
@@ -29,13 +30,12 @@ const styles = StyleSheet.create({
     color: colors.grey,
     textAlign: "left",
     fontSize: 14,
-    paddingRight: 16,
-    flex: 0.5,
+    paddingRight: 8,
   },
   dataRowValue: {
     color: colors.darkBlue,
     fontSize: 14,
-    flex: 1,
+    flexGrow: 1,
     textAlign: "right",
   },
   text: {


### PR DESCRIPTION
Allow the value (right element) on a `DataRow` from the validation step of the send flow and any other flow that uses it to grow while possible and then wrap to the next line as a whole instead of wrapping the ticker first. On the extreme case of the amount itself being wider than the whole scree, then it will wrap the text because there's nothing we can do about it. But at that point you're viewing the app on a watch screen.

![grow](https://user-images.githubusercontent.com/4631227/95449496-2a3e3980-0965-11eb-921a-7da154a44b10.png)

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-3366

### Parts of the app affected / Test plan

- Go through a send flow with many decimals / small screen
- Reach the device validation step
- Check that it doesn't do the OMG bug (ticker wrap) uglyness from the ticket linked
