### PR TITLE
Blind fix for swap op details erc20 crash

### DIFF
--- a/src/screens/Swap/OperationDetails.js
+++ b/src/screens/Swap/OperationDetails.js
@@ -15,7 +15,7 @@ import {
 import Icon from "react-native-vector-icons/dist/Ionicons";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
-import { accountsSelector } from "../../reducers/accounts";
+import { flattenAccountsSelector } from "../../reducers/accounts";
 import CurrencyUnitValue from "../../components/CurrencyUnitValue";
 import LText from "../../components/LText";
 import SectionSeparator from "../../components/SectionSeparator";
@@ -45,7 +45,7 @@ const OperationDetails = ({ route }: Props) => {
     operation,
   } = swapOperation;
 
-  const accounts = useSelector(accountsSelector);
+  const accounts = useSelector(flattenAccountsSelector);
   const fromAccount = accounts.find(a => a.id === swapOperation.fromAccount.id);
   const swap = fromAccount.swapHistory.find(s => s.swapId === swapId);
   const status = swap.status;


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type
Bug fix
<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context
Crash reported on slack
<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan
Make a swap from an erc20 token and try to see its op details, currently it should normally crash the app 🤦‍♀️ after this fix it should work as usual. 
<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
