### PR TITLE
Bring back the sticky header on portfolio

### DIFF
--- a/src/screens/Portfolio/index.js
+++ b/src/screens/Portfolio/index.js
@@ -39,14 +39,14 @@ import { useScrollToTop } from "../../navigation/utils";
 
 export { default as PortfolioTabIcon } from "./TabIcon";
 
-const AnimatedSectionList = createNativeWrapper(
-  Animated.createAnimatedComponent(SectionList),
+const AnimatedFlatList = createNativeWrapper(
+  Animated.createAnimatedComponent(FlatList),
   {
     disallowInterruption: true,
     shouldCancelWhenOutside: false,
   },
 );
-const List = globalSyncRefreshControl(FlatList);
+const SectionListWithRefreshControl = globalSyncRefreshControl(SectionList);
 
 type Props = {
   navigation: any,
@@ -149,14 +149,14 @@ export default function PortfolioScreen({ navigation }: Props) {
 
       <TrackScreen category="Portfolio" accountsLength={accounts.length} />
       <OngoingScams />
-      <List
+      <AnimatedFlatList
         ref={ref}
         data={[
           ...(accounts.length > 0 && !accounts.every(isAccountEmpty)
             ? [<Carousel />]
             : []),
           ListHeaderComponent(),
-          <AnimatedSectionList
+          <SectionListWithRefreshControl
             sections={sections}
             style={styles.list}
             contentContainerStyle={styles.contentContainer}
@@ -165,10 +165,6 @@ export default function PortfolioScreen({ navigation }: Props) {
             renderSectionHeader={renderSectionHeader}
             onEndReached={onEndReached}
             stickySectionHeadersEnabled={false}
-            showsVerticalScrollIndicator={false}
-            onScroll={Animated.event([
-              { nativeEvent: { contentOffset: { y: scrollY } } },
-            ])}
             ListFooterComponent={
               !completed ? (
                 <LoadingFooter />
@@ -184,6 +180,10 @@ export default function PortfolioScreen({ navigation }: Props) {
         style={styles.inner}
         renderItem={({ item }) => item}
         keyExtractor={(item, index) => String(index)}
+        showsVerticalScrollIndicator={false}
+        onScroll={Animated.event([
+          { nativeEvent: { contentOffset: { y: scrollY } } },
+        ])}
       />
       <MigrateAccountsBanner />
     </SafeAreaView>

--- a/src/screens/Portfolio/index.js
+++ b/src/screens/Portfolio/index.js
@@ -148,10 +148,11 @@ export default function PortfolioScreen({ navigation }: Props) {
       <RequireTerms />
 
       <TrackScreen category="Portfolio" accountsLength={accounts.length} />
-      <OngoingScams />
+
       <AnimatedFlatList
         ref={ref}
         data={[
+          <OngoingScams />,
           ...(accounts.length > 0 && !accounts.every(isAccountEmpty)
             ? [<Carousel />]
             : []),


### PR DESCRIPTION
The carousel brought yet another regression, we lost the sticky header. But fear not, I stumbled upon this by pure chance, and brought it back. If you were wondering where the sticky header was, it's here. It's back.

![image](https://user-images.githubusercontent.com/4631227/98161947-ddf10580-1ee0-11eb-8db8-261a76329d31.png)

### Type

Bug Fix

### Context

Slack messages

### Parts of the app affected / Test plan

- Launch the app
- Scroll down a bit
- It is expected that a sticky header with your total balance should be visible
