### PR TITLE
remove BCH warnings

### DIFF
--- a/src/components/CurrencyDownStatusAlert.js
+++ b/src/components/CurrencyDownStatusAlert.js
@@ -1,24 +1,14 @@
 // @flow
-import React from "react";
-import { createCustomErrorClass } from "@ledgerhq/errors";
 import type {
   TokenCurrency,
   CryptoCurrency,
 } from "@ledgerhq/live-common/lib/types";
-import WarningBanner from "./WarningBanner";
 
 type Props = {
   currencies: Array<CryptoCurrency | TokenCurrency>,
 };
 
-const BitcoinCashHardforkOct2020Warning = createCustomErrorClass(
-  "BitcoinCashHardforkOct2020Warning",
-);
-
-const CurrencyDownStatusAlert = ({ currencies }: Props) => {
-  if (currencies.some(c => c.id === "bitcoin_cash")) {
-    return <WarningBanner error={new BitcoinCashHardforkOct2020Warning()} />;
-  }
+const CurrencyDownStatusAlert = (_: Props) => {
   return null;
 };
 

--- a/src/config/urls.js
+++ b/src/config/urls.js
@@ -19,8 +19,6 @@ export const urls = {
     "https://support.ledger.com/hc/en-us/articles/115005197845-Manage-ERC20-tokens",
   errors: {
     PairingFailed: "https://support.ledger.com/hc/en-us/articles/360025864773",
-    BitcoinCashHardforkOct2020Warning:
-      "https://www.ledger.com/bitcoin-cash-fork-15-november-2020-what-it-means-for-you",
   },
   multipleAddresses:
     "https://support.ledger.com/hc/en-us/articles/360033802154",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -91,10 +91,6 @@
       "title": "Oops, Bluetooth disabled",
       "description": "Please enable Bluetooth in your phone Settings. ({{state}} state)"
     },
-    "BitcoinCashHardforkOct2020Warning": {
-      "title": "",
-      "description": "Bitcoin Cash is currently undergoing a hard fork without replay protection. We will temporarily interrupt the Bitcoin Cash service until the network has stabilized."
-    },
     "BtcUnmatchedApp": {
       "title": "That's the wrong app",
       "description": "Open the ‘{{managerAppName}}’ app on your device"


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

rollback temporary banner measure

### Context

upon internal request, we will resume BCH services and no longer need the banner.

### Parts of the app affected / Test plan

not sure if testable but if you have BCH no warning will appear.