### PR TITLE
Fix yarn run-android due to @segment analytics build issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         minSdkVersion = 24
         compileSdkVersion = 28
         targetSdkVersion = 28
+        kotlinVersion = "1.4.10"
     }
     repositories {
         jcenter()


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
force kotlin version to a higher version to ensure @segment/analytics-react-native builds
(version set is 1.4.10 as it is the latest)
solution found [here](https://github.com/segmentio/analytics-react-native/issues/225)
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug fix
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Try yarn android without this should fail on build of task :segment_analytics-react-native:compileDebugKotlin
This should fix it
