### PR TITLE
Move resources to dedicated screen for small screen comp

### DIFF
--- a/src/components/BottomModalChoice.js
+++ b/src/components/BottomModalChoice.js
@@ -17,7 +17,7 @@ const hitSlop = {
 };
 
 export default class BottomModalChoice extends PureComponent<{
-  onPress: ?() => void,
+  onPress: ?() => any,
   Icon: React$ComponentType<*>,
   title: string,
   description?: string,

--- a/src/components/RootNavigator/SettingsNavigator.js
+++ b/src/components/RootNavigator/SettingsNavigator.js
@@ -15,6 +15,7 @@ import DebugPlayground from "../../screens/DebugPlayground";
 import Settings from "../../screens/Settings";
 import AccountsSettings from "../../screens/Settings/Accounts";
 import AboutSettings from "../../screens/Settings/About";
+import Resources from "../../screens/Settings/Resources";
 import GeneralSettings from "../../screens/Settings/General";
 import CountervalueSettings from "../../screens/Settings/General/CountervalueSettings";
 import HelpSettings from "../../screens/Settings/Help";
@@ -80,6 +81,11 @@ export default function SettingsNavigator() {
         options={{
           title: t("settings.help.header"),
         }}
+      />
+      <Stack.Screen
+        name={ScreenName.Resources}
+        component={Resources}
+        options={{ title: t("settings.resources") }}
       />
       <Stack.Screen
         name={NavigatorName.CryptoAssetsSettings}

--- a/src/const/navigation.js
+++ b/src/const/navigation.js
@@ -104,6 +104,7 @@ export const ScreenName = {
   ReceiveConnectDevice: "ReceiveConnectDevice",
   ReceiveSelectAccount: "ReceiveSelectAccount",
   RepairDevice: "RepairDevice",
+  Resources: "Resources",
   RippleEditFee: "RippleEditFee",
   RippleEditTag: "RippleEditTag",
   ScanAccounts: "ScanAccounts",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1115,6 +1115,7 @@
   },
   "settings": {
     "header": "Settings",
+    "resources": "Ledger Resources",
     "display": {
       "title": "General",
       "desc": "Configure general Ledger Live settings.",

--- a/src/screens/Settings/HelpButton.js
+++ b/src/screens/Settings/HelpButton.js
@@ -1,102 +1,20 @@
-import React, { useState } from "react";
-import { TouchableOpacity, Linking } from "react-native";
-import { useTranslation } from "react-i18next";
-import Icon from "react-native-vector-icons/dist/Feather";
+import React from "react";
+import { TouchableOpacity } from "react-native";
+import { useNavigation } from "@react-navigation/native";
 import IconQuestion from "../../icons/Question";
 import colors from "../../colors";
-import type { Props as ModalProps } from "../../components/BottomModal";
-import BottomModal from "../../components/BottomModal";
-import BottomModalChoice from "../../components/BottomModalChoice";
-import IconHelp from "../../icons/Help";
-import IconDevice2 from "../../icons/Device2";
-import IconAcademy from "../../icons/Academy";
-import IconFacebook from "../../icons/Facebook";
-import IconTwitter from "../../icons/Twitter";
-import IconGithub from "../../icons/Github";
-
-function CreateModal({ isOpened, onClose }: ModalProps) {
-  const { t } = useTranslation();
-
-  return (
-    <BottomModal id="HelpModal" isOpened={isOpened} onClose={onClose}>
-      <BottomModalChoice
-        event="GettingStarted"
-        title={t("help.gettingStarted.title")}
-        description={t("help.gettingStarted.desc")}
-        onPress={() =>
-          Linking.openURL(
-            "https://www.ledger.com/academy/?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
-          )
-        }
-        Icon={IconDevice2}
-      />
-      <BottomModalChoice
-        event="HelpHelpCenter"
-        title={t("help.helpCenter.title")}
-        description={t("help.helpCenter.desc")}
-        onPress={() =>
-          Linking.openURL(
-            "https://www.ledger.com/start?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
-          )
-        }
-        Icon={IconHelp}
-      />
-      <BottomModalChoice
-        event="HelpLedgerAcademy"
-        title={t("help.ledgerAcademy.title")}
-        description={t("help.ledgerAcademy.desc")}
-        onPress={() =>
-          Linking.openURL(
-            "https://support.ledger.com/hc/en-us?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
-          )
-        }
-        Icon={IconAcademy}
-      />
-      <BottomModalChoice
-        event="HelpFacebook"
-        title={t("help.facebook.title")}
-        description={t("help.facebook.desc")}
-        onPress={() => Linking.openURL("https://facebook.com/Ledger")}
-        Icon={IconFacebook}
-      />
-      <BottomModalChoice
-        event="HelpTwitter"
-        title={t("help.twitter.title")}
-        description={t("help.twitter.desc")}
-        onPress={() => Linking.openURL("https://twitter.com/Ledger")}
-        Icon={IconTwitter}
-      />
-      <BottomModalChoice
-        event="HelpGithub"
-        title={t("help.github.title")}
-        description={t("help.github.desc")}
-        onPress={() => Linking.openURL("https://github.com/LedgerHQ")}
-        Icon={IconGithub}
-      />
-      <BottomModalChoice
-        event="HelpLedgerStatus"
-        title={t("help.status.title")}
-        description={t("help.status.desc")}
-        onPress={() => Linking.openURL("https://status.ledger.com")}
-        Icon={({ size, color }) => (
-          <Icon name="activity" color={color} size={size} />
-        )}
-      />
-    </BottomModal>
-  );
-}
+import { ScreenName } from "../../const";
 
 const HelpButton = () => {
-  const [isOpen, setOpen] = useState(false);
+  const { navigate } = useNavigation();
   return (
     <>
       <TouchableOpacity
         style={{ marginRight: 16 }}
-        onPress={() => setOpen(true)}
+        onPress={() => navigate(ScreenName.Resources)}
       >
         <IconQuestion size={18} color={colors.grey} />
       </TouchableOpacity>
-      <CreateModal isOpened={isOpen} onClose={() => setOpen(false)} />
     </>
   );
 };

--- a/src/screens/Settings/Resources.js
+++ b/src/screens/Settings/Resources.js
@@ -1,0 +1,91 @@
+/* @flow */
+import React from "react";
+import { StyleSheet, Linking } from "react-native";
+import { useTranslation } from "react-i18next";
+import Icon from "react-native-vector-icons/dist/Feather";
+import NavigationScrollView from "../../components/NavigationScrollView";
+import BottomModalChoice from "../../components/BottomModalChoice";
+import IconHelp from "../../icons/Help";
+import IconDevice2 from "../../icons/Device2";
+import IconAcademy from "../../icons/Academy";
+import IconFacebook from "../../icons/Facebook";
+import IconTwitter from "../../icons/Twitter";
+import IconGithub from "../../icons/Github";
+
+const Resources = () => {
+  const { t } = useTranslation();
+
+  return (
+    <NavigationScrollView contentContainerStyle={styles.root}>
+      <BottomModalChoice
+        event="GettingStarted"
+        title={t("help.gettingStarted.title")}
+        description={t("help.gettingStarted.desc")}
+        onPress={() =>
+          Linking.openURL(
+            "https://www.ledger.com/academy/?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
+          )
+        }
+        Icon={IconDevice2}
+      />
+      <BottomModalChoice
+        event="HelpHelpCenter"
+        title={t("help.helpCenter.title")}
+        description={t("help.helpCenter.desc")}
+        onPress={() =>
+          Linking.openURL(
+            "https://www.ledger.com/start?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
+          )
+        }
+        Icon={IconHelp}
+      />
+      <BottomModalChoice
+        event="HelpLedgerAcademy"
+        title={t("help.ledgerAcademy.title")}
+        description={t("help.ledgerAcademy.desc")}
+        onPress={() =>
+          Linking.openURL(
+            "https://support.ledger.com/hc/en-us?utm_source=ledger_live&utm_medium=self_referral&utm_content=help_mobile",
+          )
+        }
+        Icon={IconAcademy}
+      />
+      <BottomModalChoice
+        event="HelpFacebook"
+        title={t("help.facebook.title")}
+        description={t("help.facebook.desc")}
+        onPress={() => Linking.openURL("https://facebook.com/Ledger")}
+        Icon={IconFacebook}
+      />
+      <BottomModalChoice
+        event="HelpTwitter"
+        title={t("help.twitter.title")}
+        description={t("help.twitter.desc")}
+        onPress={() => Linking.openURL("https://twitter.com/Ledger")}
+        Icon={IconTwitter}
+      />
+      <BottomModalChoice
+        event="HelpGithub"
+        title={t("help.github.title")}
+        description={t("help.github.desc")}
+        onPress={() => Linking.openURL("https://github.com/LedgerHQ")}
+        Icon={IconGithub}
+      />
+      <BottomModalChoice
+        event="HelpLedgerStatus"
+        title={t("help.status.title")}
+        description={t("help.status.desc")}
+        onPress={() => Linking.openURL("https://status.ledger.com")}
+        Icon={({ size, color }) => (
+          <Icon name="activity" color={color} size={size} />
+        )}
+      />
+    </NavigationScrollView>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: { paddingTop: 16, backgroundColor: "#fff" },
+});
+
+export default Resources;


### PR DESCRIPTION
Due to the bug found by @nabil-brn where a user could be locked in the help button bottom modal if the display was too small, we moved the content of that modal to a dedicated screen. Title to be checked with product cc @dasilvarosa in case the one we came up with is not good enough

![image](https://user-images.githubusercontent.com/4631227/99250207-984f0980-280b-11eb-8a1f-480f54a79205.png)

### Type

UI Polish/Bug fix

### Context

Slack https://ledger.slack.com/archives/GBX53P53Q/p1605519371031000

### Parts of the app affected / Test plan

Make sure the screen works, the links link, and the back action too.