### PR TITLE
LL-3679 Make settings/accounts navigators go to first screen on blur

### DIFF
--- a/src/components/RootNavigator/MainNavigator.js
+++ b/src/components/RootNavigator/MainNavigator.js
@@ -34,6 +34,7 @@ export default function MainNavigator() {
         name={NavigatorName.Accounts}
         component={AccountsNavigator}
         options={{
+          unmountOnBlur: true,
           tabBarIcon: (props: any) => (
             <TabIcon Icon={AccountsIcon} i18nKey="tabs.accounts" {...props} />
           ),
@@ -58,6 +59,7 @@ export default function MainNavigator() {
         name={NavigatorName.Settings}
         component={SettingsNavigator}
         options={{
+          unmountOnBlur: true,
           tabBarIcon: (props: any) => (
             <TabIcon Icon={SettingsIcon} i18nKey="tabs.settings" {...props} />
           ),


### PR DESCRIPTION
When the user navigates to a secondary/deeper screen from the bottom tab navigator and then navigates to another tab, reset the first tab to the initial screen so that when we come back it's not still in the secondary screen. Was that clear enough? I don't think so, I'll explain better in the test plan.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-3679

### Parts of the app affected / Test plan

- Press the settings tab
- Click on General
- Click on the Accounts tab
- Click on the Settings tab.

We should now be on the main settings screen and **not** in the _General_ one. The same thing applies to the Accounts navigator, you should be able to access a particular account screen, go to the portfolio, come back to the accounts tab and be on the main screen and not the nested one.
