### PR TITLE
LL-3877 add buy/receive info drawer on lending dashboard

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1502,6 +1502,16 @@
           "cta": "Lend now"
         }
       },
+      "noTokenAccount": {
+        "info": {
+          "title": "You don’t have {{ name }} account.",
+          "description": "In order to deposit funds and lend crypto you need a {{ name }} account. Please Receive funds on your Ethereum address."
+        },
+        "buttons": {
+          "receive": "Receive {{ name }}",
+          "buy": "Buy {{ name }}"
+        }
+      },
       "enable": {
         "info": {
           "title": "This account is not approved",

--- a/src/screens/Lending/Dashboard/InfoModalBottom.js
+++ b/src/screens/Lending/Dashboard/InfoModalBottom.js
@@ -11,7 +11,7 @@ import TrackScreen from "../../../analytics/TrackScreen";
 
 type button = {
   title: string,
-  onPress: function,
+  onPress: Function,
 };
 
 type Props = {

--- a/src/screens/Lending/Dashboard/InfoModalBottom.js
+++ b/src/screens/Lending/Dashboard/InfoModalBottom.js
@@ -7,6 +7,7 @@ import colors, { rgba } from "../../../colors";
 import BottomModal from "../../../components/BottomModal";
 import LText from "../../../components/LText";
 import Button from "../../../components/Button";
+import TrackScreen from "../../../analytics/TrackScreen";
 
 type button = {
   title: string,
@@ -50,6 +51,9 @@ class ConfirmationModal extends PureComponent<Props> {
         style={styles.confirmationModal}
         {...rest}
       >
+        {isOpened ? (
+          <TrackScreen category="LendingNoTokenAccountInfoModal" />
+        ) : null}
         {Icon && (
           <View style={styles.icon}>
             <Icon size={24} />

--- a/src/screens/Lending/Dashboard/InfoModalBottom.js
+++ b/src/screens/Lending/Dashboard/InfoModalBottom.js
@@ -1,0 +1,127 @@
+// @flow
+
+import React, { PureComponent } from "react";
+import { View, StyleSheet } from "react-native";
+
+import colors, { rgba } from "../../../colors";
+import BottomModal from "../../../components/BottomModal";
+import LText from "../../../components/LText";
+import Button from "../../../components/Button";
+
+type button = {
+  title: string,
+  onPress: function,
+};
+
+type Props = {
+  isOpened: boolean,
+  onClose: () => void,
+  onConfirm: () => *,
+  onModalHide?: () => *,
+  title?: React$Node,
+  description?: React$Node,
+  Icon?: React$ComponentType<*>,
+  buttons: button[],
+  alert: boolean,
+};
+
+class ConfirmationModal extends PureComponent<Props> {
+  static defaultProps = {
+    alert: false,
+  };
+
+  render() {
+    const {
+      isOpened,
+      onClose,
+      title,
+      description,
+      onConfirm,
+      Icon,
+      alert,
+      buttons,
+      ...rest
+    } = this.props;
+    return (
+      <BottomModal
+        id="ConfirmationModal"
+        isOpened={isOpened}
+        onClose={onClose}
+        style={styles.confirmationModal}
+        {...rest}
+      >
+        {Icon && (
+          <View style={styles.icon}>
+            <Icon size={24} />
+          </View>
+        )}
+        {title && (
+          <LText secondary semiBold style={styles.title}>
+            {title}
+          </LText>
+        )}
+        {description && <LText style={styles.description}>{description}</LText>}
+        <View style={styles.confirmationFooter}>
+          <Button
+            containerStyle={styles.confirmationButton}
+            type="primary"
+            title={buttons[0].title}
+            onPress={buttons[0].onPress}
+          />
+
+          {buttons[1] ? (
+            <Button
+              containerStyle={[
+                styles.confirmationButton,
+                styles.confirmationLastButton,
+              ]}
+              type="secondary"
+              title={buttons[1].title}
+              onPress={buttons[1].onPress}
+            />
+          ) : null}
+        </View>
+      </BottomModal>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  confirmationModal: {
+    paddingVertical: 24,
+    paddingTop: 24,
+    paddingHorizontal: 16,
+  },
+  title: {
+    textAlign: "center",
+    fontSize: 18,
+    color: colors.darkBlue,
+  },
+  description: {
+    marginVertical: 32,
+    textAlign: "center",
+    fontSize: 14,
+    color: colors.smoke,
+  },
+  confirmationFooter: {
+    justifyContent: "flex-end",
+  },
+  confirmationButton: {
+    flexGrow: 1,
+  },
+  confirmationLastButton: {
+    marginTop: 16,
+  },
+  icon: {
+    alignSelf: "center",
+    backgroundColor: rgba(colors.yellow, 0.08),
+    width: 56,
+    borderRadius: 28,
+    height: 56,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 18,
+  },
+});
+
+export default ConfirmationModal;

--- a/src/screens/Lending/Dashboard/Rates.js
+++ b/src/screens/Lending/Dashboard/Rates.js
@@ -91,7 +91,10 @@ const Rates = ({
     token => {
       navigation.navigate(NavigatorName.ExchangeBuyFlow, {
         screen: ScreenName.ExchangeSelectAccount,
-        params: { currency: token },
+        params: {
+          currency: token,
+          mode: "buy",
+        },
       });
     },
     [navigation],

--- a/src/screens/Lending/Dashboard/Rates.js
+++ b/src/screens/Lending/Dashboard/Rates.js
@@ -1,8 +1,9 @@
 // @flow
-import React, { useMemo, useCallback } from "react";
+import React, { useMemo, useCallback, useState } from "react";
 import { View, StyleSheet, FlatList } from "react-native";
 import { BigNumber } from "bignumber.js";
 import { Trans } from "react-i18next";
+import _ from "lodash";
 import type { AccountLikeArray } from "@ledgerhq/live-common/lib/types";
 import type { CurrentRate } from "@ledgerhq/live-common/lib/families/ethereum/modules/compound";
 // import { formatShort } from "@ledgerhq/live-common/lib/currencies";
@@ -13,24 +14,20 @@ import CurrencyIcon from "../../../components/CurrencyIcon";
 import Touchable from "../../../components/Touchable";
 import colors from "../../../colors";
 import { NavigatorName, ScreenName } from "../../../const";
+import InfoModalBottom from "./InfoModalBottom";
+import { getSupportedCurrencies } from "../../Exchange/coinifyConfig";
 
 const Row = ({
   data,
   // $FlowFixMe
   accounts,
+  onPress,
 }: {
   data: CurrentRate,
   accounts: AccountLikeArray,
+  onPress: function,
 }) => {
   const { token, supplyAPY } = data;
-  const navigation = useNavigation();
-
-  const navigateToEnableFlow = useCallback(() => {
-    navigation.navigate(NavigatorName.LendingEnableFlow, {
-      screen: ScreenName.LendingEnableSelectAccount,
-      params: { currency: token },
-    });
-  }, [navigation, token]);
 
   const totalBalance = useMemo(() => {
     return accounts.reduce((total, account) => {
@@ -44,7 +41,7 @@ const Row = ({
   return (
     <Touchable
       style={styles.row}
-      onPress={navigateToEnableFlow}
+      onPress={() => onPress(token)}
       event="Page Lend deposit"
       eventProperties={{ currency: token.id }}
     >
@@ -78,12 +75,111 @@ const Rates = ({
   rates: CurrentRate[],
   accounts: AccountLikeArray,
 }) => {
+  const navigation = useNavigation();
+  const [modalOpen, setModalOpen] = useState();
+
+  const navigateToEnableFlow = useCallback(
+    token => {
+      navigation.navigate(NavigatorName.LendingEnableFlow, {
+        screen: ScreenName.LendingEnableSelectAccount,
+        params: { currency: token },
+      });
+    },
+    [navigation],
+  );
+  const navigateToBuyFlow = useCallback(
+    token => {
+      navigation.navigate(NavigatorName.ExchangeBuyFlow, {
+        screen: ScreenName.ExchangeSelectAccount,
+        params: { currency: token },
+      });
+    },
+    [navigation],
+  );
+
+  const CheckIfCanNavigate = useCallback(
+    token => {
+      if (
+        _.find(
+          accounts,
+          account => account.token && account.token.id === token.id,
+        )
+      ) {
+        return navigateToEnableFlow(token);
+      }
+      return setModalOpen(token);
+    },
+    [accounts, navigateToEnableFlow],
+  );
+
+  const selectedTokenCanBuy =
+    modalOpen && getSupportedCurrencies("buy").includes(modalOpen.id);
+
+  const buttons = [];
+  if (selectedTokenCanBuy) {
+    buttons.push({
+      title: (
+        <Trans
+          i18nKey="transfer.lending.noTokenAccount.buttons.buy"
+          values={{
+            name: modalOpen?.name,
+          }}
+        />
+      ),
+      onPress: () => {
+        setModalOpen();
+        navigateToBuyFlow(modalOpen);
+      },
+    });
+  }
+  buttons.push({
+    title: (
+      <Trans
+        i18nKey="transfer.lending.noTokenAccount.buttons.receive"
+        values={{
+          name: modalOpen?.name,
+        }}
+      />
+    ),
+    onPress: () => {
+      setModalOpen();
+      navigateToEnableFlow(modalOpen);
+    },
+  });
+
   return (
     <View>
       <FlatList
         data={rates}
-        renderItem={({ item }) => <Row data={item} accounts={accounts} />}
+        renderItem={({ item }) => (
+          <Row data={item} accounts={accounts} onPress={CheckIfCanNavigate} />
+        )}
         keyExtractor={item => item.ctoken.id}
+      />
+      <InfoModalBottom
+        isOpened={modalOpen}
+        onClose={() => setModalOpen()}
+        title={
+          <Trans
+            i18nKey="transfer.lending.noTokenAccount.info.title"
+            values={{
+              name: modalOpen?.name,
+            }}
+          />
+        }
+        description={
+          <Trans
+            i18nKey="transfer.lending.noTokenAccount.info.description"
+            values={{
+              name: modalOpen?.name,
+            }}
+          />
+        }
+        Icon={
+          modalOpen &&
+          (() => <CurrencyIcon radius={100} currency={modalOpen} size={54} />)
+        }
+        buttons={buttons}
       />
     </View>
   );

--- a/src/screens/Lending/Dashboard/Rates.js
+++ b/src/screens/Lending/Dashboard/Rates.js
@@ -25,7 +25,7 @@ const Row = ({
 }: {
   data: CurrentRate,
   accounts: AccountLikeArray,
-  onPress: function,
+  onPress: Function,
 }) => {
   const { token, supplyAPY } = data;
 


### PR DESCRIPTION
Add an info drawer when a token account is non existant in the lending dashboard

### Type

Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-3877

### Parts of the app affected / Test plan

You need to test with an eth account without having token accounts. and test after with one eth account which has token accounts.
