### PR TITLE
LL-3609 Better flow when accessing manager from Swap with query/tab

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -600,7 +600,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   djinni_objc: f04ed3e34aeabad13c48893d48cd72c9e2275dbd
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 878b59e31113e289e275165efbe4b54fa614d43d
   FBReactNativeSpec: 7da9338acfb98d4ef9e5536805a0704572d33c2f
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
@@ -611,7 +611,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   ledger-core-objc: 2b7223951d4bcdb999b1c5c75e2359169031e2ba
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
   lottie-react-native: 2a1a82bb326ae51331a5520de0cf706733c6db69

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -600,7 +600,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
   djinni_objc: f04ed3e34aeabad13c48893d48cd72c9e2275dbd
-  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
+  DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 878b59e31113e289e275165efbe4b54fa614d43d
   FBReactNativeSpec: 7da9338acfb98d4ef9e5536805a0704572d33c2f
   Flipper: be611d4b742d8c87fbae2ca5f44603a02539e365
@@ -611,7 +611,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
   ledger-core-objc: 2b7223951d4bcdb999b1c5c75e2359169031e2ba
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
   lottie-react-native: 2a1a82bb326ae51331a5520de0cf706733c6db69

--- a/src/components/DeviceActionModal.js
+++ b/src/components/DeviceActionModal.js
@@ -16,6 +16,7 @@ type Props = {
   // TODO: fix request type
   request?: any,
   onClose?: () => void,
+  onModalHide: () => void,
   onResult: $PropertyType<React$ElementProps<typeof DeviceAction>, "onResult">,
 };
 
@@ -25,6 +26,7 @@ export default function DeviceActionModal({
   request,
   onClose,
   onResult,
+  onModalHide,
 }: Props) {
   return (
     <BottomModal
@@ -32,6 +34,7 @@ export default function DeviceActionModal({
       isOpened={!!device}
       onClose={onClose}
       onResult={onResult}
+      onModalHide={onModalHide}
     >
       {device && (
         <ModalBottomAction

--- a/src/components/RootNavigator/MainNavigator.js
+++ b/src/components/RootNavigator/MainNavigator.js
@@ -54,6 +54,22 @@ export default function MainNavigator() {
         options={{
           tabBarIcon: (props: any) => <ManagerTabIcon {...props} />,
         }}
+        listeners={({ navigation }) => ({
+          tabPress: e => {
+            e.preventDefault();
+            // NB The default behaviour is not reset route params, leading to always having the same
+            // search query or preselected tab after the first time (ie from Swap/Sell)
+            // https://github.com/react-navigation/react-navigation/issues/6674#issuecomment-562813152
+            navigation.navigate(NavigatorName.Manager, {
+              screen: ScreenName.Manager,
+              params: {
+                tab: undefined,
+                searchQuery: undefined,
+                updateModalOpened: undefined,
+              },
+            });
+          },
+        })}
       />
       <Tab.Screen
         name={NavigatorName.Settings}

--- a/src/screens/Manager/AppsList/AppUpdateAll.js
+++ b/src/screens/Manager/AppsList/AppUpdateAll.js
@@ -14,11 +14,17 @@ type Props = {
   state: State,
   appsToUpdate: App[],
   dispatch: Action => void,
+  isModalOpened?: boolean,
 };
 
-const AppUpdateAll = ({ state, appsToUpdate, dispatch }: Props) => {
+const AppUpdateAll = ({
+  state,
+  appsToUpdate,
+  dispatch,
+  isModalOpened,
+}: Props) => {
   const { updateAllQueue } = state;
-  const [modalOpen, setModalOpen] = useState(false);
+  const [modalOpen, setModalOpen] = useState(isModalOpened);
 
   const openModal = useCallback(() => setModalOpen(true), [setModalOpen]);
   const closeModal = useCallback(() => setModalOpen(false), [setModalOpen]);

--- a/src/screens/Manager/AppsScreen.js
+++ b/src/screens/Manager/AppsScreen.js
@@ -17,6 +17,7 @@ import Animated from "react-native-reanimated";
 
 import i18next from "i18next";
 import { Trans } from "react-i18next";
+import type { ManagerTab } from "./Manager";
 
 import colors from "../../colors";
 
@@ -44,13 +45,15 @@ type Props = {
   setAppInstallWithDependencies: ({ app: App, dependencies: App[] }) => void,
   setAppUninstallWithDependencies: ({ dependents: App[], app: App }) => void,
   setStorageWarning: () => void,
-  managerTabs: *,
+  managerTabs: { [ManagerTab]: ManagerTab },
   deviceId: string,
   initialDeviceName: string,
   navigation: *,
   blockNavigation: boolean,
   deviceInfo: *,
   searchQuery?: string,
+  updateModalOpened?: boolean,
+  tab: ManagerTab,
 };
 
 const AppsScreen = ({
@@ -66,12 +69,14 @@ const AppsScreen = ({
   blockNavigation,
   deviceInfo,
   searchQuery,
+  updateModalOpened,
+  tab,
 }: Props) => {
   const distribution = distribute(state);
 
   const listRef = useRef();
 
-  const [index, setIndex] = useState(0);
+  const [index, setIndex] = useState(tab === managerTabs.CATALOG ? 0 : 1);
   const [routes] = React.useState([
     {
       key: managerTabs.CATALOG,
@@ -189,6 +194,7 @@ const AppsScreen = ({
               state={state}
               appsToUpdate={update}
               dispatch={dispatch}
+              isModalOpened={updateModalOpened}
             />
             <View>
               {device && device.length > 0 && !state.updateAllQueue.length && (

--- a/src/screens/Manager/Manager.js
+++ b/src/screens/Manager/Manager.js
@@ -16,10 +16,12 @@ import UninstallDependenciesModal from "./Modals/UninstallDependenciesModal";
 import { useLockNavigation } from "../../components/RootNavigator/CustomBlockRouterNavigator";
 import { stackNavigatorConfig } from "../../navigation/navigatorConfig";
 
-const MANAGER_TABS = {
+export const MANAGER_TABS = {
   CATALOG: "CATALOG",
   INSTALLED_APPS: "INSTALLED_APPS",
 };
+
+export type ManagerTab = $Keys<typeof MANAGER_TABS>;
 
 type Props = {
   navigation: any,
@@ -29,6 +31,8 @@ type Props = {
       deviceInfo: DeviceInfo,
       result: ListAppsResult,
       searchQuery?: string,
+      updateModalOpened?: boolean,
+      tab: ManagerTab,
     },
   },
 };
@@ -36,7 +40,14 @@ type Props = {
 const Manager = ({
   navigation,
   route: {
-    params: { device, deviceInfo, result, searchQuery },
+    params: {
+      device,
+      deviceInfo,
+      result,
+      searchQuery,
+      updateModalOpened,
+      tab = MANAGER_TABS.CATALOG,
+    },
   },
 }: Props) => {
   const { deviceId, deviceName, modelId } = device;
@@ -135,6 +146,8 @@ const Manager = ({
         blockNavigation={blockNavigation}
         deviceInfo={deviceInfo}
         searchQuery={searchQuery}
+        updateModalOpened={updateModalOpened}
+        tab={tab}
       />
       <GenericErrorBottomModal error={error} onClose={closeErrorModal} />
       <QuitManagerModal

--- a/src/screens/Manager/index.js
+++ b/src/screens/Manager/index.js
@@ -12,6 +12,7 @@ import connectManager from "@ledgerhq/live-common/lib/hw/connectManager";
 import { createAction } from "@ledgerhq/live-common/lib/hw/actions/manager";
 import { removeKnownDevice } from "../../actions/ble";
 import { ScreenName } from "../../const";
+import type { ManagerTab } from "./Manager";
 import SelectDevice from "../../components/SelectDevice";
 import colors from "../../colors";
 import TrackScreen from "../../analytics/TrackScreen";
@@ -61,6 +62,7 @@ const RemoveDeviceModal = ({
 
 type RouteParams = {
   searchQuery?: string,
+  tab?: ManagerTab,
 };
 
 type Props = {

--- a/src/screens/Manager/index.js
+++ b/src/screens/Manager/index.js
@@ -85,11 +85,13 @@ class ChooseDevice extends Component<
   {
     showMenu: boolean,
     device?: Device,
+    result?: Object,
   },
 > {
   state = {
     showMenu: false,
     device: undefined,
+    result: undefined,
   };
 
   chosenDevice: Device;
@@ -112,15 +114,16 @@ class ChooseDevice extends Component<
   };
 
   onSelect = (result: Object) => {
-    this.setState(
-      { device: undefined },
-      () =>
-        result.result &&
-        this.props.navigation.navigate(ScreenName.ManagerMain, {
-          ...result,
-          ...this.props.route.params,
-        }),
-    );
+    this.setState({ device: undefined, result });
+  };
+
+  onModalHide = () => {
+    const { result } = this.state;
+    result?.result &&
+      this.props.navigation.navigate(ScreenName.ManagerMain, {
+        ...result,
+        ...this.props.route.params,
+      });
   };
 
   onStepEntered = (i: number, meta: Object) => {
@@ -166,6 +169,7 @@ class ChooseDevice extends Component<
           <Trans i18nKey="manager.connect" />
         </LText>
         <SelectDevice
+          autoSelectOnAdd
           onSelect={this.onSelectDevice}
           onStepEntered={this.onStepEntered}
           onBluetoothDeviceAction={this.onShowMenu}
@@ -174,6 +178,7 @@ class ChooseDevice extends Component<
           onClose={this.onSelectDevice}
           device={device}
           onResult={this.onSelect}
+          onModalHide={this.onModalHide}
           action={action}
           request={null}
         />

--- a/src/screens/Swap/Form/SelectAccount/BadSelectionModal.js
+++ b/src/screens/Swap/Form/SelectAccount/BadSelectionModal.js
@@ -27,17 +27,23 @@ const BadSelectionModal = ({
 }) => {
   const { navigate } = useNavigation();
   const openManagerForApp = useCallback(() => {
+    const outdated = status === "outdatedApp";
     navigate(NavigatorName.Manager, {
       screen: ScreenName.Manager,
-      params: {
-        searchQuery: currency
-          ? currency.type === "TokenCurrency"
-            ? currency?.parentCurrency?.managerAppName
-            : currency?.managerAppName
-          : null,
-      },
+      params: outdated
+        ? {
+            tab: MANAGER_TABS.INSTALLED_APPS,
+            updateModalOpened: true,
+          }
+        : {
+            searchQuery: currency
+              ? currency.type === "TokenCurrency"
+                ? currency?.parentCurrency?.managerAppName
+                : currency?.managerAppName
+              : null,
+          },
     });
-  }, [navigate, currency]);
+  }, [status, navigate, currency]);
 
   if (!currency) return null;
   const appName =

--- a/src/screens/Swap/Form/SelectAccount/BadSelectionModal.js
+++ b/src/screens/Swap/Form/SelectAccount/BadSelectionModal.js
@@ -12,6 +12,7 @@ import type { CurrencyStatus } from "@ledgerhq/live-common/lib/exchange/swap/log
 import { ScreenName, NavigatorName } from "../../../../const";
 import Circle from "../../../../components/Circle";
 import BottomModal from "../../../../components/BottomModal";
+import { MANAGER_TABS } from "../../../Manager/Manager";
 import LText from "../../../../components/LText";
 import Button from "../../../../components/Button";
 import colors from "../../../../colors";

--- a/src/screens/Swap/Form/SelectAccount/BadSelectionModal.js
+++ b/src/screens/Swap/Form/SelectAccount/BadSelectionModal.js
@@ -37,6 +37,7 @@ const BadSelectionModal = ({
             updateModalOpened: true,
           }
         : {
+            tab: MANAGER_TABS.CATALOG,
             searchQuery: currency
               ? currency.type === "TokenCurrency"
                 ? currency?.parentCurrency?.managerAppName

--- a/src/screens/Swap/MissingOrOutdatedSwapApp.js
+++ b/src/screens/Swap/MissingOrOutdatedSwapApp.js
@@ -5,6 +5,7 @@ import SafeAreaView from "react-native-safe-area-view";
 import { StyleSheet, View } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { ScreenName, NavigatorName } from "../../const";
+import { MANAGER_TABS } from "../Manager/Manager";
 import Button from "../../components/Button";
 import LText from "../../components/LText";
 import AppIcon from "../Manager/AppsList/AppIcon";
@@ -20,7 +21,12 @@ const MissingOrOutdatedSwapApp = ({
   const onPress = () => {
     navigate(NavigatorName.Manager, {
       screen: ScreenName.Manager,
-      params: { searchQuery: "Exchange" },
+      params: outdated
+        ? {
+            tab: MANAGER_TABS.INSTALLED_APPS,
+            updateModalOpened: true,
+          }
+        : { searchQuery: "Exchange" },
     });
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1518,53 +1518,54 @@
   integrity sha512-6NKX/WzzC5FP2RSzoq+7CW/iIiRL2S6yN0JKiGvZ8EWAzJ43dbX5KG4kRa1JiKopAal5Vyh80dymbygeylwekQ==
 
 "@react-navigation/bottom-tabs@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-5.1.1.tgz#04636a6b0c2105228f81d6b05aab285a1fcc7ff9"
-  integrity sha512-3eKoLgBsRKXFQoWv9co6bXr2DjlRDtgaS1XZ/2LpOs27lDthShGdVkWzTVaFZ6aGf6pOhUaeKtd8wX+jkUXk0A==
+  version "5.10.5"
+  resolved "https://registry.yarnpkg.com/@react-navigation/bottom-tabs/-/bottom-tabs-5.10.5.tgz#3325b2384a02f8680f3fc39ed12833f3b98110f6"
+  integrity sha512-h082KTS/TaT+WADyYCiMnQ6wj9zMHkAZK0IuAI/dBst6SpBkMNk0CL7xxjBDIepSmwnyrX90hVD1uX/aaH9acg==
   dependencies:
-    color "^3.1.2"
-    react-native-iphone-x-helper "^1.2.1"
+    color "^3.1.3"
+    react-native-iphone-x-helper "^1.3.0"
 
-"@react-navigation/core@^5.2.1":
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.2.1.tgz#8fae1b40b3fbaeb70c6182e00899a2e4d281a12f"
-  integrity sha512-fRezZDtVFMfPtCkFUXFZlhrtECXuuFE9t2LnSyZdm3hZXBf7Gp6KvcMrlzAVXC/n8YCDSqhtDYz7EbF2gX6DJg==
+"@react-navigation/core@^5.13.5":
+  version "5.13.5"
+  resolved "https://registry.yarnpkg.com/@react-navigation/core/-/core-5.13.5.tgz#6d7df178200da45a46b6a438358580bf462043c1"
+  integrity sha512-YYXvkQWL3fH2YOWPIqRA0XMv2kamF3b2rHdEIvoxXTuZ61wSpYQvNfn5A7EeuYClmlVeKVylokQey1bn//geFg==
   dependencies:
-    "@react-navigation/routers" "^5.1.0"
-    escape-string-regexp "^2.0.0"
-    query-string "^6.10.1"
-    react-is "^16.12.0"
-    shortid "^2.2.15"
-    use-subscription "^1.3.0"
+    "@react-navigation/routers" "^5.5.1"
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.1.15"
+    query-string "^6.13.6"
+    react-is "^16.13.0"
 
 "@react-navigation/material-top-tabs@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/material-top-tabs/-/material-top-tabs-5.1.1.tgz#2166b30adc72e4e9aa019093585a3f590fa9cc1c"
-  integrity sha512-zR5yRxRJ3CO/zY/djdkGtNk91fjPVlau/pN9vabLwfMoCiF9igTzLN61ozLPNyNLn5rZMT6f+GOz+y0u5F297g==
+  version "5.3.5"
+  resolved "https://registry.yarnpkg.com/@react-navigation/material-top-tabs/-/material-top-tabs-5.3.5.tgz#fa63e401ec65ec5aab535adfbb13acf319f68fba"
+  integrity sha512-Q8j0Og700xGs5j5VVA7hlHRLaIN39rPqb01SkQbEk9vnpYc6fhUnXNf5SClhZOEMjEwJ38Qt+eTubQ6GxvMm8A==
   dependencies:
-    color "^3.1.2"
+    color "^3.1.3"
 
 "@react-navigation/native@^5.0.9":
-  version "5.0.9"
-  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.0.9.tgz#bbd22928f0fbe808a96dd525ebeb9a1aa0b82900"
-  integrity sha512-iiCBWKv5zQ/PdvGhUEqMyDU30KK8PL2yXIG0j0CCTXriwRebJ1GPhBtfJdDFkSzzFt9Mhxgmok/+GJV8HqvJqA==
+  version "5.8.5"
+  resolved "https://registry.yarnpkg.com/@react-navigation/native/-/native-5.8.5.tgz#4cadb2220211477d99ac96d05e76a2a623f02129"
+  integrity sha512-p6Z7mQGgKS285dQoluxe1XwaDx3k3iA0ECfJM9meB6ZKr2BQ03w0YEnTx8hrHMuI57eqj3bWeJhoOhH/FBdMTg==
   dependencies:
-    "@react-navigation/core" "^5.2.1"
+    "@react-navigation/core" "^5.13.5"
+    escape-string-regexp "^4.0.0"
+    nanoid "^3.1.15"
 
-"@react-navigation/routers@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.1.0.tgz#ec741e734d501b7024120bef3d109b17f69a7b6b"
-  integrity sha512-sY+eCIcWheflQIfGMSnWomnjP8d+7ZPmH1dKZ1pRezTqLWVlCFntQfQSr2FfM5LLVWty4gZ/K9D+o6UT4ntc3w==
+"@react-navigation/routers@^5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@react-navigation/routers/-/routers-5.5.1.tgz#ece34180e0734e453a7f30dbeeaf3856f25afa00"
+  integrity sha512-Unn2T5+xnolyGzEhiuFnHEGfgvh7+1OJ5KzBY7T65e4gHWT7E1CO8unRbDxRI0KYkXflmRPCfuDjobVTj5xepw==
   dependencies:
-    shortid "^2.2.15"
+    nanoid "^3.1.15"
 
 "@react-navigation/stack@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-5.1.1.tgz#4fff1dc3fec66d7b71cfc31691d6e83d8777d5f8"
-  integrity sha512-tQV4SNESAeqViItGFT8bLrCGWxYfSjw4uXGrCokzSBOMtrdUwINwXDqo40LZt/KZOT0kVN6MdzHq57ILB1LsGA==
+  version "5.12.2"
+  resolved "https://registry.yarnpkg.com/@react-navigation/stack/-/stack-5.12.2.tgz#ea22428494f39d38e679b17d111c75d8135495f6"
+  integrity sha512-4RfZl7+vS9mY1Owy3fdn1G6VKjl17S0lesfS6/b0HwV7K6WVqQcDdgiSfoIl5ht6aUdX2c2eQiMnT0VsgoK8lg==
   dependencies:
-    color "^3.1.2"
-    react-native-iphone-x-helper "^1.2.1"
+    color "^3.1.3"
+    react-native-iphone-x-helper "^1.3.0"
 
 "@segment/analytics-react-native@^1.3.2":
   version "1.3.2"
@@ -3172,7 +3173,7 @@ color@3.0.x:
     color-convert "^1.9.1"
     color-string "^1.5.2"
 
-color@^3.1.2, color@^3.1.3:
+color@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/color/-/color-3.1.3.tgz#ca67fb4e7b97d611dcde39eceed422067d91596e"
   integrity sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==
@@ -4055,6 +4056,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@^1.14.1:
   version "1.14.3"
@@ -7959,10 +7965,10 @@ nanoassert@^1.0.0:
   resolved "https://registry.yarnpkg.com/nanoassert/-/nanoassert-1.1.0.tgz#4f3152e09540fde28c76f44b19bbcd1d5a42478d"
   integrity sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40=
 
-nanoid@^2.1.0:
-  version "2.1.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
-  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
+nanoid@^3.1.15:
+  version "3.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.16.tgz#b21f0a7d031196faf75314d7c65d36352beeef64"
+  integrity sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -8953,10 +8959,10 @@ query-string@^5.0.1:
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 
-query-string@^6.10.1:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.11.0.tgz#dc27a05733d1be66f16d0f83dfa957270f45f66d"
-  integrity sha512-jS+me8X3OEGFTsF6kF+vUUMFG/d3WUCvD7bHhfZP5784nOq1pjj8yau/u86nfOncmcN6ZkSWKWkKAvv/MGxzLA==
+query-string@^6.13.6:
+  version "6.13.6"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.6.tgz#e5ac7c74f2a5da43fbca0b883b4f0bafba439966"
+  integrity sha512-/WWZ7d9na6s2wMEGdVCVgKWE9Rt7nYyNIf7k8xmHXcesPMlEzicWo3lbYwHyA4wBktI2KrXxxZeACLbE84hvSQ==
   dependencies:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"
@@ -9047,7 +9053,7 @@ react-i18next@11.7.3:
     "@babel/runtime" "^7.3.1"
     html-parse-stringify2 "2.0.1"
 
-react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.12.0, react-is@^16.13.0, react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -9139,10 +9145,10 @@ react-native-gesture-handler@^1.6.0:
     invariant "^2.2.4"
     prop-types "^15.7.2"
 
-react-native-iphone-x-helper@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
-  integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
+react-native-iphone-x-helper@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.0.tgz#84fd13e6b89cc3aa4daa80ec514bf15cb724d86d"
+  integrity sha512-+/bcZWFeZt0xSS/+3CHM5K7qPL4vDO/3ARLIowzFpUPGZiPsv9+NET+XNqqseRYwFJwYMmtX+Q4TZKxAVy09ew==
 
 react-native-keychain@^5.0.0:
   version "5.0.0"
@@ -10215,13 +10221,6 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shortid@^2.2.15:
-  version "2.2.15"
-  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
-  integrity sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==
-  dependencies:
-    nanoid "^2.1.0"
-
 side-channel@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.2.tgz#df5d1abadb4e4bf4af1cd8852bf132d2f7876947"
@@ -11228,7 +11227,7 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-subscription@^1.0.0, use-subscription@^1.3.0:
+use-subscription@^1.0.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.4.1.tgz#edcbcc220f1adb2dd4fa0b2f61b6cc308e620069"
   integrity sha512-7+IIwDG/4JICrWHL/Q/ZPK5yozEnvRm6vHImu0LKwQlmWGKeiF7mbAenLlK/cTNXrTtXHU/SFASQHzB6+oSJMQ==


### PR DESCRIPTION
### Original issue in the ticket
When following an error flow end from the swap (will likely need to be integrated on Sell cc @IAmMorrow) there is a possibility that the user can have a missing exchange app, an outdated exchange app, or any number of missing/outdated currency apps. In those cases, we will prompt the user to go to the manager and install or update the app accordingly.

The first iteration of this merely redirected the user to the manager but was further improved by the work of @LFBarreto introducing the `searchQuery` concept that we could pass as a route param to the navigator and have the screen pre-filled to that currency's name. This was great, but being the nonconformist beings we are we decided it would be nicer to preselect the installed tab and show the banner to update, if that was the action the user was coming to the manager for after-all.

Cool, cool. We introduce a new flag to show the update modal, change a bit the logic depending on missing/outdated, pass a default tab for the manager to be able to be on the installed tab by default, and test it all works.

### Uncovered issue found while doing the ticket
After accessing the manager with a pre-filled search query, **any future access to the manager will include that search query.** So if the user didn't have the exchange app installed, accessed the manager from the swap flow, installed the app and then did other things... When that user accessed the manager again during this same session, it will once again show a filtered catalog with the "exchange" app only on that list.

**Why?** Because that's the expected behaviour from https://github.com/react-navigation/react-navigation/issues/6674 and we are expected to reset the route parameters ourselves. (┛ಠ_ಠ)┛彡┻━┻ In order to do this, we need to listen to the `tabPress` event on the navigator definition, but the signature of that parameter which allows us to access the navigator itself required a library bump. Which, luckily, seems to not have broken anything.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-3609

### Flow diagram
![Group](https://user-images.githubusercontent.com/4631227/98147215-834dae80-1ecc-11eb-9b87-7f850073de7a.png)

### How to test this

#### Case 1. Missing exchange app
- [x] Uninstall if needed the exchange app
- [x] Access the swap feature
- [x] Click on the access manager button to install the exchange app
- [x] It is expected that the manager will be in the catalog tab search with the list filtered to only see "exchange"
- [x] Go to the portfolio
- [x] Access the manager from the bottom tab, it is expected that the manager shows the catalog with no filters

#### Case 2. Outdated exchange app
- [x] Install the exchange app, and go into provider 4 to simulate an outdated exchange app
- [x] Access the swap feature
- [x] Click on the access manager button to update the exchange app
- [x] It is expected that the manager will be in the "Installed apps" tab, and the update bottom modal will be visible, allowing you to update the outdated apps.
- [x] Go to the portfolio
- [x] Access the manager from the bottom tab, it is expected that the manager shows the catalog with no filters

#### Case 3. Missing currency app
- [x] Access the swap feature with the exchange app installed and updated
- [x] On the swap form, select a currency that you don't have installed.
- [x] On the bottom modal that shows, click on "Go to Manager" to install the missing currency app
- [x] It is expected that the manager will be in the catalog search with the list filtered to only see the expected currency app or any app that build up on its name. For example, if we are missing Ethereum, the filter will also show Ethereum Classic.
- [x] Go to the portfolio
- [x] Access the manager from the bottom tab, it is expected that the manager shows the catalog with no filters

#### Case 4. Outdated currency app
- [x] Access the swap feature with the exchange app installed and updated
- [x] On the swap form, select a currency that you do have installed but is outdated (provider 4 once again for ETH)
- [x] On the bottom modal that shows, click on "Go to Manager" to update the currency app
- [x] It is expected that the manager will be in the "Installed apps" tab, and the update bottom modal will be visible, allowing you to update the outdated apps.
- [x] Go to the portfolio
- [x] Access the manager from the bottom tab, it is expected that the manager shows the catalog with no filters


Apart from these explicit tests, make sure that the update of react-navigation didn't break anything. Play with the app a bit, I didn't have to make any code changes and I haven't noticed any new crashes or weird behaviour but you never know with this library.