### PR TITLE
Make unavailable swap error more generic

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1323,7 +1323,7 @@
         "disclaimer": "I acknowledge that my location data will be shared with third parties for compliance purposes."
       },
       "notAvailable": {
-        "title": "Swap feature is not available in your country"
+        "title": "Service temporarily unavailable, or not available in your country"
       },
       "pendingOperation": {
         "description": "Your Swap operation has been sent to the network for confirmation. It may take up to an hour before you receive your swapped crypto assets.",


### PR DESCRIPTION
Due to the unforeseen outage by the provider side yesterday evening, and until we have a way to differentiate between the service not being available due to IP restrictions and the service being temporarily disrupted, we are making the wording for the swap feature's unavailability more generic.

![image](https://user-images.githubusercontent.com/4631227/100728929-72f3fb00-33c8-11eb-9b76-0d87cfa46436.png)
