### PR TITLE
Bring back the scroll to top on bottom tab navigation double tap

### DIFF
--- a/src/navigation/utils.js
+++ b/src/navigation/utils.js
@@ -36,6 +36,11 @@ export function useScrollToTop(
       ) {
         // this handles SectionList with Animated wrapper
         scrollSectionListToTop(ref.current.getNode());
+      } else if (
+        typeof ref.current.getNode === "function" &&
+        typeof ref.current.getNode().scrollToOffset === "function"
+      ) {
+        ref.current.getNode().scrollToOffset({ animated: true, offset: 0 });
       }
     });
 


### PR DESCRIPTION
There's a if/else block where we try to determine the type of view that we are trying to scroll to top, due to the fact that we wrapped the content of the portfolio screen inside a flat list and that is wrapped inside a wrapped component, the scroll to top wasn't contemplated. This adds support for _that_
https://github.com/juan-cortes/ledger-live-mobile/blob/1124a0a826f794cd159f324cd4602fa442165de2/src/navigation/utils.js#L24-L45

### Type

Bug Fix

### Context

Slack

### Parts of the app affected / Test plan

- Open the app
- Scroll down on the portfolio screen
- Double tap on the tab
- It is expected that the screen will scroll to top
