### PR TITLE
LL-3538 Add ledger status link to support modal

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1043,6 +1043,10 @@
     "github": {
       "title": "Github",
       "desc": "Review our code"
+    },
+    "status": {
+      "title": "Ledger Status",
+      "desc": "Check our system status"
     }
   },
   "settings": {

--- a/src/screens/Settings/HelpButton.js
+++ b/src/screens/Settings/HelpButton.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { TouchableOpacity, Linking } from "react-native";
 import { useTranslation } from "react-i18next";
+import Icon from "react-native-vector-icons/dist/Feather";
 import IconQuestion from "../../icons/Question";
 import colors from "../../colors";
 import type { Props as ModalProps } from "../../components/BottomModal";
@@ -71,6 +72,15 @@ function CreateModal({ isOpened, onClose }: ModalProps) {
         description={t("help.github.desc")}
         onPress={() => Linking.openURL("https://github.com/LedgerHQ")}
         Icon={IconGithub}
+      />
+      <BottomModalChoice
+        event="HelpLedgerStatus"
+        title={t("help.status.title")}
+        description={t("help.status.desc")}
+        onPress={() => Linking.openURL("https://status.ledger.com")}
+        Icon={({ size, color }) => (
+          <Icon name="activity" color={color} size={size} />
+        )}
       />
     </BottomModal>
   );


### PR DESCRIPTION
The UI differs from the figma linked because this concept of bottom modal choice is also user for the transfer actions and the onboarding steps, I don't think it makes sense to remove the blue circles only for this one, specially with what's going to come in the future months. 
![image](https://user-images.githubusercontent.com/4631227/96715225-8e202380-13a3-11eb-9e35-27a921e615e8.png)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-3538

### Parts of the app affected / Test plan

- Go to settings,
- Click on the `?` on the top bar
- Check the link for ledger status exists and works
