### PR TITLE
LL-3990 Fix location permission on Android

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.BLUETOOTH"/>
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
-    <uses-permission-sdk-23 android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission-sdk-23 android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.VIBRATE"/>

--- a/src/components/RequiresBLE/RequiresLocationOnAndroid.android.js
+++ b/src/components/RequiresBLE/RequiresLocationOnAndroid.android.js
@@ -6,7 +6,7 @@ import React, { Component } from "react";
 import { PermissionsAndroid } from "react-native";
 import LocationRequired from "../../screens/LocationRequired";
 
-const permission = PermissionsAndroid.PERMISSIONS.ACCESS_COARSE_LOCATION;
+const permission = PermissionsAndroid.PERMISSIONS.ACCESS_FINE_LOCATION;
 
 class RequiresBLE extends Component<
   {


### PR DESCRIPTION
Android 10 deprecated using `ACCESS_COARSE_LOCATION` for scanning for BLE devices, and now requires `ACCESS_FINE_LOCATION` (cf https://developer.android.com/about/versions/10/privacy/changes#location-telephony-bluetooth-wifi), this broke the location permission flow when we changed our `targetSdkVersion` to `29`.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-3990
#1476

### Parts of the app affected

Pairing on a _newly_ installed app.
Maybe affects only Android 10+, not sure.

### Test plan

- Be on Android 10 or 11
- Re-install the app (erasing data or changing the permissions in the app detail is probably not enough)
- The pairing flow should ask for location permission, and continue smoothly once allowed

I tested on my side with a Google Pixel 3 on Android 11
