### PR TITLE
AnalyticsConsole, debugging tool for tracked events

### DIFF
--- a/src/analytics/HookAnalytics.js
+++ b/src/analytics/HookAnalytics.js
@@ -1,35 +1,21 @@
-import { Component } from "react";
-import { connect } from "react-redux";
+import { useEffect, useState, useCallback } from "react";
+import { useSelector } from "react-redux";
 import { hasCompletedOnboardingSelector } from "../reducers/settings";
 import { start } from "./segment";
 
-let isAnalyticsStarted = false;
+const HookAnalytics = ({ store }: { store: * }) => {
+  const hasCompletedOnboarding = useSelector(hasCompletedOnboardingSelector);
+  const [analyticsStarted, setAnalyticsStarted] = useState(false);
 
-class HookAnalytics extends Component<{
-  store: *,
-}> {
-  componentDidMount() {
-    this.sync();
-  }
+  const sync = useCallback(() => {
+    if (analyticsStarted || !hasCompletedOnboarding) return;
+    setAnalyticsStarted(true);
+    start(store);
+  }, [analyticsStarted, hasCompletedOnboarding, store]);
 
-  componentDidUpdate() {
-    this.sync();
-  }
+  useEffect(sync, [hasCompletedOnboarding, sync]);
 
-  sync = () => {
-    if (isAnalyticsStarted) return;
-    const { store } = this.props;
-    const state = store.getState();
-    const hasCompletedOnboarding = hasCompletedOnboardingSelector(state);
-    if (hasCompletedOnboarding) {
-      isAnalyticsStarted = true;
-      start(store);
-    }
-  };
+  return null;
+};
 
-  render() {
-    return null;
-  }
-}
-
-export default connect()(HookAnalytics);
+export default HookAnalytics;

--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -8,6 +8,7 @@ import { Platform } from "react-native";
 import analytics from "@segment/analytics-react-native";
 import VersionNumber from "react-native-version-number";
 import Locale from "react-native-locale";
+import { ReplaySubject } from "rxjs";
 import {
   getAndroidArchitecture,
   getAndroidVersionCode,
@@ -81,6 +82,11 @@ export const stop = () => {
   storeInstance = null;
 };
 
+export const trackSubject = new ReplaySubject<{
+  event: string,
+  properties: ?Object,
+}>(10);
+
 export const track = (
   event: string,
   properties: ?Object,
@@ -100,6 +106,8 @@ export const track = (
     return;
   }
   if (ANALYTICS_LOGS) console.log("analytics:track", event, properties);
+  trackSubject.next({ event, properties });
+
   if (!token) return;
   analytics.track(
     event,
@@ -128,6 +136,8 @@ export const screen = (
   }
   if (ANALYTICS_LOGS)
     console.log("analytics:screen", category, name, properties);
+  trackSubject.next({ event: title, properties });
+
   if (!token) return;
   analytics.track(
     title,

--- a/src/components/AnalyticsConsole.js
+++ b/src/components/AnalyticsConsole.js
@@ -1,0 +1,53 @@
+// @flow
+import React, { useReducer, useEffect } from "react";
+import { StyleSheet, View, Text } from "react-native";
+import { map } from "rxjs/operators";
+import useEnv from "@ledgerhq/live-common/lib/hooks/useEnv";
+import { trackSubject } from "../analytics/segment";
+
+let id = 0;
+
+const AnalyticsConsole = () => {
+  const [items, addItem] = useReducer(
+    (items, item) => (items.length > 10 ? items.slice(1) : items).concat(item),
+    [],
+  );
+
+  useEffect(() => {
+    trackSubject.pipe(map(item => ({ ...item, id: ++id }))).subscribe(addItem);
+  }, []);
+  const render = useEnv("ANALYTICS_CONSOLE");
+
+  return render ? (
+    <View style={styles.root} pointerEvents="none">
+      {items.map(item => (
+        <View style={styles.item} key={item.id}>
+          <Text style={styles.eventName}>{item.event}</Text>
+          <Text>
+            {item.properties ? JSON.stringify(item.properties) : null}
+          </Text>
+        </View>
+      ))}
+    </View>
+  ) : null;
+};
+
+const styles = StyleSheet.create({
+  root: {
+    zIndex: 999,
+    backgroundColor: "#fffc",
+    flex: 1,
+    position: "absolute",
+    opacity: 0.4,
+    top: 0,
+    left: 0,
+  },
+  item: {
+    padding: 2,
+  },
+  eventName: {
+    fontWeight: "bold",
+  },
+});
+
+export default AnalyticsConsole;

--- a/src/components/RootNavigator/MainNavigator.js
+++ b/src/components/RootNavigator/MainNavigator.js
@@ -14,11 +14,22 @@ import SettingsIcon from "../../icons/Settings";
 
 import Tab from "./CustomBlockRouterNavigator";
 
-export default function MainNavigator() {
+type RouteParams = {
+  hideTabNavigation?: boolean,
+};
+export default function MainNavigator({
+  route: { params },
+}: {
+  route: { params: RouteParams },
+}) {
+  const { hideTabNavigation } = params || {};
   return (
     <Tab.Navigator
       tabBarOptions={{
-        style: styles.bottomTabBar,
+        style: [
+          styles.bottomTabBar,
+          hideTabNavigation ? { display: "none" } : {},
+        ],
         showLabel: false,
         activeTintColor: colors.live,
       }}

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ import AuthPass from "./context/AuthPass";
 import LedgerStoreProvider from "./context/LedgerStore";
 import LoadingApp from "./components/LoadingApp";
 import StyledStatusBar from "./components/StyledStatusBar";
+import AnalyticsConsole from "./components/AnalyticsConsole";
 import { BridgeSyncProvider } from "./bridge/BridgeSyncContext";
 import useDBSaveEffect from "./components/DBSave";
 import DebugRejectSwitch from "./components/DebugRejectSwitch";
@@ -140,6 +141,8 @@ function App({ importDataString }: AppProps) {
       <RootNavigator importDataString={importDataString} />
 
       <DebugRejectSwitch />
+
+      <AnalyticsConsole />
     </View>
   );
 }

--- a/src/screens/Onboarding/steps/welcome.js
+++ b/src/screens/Onboarding/steps/welcome.js
@@ -33,7 +33,7 @@ type Props = OnboardingStepProps & {
 class OnboardingStepWelcome extends Component<Props> {
   buy = () => Linking.openURL(urls.buyNanoX);
 
-  Footer = () => <PoweredByLedger />;
+  Footer = () => <PoweredByLedger hideTabNavigation />;
 
   render() {
     const { onWelcomed } = this.props;

--- a/src/screens/Settings/Debug/AnalyticsConsoleRow.js
+++ b/src/screens/Settings/Debug/AnalyticsConsoleRow.js
@@ -1,0 +1,39 @@
+/* @flow */
+import React, { useCallback } from "react";
+import { Switch } from "react-native";
+import useEnv from "@ledgerhq/live-common/lib/hooks/useEnv";
+import { setEnv } from "@ledgerhq/live-common/lib/env";
+import SettingsRow from "../../../components/SettingsRow";
+import Track from "../../../analytics/Track";
+
+const AnalyticsConsoleRow = () => {
+  const analyticsConsoleVisibility = useEnv("ANALYTICS_CONSOLE");
+  const toggleAnalyticsConsole = useCallback(() => {
+    setEnv("ANALYTICS_CONSOLE", !analyticsConsoleVisibility);
+  }, [analyticsConsoleVisibility]);
+
+  return (
+    <SettingsRow
+      event="AnalyticsConsoleRow"
+      title="View analytics overlay"
+      desc="Toggle analytics console, making tracked events visible as an overlay"
+      onPress={null}
+      alignedTop
+    >
+      <Track
+        event={
+          analyticsConsoleVisibility
+            ? "EnableAnalyticsConsole"
+            : "DisableAnalyticsConsole"
+        }
+        onUpdate
+      />
+      <Switch
+        value={analyticsConsoleVisibility}
+        onValueChange={toggleAnalyticsConsole}
+      />
+    </SettingsRow>
+  );
+};
+
+export default AnalyticsConsoleRow;

--- a/src/screens/Settings/Debug/index.js
+++ b/src/screens/Settings/Debug/index.js
@@ -17,6 +17,7 @@ import OpenDebugCrash from "./OpenDebugCrash";
 import OpenDebugHttpTransport from "./OpenDebugHttpTransport";
 import OpenDebugIcons from "./OpenDebugIcons";
 import ReadOnlyModeRow from "../General/ReadOnlyModeRow";
+import AnalyticsConsoleRow from "./AnalyticsConsoleRow";
 import OpenDebugStore from "./OpenDebugStore";
 import OpenDebugPlayground from "./OpenDebugPlayground";
 import OpenLottie from "./OpenDebugLottie";
@@ -44,6 +45,7 @@ export function DebugMocks() {
       <OpenLottie />
       <OpenDebugPlayground />
       <ReadOnlyModeRow />
+      <AnalyticsConsoleRow />
       <SkipLock />
     </NavigationScrollView>
   );

--- a/src/screens/Settings/PoweredByLedger.js
+++ b/src/screens/Settings/PoweredByLedger.js
@@ -1,23 +1,67 @@
 /* @flow */
-import React from "react";
+import React, { useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { View, StyleSheet } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { View, StyleSheet, TouchableWithoutFeedback } from "react-native";
 import LText from "../../components/LText";
 import colors from "../../colors";
 import LedgerLogoRec from "../../icons/LedgerLogoRec";
+import timer from "../../timer";
+import { NavigatorName, ScreenName } from "../../const";
 
-export default function PoweredByLedger() {
+export default function PoweredByLedger({
+  onTriggerDebug,
+  hideTabNavigation,
+}: {
+  onTriggerDebug?: () => any,
+  hideTabNavigation?: boolean,
+}) {
   const { t } = useTranslation();
+  const navigation = useNavigation();
+  const count = useRef(0);
+  const onTimeout = (): void => {
+    timer.timeout(() => {
+      count.current = 0;
+    }, 1000);
+  };
+
+  const debugTimeout = useRef(onTimeout);
+
+  const openDebugMenu = useCallback(() => {
+    navigation.navigate(NavigatorName.Base, {
+      screen: NavigatorName.Main,
+      params: {
+        hideTabNavigation,
+        screen: NavigatorName.Settings,
+        params: {
+          screen: ScreenName.DebugSettings,
+        },
+      },
+    });
+  }, [hideTabNavigation, navigation]);
+
+  const onDebugHiddenPress = useCallback((): void => {
+    if (debugTimeout) debugTimeout.current();
+    count.current++;
+    if (count.current > 5) {
+      count.current = 0;
+      onTriggerDebug ? onTriggerDebug() : openDebugMenu();
+    } else {
+      onTimeout();
+    }
+  }, [onTriggerDebug, openDebugMenu]);
 
   return (
-    <View style={styles.container}>
-      <LText secondary semiBold style={styles.textStyle}>
-        {t("common.poweredBy")}
-      </LText>
-      <View style={styles.iconStyle}>
-        <LedgerLogoRec height={17} width={68} color={colors.grey} />
+    <TouchableWithoutFeedback onPress={onDebugHiddenPress}>
+      <View style={styles.container}>
+        <LText secondary semiBold style={styles.textStyle}>
+          {t("common.poweredBy")}
+        </LText>
+        <View style={styles.iconStyle}>
+          <LedgerLogoRec height={17} width={68} color={colors.grey} />
+        </View>
       </View>
-    </View>
+    </TouchableWithoutFeedback>
   );
 }
 

--- a/src/screens/Settings/index.js
+++ b/src/screens/Settings/index.js
@@ -1,8 +1,8 @@
 /* @flow */
-import React, { useRef, useState } from "react";
+import React, { useCallback, useState } from "react";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
-import { View, StyleSheet, TouchableWithoutFeedback } from "react-native";
+import { View, StyleSheet } from "react-native";
 import Icon from "react-native-vector-icons/dist/Feather";
 import Config from "react-native-config";
 import { NavigatorName, ScreenName } from "../../const";
@@ -20,7 +20,6 @@ import Help from "../../icons/Help";
 import Display from "../../icons/Display";
 import colors from "../../colors";
 import TrackScreen from "../../analytics/TrackScreen";
-import timer from "../../timer";
 import NavigationScrollView from "../../components/NavigationScrollView";
 
 type Props = {
@@ -35,25 +34,10 @@ export default function Settings({ navigation }: Props) {
   const [debugVisible, setDebugVisible] = useState(
     Config.FORCE_DEBUG_VISIBLE || false,
   );
-  const count = useRef(0);
-  const debugTimeout = useRef(onTimeout);
 
-  function onTimeout(): void {
-    timer.timeout(() => {
-      count.current = 0;
-    }, 1000);
-  }
-
-  function onDebugHiddenPress(): void {
-    if (debugTimeout) debugTimeout.current();
-    count.current++;
-    if (count.current > 6) {
-      count.current = 0;
-      setDebugVisible(!debugVisible);
-    } else {
-      onTimeout();
-    }
-  }
+  const onSetDebugVisible = useCallback(() => {
+    setDebugVisible(true);
+  }, []);
 
   return (
     <NavigationScrollView>
@@ -109,11 +93,7 @@ export default function Settings({ navigation }: Props) {
             onClick={() => navigation.navigate(ScreenName.DebugSettings)}
           />
         ) : null}
-        <TouchableWithoutFeedback onPress={onDebugHiddenPress}>
-          <View>
-            <PoweredByLedger />
-          </View>
-        </TouchableWithoutFeedback>
+        <PoweredByLedger onTriggerDebug={onSetDebugVisible} />
       </View>
     </NavigationScrollView>
   );


### PR DESCRIPTION
> Since this includes the same bumps and updates from https://github.com/LedgerHQ/ledger-live-mobile/pull/1468 I'm HODL'ing it until we can rebase it to not include all these changes.

This pr backports the analytics console concept from LLD to LLM, allowing us to view as an overlay on the screen the events that are getting tracked via analytics. This is specially useful for product to find the name of an event to polish metrics and to identify missing or incorrect events.
![Group](https://user-images.githubusercontent.com/4631227/99576722-a43cf600-29da-11eb-87ae-49e198971dc1.png)

It has already helped identify the fact that **we were missing all the events from the first launch of the app**. The component in charge of this was not getting the update of the `hasCompletedOnboarding` flag having changed and therefore we remained with uninitialised analytics for the duration of the first launch. Subsequent launched would work as expected, but we lost the metrics of all the first launches. This should be addressed here too.

### Type

Feature

### Context

n/a

### Parts of the app affected / Test plan
- During onboarding, clicking on the Powered by ledger footer multiple times should take you to the debug screen.
- Enable the analytics console in the mock & test screen
- Complete the onboarding and take a look at events tracked.

Note: This behaves strangely with live reload so for best reliability don't edit the code while you are debugging the events. Relaunch the app completely if possible.