### PR TITLE
LL-3113 (GenericErrorModal): closing on network-down event should function now

### DIFF
--- a/src/families/tron/VoteFlow/02-VoteCast.js
+++ b/src/families/tron/VoteFlow/02-VoteCast.js
@@ -1,7 +1,7 @@
 /* @flow */
 import invariant from "invariant";
 import useBridgeTransaction from "@ledgerhq/live-common/lib/bridge/useBridgeTransaction";
-import React, { useCallback, useState, useMemo } from "react";
+import React, { useCallback, useState, useMemo, useEffect } from "react";
 import { View, StyleSheet, ScrollView, TouchableOpacity } from "react-native";
 import SafeAreaView from "react-native-safe-area-view";
 import { useSelector } from "react-redux";
@@ -156,12 +156,18 @@ export default function VoteCast({ route, navigation }: Props) {
     });
   }, [account, navigation, transaction, status]);
 
+  const [bridgeErr, setBridgeErr] = useState(bridgeError);
+
+  useEffect(() => setBridgeErr(bridgeError), [bridgeError]);
+
   const onBridgeErrorCancel = useCallback(() => {
+    setBridgeErr(null);
     const parent = navigation.dangerouslyGetParent();
     if (parent) parent.goBack();
   }, [navigation]);
 
   const onBridgeErrorRetry = useCallback(() => {
+    setBridgeErr(null);
     if (!transaction) return;
     setTransaction(bridge.updateTransaction(transaction, {}));
   }, [setTransaction, transaction, bridge]);
@@ -246,7 +252,7 @@ export default function VoteCast({ route, navigation }: Props) {
       ) : null}
 
       <GenericErrorBottomModal
-        error={bridgeError}
+        error={bridgeErr}
         onClose={onBridgeErrorRetry}
         footerButtons={
           <>

--- a/src/screens/FreezeFunds/02-Amount.js
+++ b/src/screens/FreezeFunds/02-Amount.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { BigNumber } from "bignumber.js";
 import useBridgeTransaction from "@ledgerhq/live-common/lib/bridge/useBridgeTransaction";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useMemo, useState, useEffect } from "react";
 import {
   View,
   StyleSheet,
@@ -126,12 +126,18 @@ export default function FreezeAmount({ navigation, route }: Props) {
     });
   }, [account, navigation, transaction, status]);
 
+  const [bridgeErr, setBridgeErr] = useState(bridgeError);
+
+  useEffect(() => setBridgeErr(bridgeError), [bridgeError]);
+
   const onBridgeErrorCancel = useCallback(() => {
+    setBridgeErr(null);
     const parent = navigation.dangerouslyGetParent();
     if (parent) parent.goBack();
   }, [navigation]);
 
   const onBridgeErrorRetry = useCallback(() => {
+    setBridgeErr(null);
     if (!transaction) return;
     setTransaction(bridge.updateTransaction(transaction, {}));
   }, [setTransaction, transaction, bridge]);
@@ -309,7 +315,7 @@ export default function FreezeAmount({ navigation, route }: Props) {
       />
 
       <GenericErrorBottomModal
-        error={bridgeError}
+        error={bridgeErr}
         onClose={onBridgeErrorRetry}
         footerButtons={
           <>

--- a/src/screens/SendFunds/02-SelectRecipient.js
+++ b/src/screens/SendFunds/02-SelectRecipient.js
@@ -7,7 +7,7 @@ import {
 } from "@ledgerhq/live-common/lib/bridge/react";
 import useBridgeTransaction from "@ledgerhq/live-common/lib/bridge/useBridgeTransaction";
 import type { Transaction } from "@ledgerhq/live-common/lib/types";
-import React, { useCallback, useRef, useEffect } from "react";
+import React, { useCallback, useRef, useEffect, useState } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { Platform, StyleSheet, View } from "react-native";
 import Icon from "react-native-vector-icons/dist/FontAwesome";
@@ -88,12 +88,18 @@ export default function SendSelectRecipient({ navigation, route }: Props) {
   );
   const clear = useCallback(() => onChangeText(""), [onChangeText]);
 
+  const [bridgeErr, setBridgeErr] = useState(bridgeError);
+
+  useEffect(() => setBridgeErr(bridgeError), [bridgeError]);
+
   const onBridgeErrorCancel = useCallback(() => {
+    setBridgeErr(null);
     const parent = navigation.dangerouslyGetParent();
     if (parent) parent.goBack();
   }, [navigation]);
 
   const onBridgeErrorRetry = useCallback(() => {
+    setBridgeErr(null);
     if (!transaction) return;
     const bridge = getAccountBridge(account, parentAccount);
     setTransaction(bridge.updateTransaction(transaction, {}));
@@ -186,7 +192,7 @@ export default function SendSelectRecipient({ navigation, route }: Props) {
       </SafeAreaView>
 
       <GenericErrorBottomModal
-        error={bridgeError}
+        error={bridgeErr}
         onClose={onBridgeErrorRetry}
         footerButtons={
           <>

--- a/src/screens/SendFunds/03-Amount.js
+++ b/src/screens/SendFunds/03-Amount.js
@@ -111,12 +111,18 @@ export default function SendAmount({ navigation, route }: Props) {
     });
   }, [account, parentAccount, navigation, transaction]);
 
+  const [bridgeErr, setBridgeErr] = useState(bridgeError);
+
+  useEffect(() => setBridgeErr(bridgeError), [bridgeError]);
+
   const onBridgeErrorCancel = useCallback(() => {
+    setBridgeErr(null);
     const parent = navigation.dangerouslyGetParent();
     if (parent) parent.goBack();
   }, [navigation]);
 
   const onBridgeErrorRetry = useCallback(() => {
+    setBridgeErr(null);
     if (!transaction) return;
     const bridge = getAccountBridge(account, parentAccount);
     setTransaction(bridge.updateTransaction(transaction, {}));
@@ -202,7 +208,7 @@ export default function SendAmount({ navigation, route }: Props) {
       </SafeAreaView>
 
       <GenericErrorBottomModal
-        error={bridgeError}
+        error={bridgeErr}
         onClose={onBridgeErrorRetry}
         footerButtons={
           <>

--- a/src/screens/UnfreezeFunds/01-Amount.js
+++ b/src/screens/UnfreezeFunds/01-Amount.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { BigNumber } from "bignumber.js";
 import invariant from "invariant";
-import React, { useCallback, useMemo } from "react";
+import React, { useCallback, useMemo, useEffect, useState } from "react";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
 import SafeAreaView from "react-native-safe-area-view";
 import { useSelector } from "react-redux";
@@ -148,12 +148,18 @@ function UnfreezeAmountInner({ account }: InnerProps) {
     });
   }, [account, navigation, transaction, status]);
 
+  const [bridgeErr, setBridgeErr] = useState(bridgeError);
+
+  useEffect(() => setBridgeErr(bridgeError), [bridgeError]);
+
   const onBridgeErrorCancel = useCallback(() => {
+    setBridgeErr(null);
     const parent = navigation.dangerouslyGetParent();
     if (parent) parent.goBack();
   }, [navigation]);
 
   const onBridgeErrorRetry = useCallback(() => {
+    setBridgeErr(null);
     if (!transaction) return;
     setTransaction(bridge.updateTransaction(transaction, {}));
   }, [bridge, setTransaction, transaction]);
@@ -288,7 +294,7 @@ function UnfreezeAmountInner({ account }: InnerProps) {
       </SafeAreaView>
 
       <GenericErrorBottomModal
-        error={bridgeError}
+        error={bridgeErr}
         onClose={onBridgeErrorRetry}
         footerButtons={
           <>


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(GenericErrorModal): closing on network-down event should function now
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug fix
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-3113
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Error modals that can be triggered from network down on send flow etc. upon clicking on cancel and close button the modal should close properly now
