### PR TITLE
LL-3530 Onboarding ConnectDevice already paired loading issue

### DIFF
--- a/src/components/SelectDevice/index.js
+++ b/src/components/SelectDevice/index.js
@@ -24,6 +24,7 @@ type Props = {
   withArrows?: boolean,
   usbOnly?: boolean,
   filter?: (transportModule: TransportModule) => boolean,
+  autoSelectOnAdd: boolean,
 };
 
 export default function SelectDevice({
@@ -32,6 +33,7 @@ export default function SelectDevice({
   filter = () => true,
   onSelect,
   onBluetoothDeviceAction,
+  autoSelectOnAdd,
 }: Props) {
   const navigation = useNavigation();
   const knownDevices = useSelector(knownDevicesSelector);
@@ -39,8 +41,10 @@ export default function SelectDevice({
   const [devices, setDevices] = useState([]);
 
   const onPairNewDevice = useCallback(() => {
-    navigation.navigate(ScreenName.PairDevices);
-  }, [navigation]);
+    navigation.navigate(ScreenName.PairDevices, {
+      onDone: autoSelectOnAdd ? onSelect : null,
+    });
+  }, [autoSelectOnAdd, navigation, onSelect]);
 
   const renderItem = useCallback(
     (item: Device) => (

--- a/src/screens/Onboarding/steps/pair-new.js
+++ b/src/screens/Onboarding/steps/pair-new.js
@@ -72,7 +72,7 @@ export default function OnboardingStepPairNew() {
         withArrows
         usbOnly={usbOnly}
         deviceModelId={deviceModelId}
-        onSelect={setDevice}
+        onSelect={usbOnly ? setDevice : next}
         autoSelectOnAdd
       />
       <DeviceActionModal


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
During onboarding on bluetooth if device already paired we should not see the device connection modal anymore and be redirected to next step directly.
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI polish
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-3530
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Onboarding using bluetooth. check also usb if everything is ok.
