### PR TITLE
Fix bug on autoSelectOnAdd manager pairing

### DIFF
--- a/src/components/DeviceItemSummary.js
+++ b/src/components/DeviceItemSummary.js
@@ -15,7 +15,6 @@ import Alert from "../icons/Alert";
 
 type Props = {
   deviceId: string,
-  name: string,
   genuine: boolean,
   onEdit: () => void,
 };

--- a/src/components/SelectDevice/index.js
+++ b/src/components/SelectDevice/index.js
@@ -96,7 +96,7 @@ export default function SelectDevice({
         return devices;
       });
     });
-    return () => subscription.unsubscribe;
+    return () => subscription.unsubscribe();
   }, [knownDevices, filter]);
 
   return (

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1944,7 +1944,7 @@
     },
     "GenuineCheck": {
       "title": "Device authentication check",
-      "accept": "Please don't turn off your Nano X. Make sure you enable <1>Ledger Manager</1>."
+      "accept": "Please don't turn off your Nano X. Make sure you allow <1>Ledger Manager</1>."
     },
     "ScanningHeader": {
       "title": "Looking for devices",
@@ -1958,7 +1958,7 @@
     "alreadyPaired": "Already paired"
   },
   "DeviceItemSummary": {
-    "genuine": "Authentication",
+    "genuine": "Your device is genuine",
     "genuineFailed": "Device authentication <1><0>failed</0></1>"
   },
   "DeviceNameRow": {

--- a/src/screens/PairDevices/Paired.js
+++ b/src/screens/PairDevices/Paired.js
@@ -6,6 +6,7 @@ import { Trans } from "react-i18next";
 import { getDeviceModel } from "@ledgerhq/devices";
 import { useSelector } from "react-redux";
 import { useNavigation } from "@react-navigation/native";
+import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 
 import { TrackScreen } from "../../analytics";
 import colors from "../../colors";
@@ -19,19 +20,18 @@ import NanoX from "../../icons/NanoX";
 import { deviceNameByDeviceIdSelectorCreator } from "../../reducers/ble";
 
 type Props = {
-  deviceId: string,
-  deviceName: string,
-  onContinue: (deviceId: string) => void,
+  device: Device,
+  onContinue: (device: Device) => void,
   genuine: boolean,
 };
 
 export default function Paired({
-  deviceId,
-  deviceName,
+  device,
   onContinue: onContinuewProps,
   genuine,
 }: Props) {
   const navigation = useNavigation();
+  const { deviceId, deviceName } = device;
   const name = useSelector(deviceNameByDeviceIdSelectorCreator(deviceId));
 
   const onEdit = useCallback(() => {
@@ -42,8 +42,8 @@ export default function Paired({
   }, [navigation, deviceId, deviceName, name]);
 
   const onContinue = useCallback(() => {
-    onContinuewProps(deviceId);
-  }, [onContinuewProps, deviceId]);
+    onContinuewProps(device);
+  }, [onContinuewProps, device]);
 
   return (
     <View style={styles.root}>

--- a/src/screens/PairDevices/index.js
+++ b/src/screens/PairDevices/index.js
@@ -9,6 +9,7 @@ import getDeviceInfo from "@ledgerhq/live-common/lib/hw/getDeviceInfo";
 import getDeviceName from "@ledgerhq/live-common/lib/hw/getDeviceName";
 import { listApps } from "@ledgerhq/live-common/lib/apps/hw";
 import { delay } from "@ledgerhq/live-common/lib/promise";
+import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import logger from "../../logger";
 import TransportBLE from "../../react-native-hw-transport-ble";
 import { GENUINE_CHECK_TIMEOUT } from "../../constants";
@@ -42,7 +43,7 @@ type RouteParams = {
   onDone?: (deviceId: string) => void,
 };
 
-type Device = {
+type BleDevice = {
   id: string,
   name: string,
 };
@@ -87,11 +88,18 @@ class PairDevices extends Component<PairDevicesProps, State> {
     this.setState({ error });
   };
 
-  onSelect = async (device: Device) => {
+  onSelect = async (bleDevice: BleDevice) => {
     const { hasCompletedOnboarding, installAppFirstTime } = this.props;
+    const device = {
+      deviceName: bleDevice.name,
+      deviceId: bleDevice.id,
+      modelId: "nanoX",
+      wired: false,
+    };
+
     this.setState({ device, status: "pairing", genuineAskedOnDevice: false });
     try {
-      const transport = await TransportBLE.open(device);
+      const transport = await TransportBLE.open(bleDevice);
       if (this.unmounted) return;
       try {
         const deviceInfo = await getDeviceInfo(transport);
@@ -133,15 +141,16 @@ class PairDevices extends Component<PairDevicesProps, State> {
         await genuineCheckPromise;
         if (this.unmounted) return;
 
-        const name = (await getDeviceName(transport)) || device.name;
+        const name =
+          (await getDeviceName(transport)) || device.deviceName || "";
         if (this.unmounted) return;
 
-        this.props.addKnownDevice({ id: device.id, name });
+        this.props.addKnownDevice({ id: device.deviceId, name });
         if (this.unmounted) return;
         this.setState({ status: "paired" });
       } finally {
         transport.close();
-        await TransportBLE.disconnect(device.id).catch(() => {});
+        await TransportBLE.disconnect(device.deviceId).catch(() => {});
         await delay(500);
       }
     } catch (error) {
@@ -154,19 +163,22 @@ class PairDevices extends Component<PairDevicesProps, State> {
   onBypassGenuine = () => {
     const { device, name } = this.state;
     if (device) {
-      this.props.addKnownDevice({ id: device.id, name: name || device.name });
+      this.props.addKnownDevice({
+        id: device.deviceId,
+        name: name || device.deviceName || "",
+      });
       this.setState({ status: "paired", error: null, skipCheck: true });
     } else {
       this.setState({ status: "scanning", error: null, device: null });
     }
   };
 
-  onDone = (deviceId: string) => {
+  onDone = (device: Device) => {
     const { navigation, route } = this.props;
     const onDone = route.params?.onDone;
     navigation.goBack();
     if (onDone) {
-      onDone(deviceId);
+      onDone(device);
     }
   };
 
@@ -214,8 +226,7 @@ class PairDevices extends Component<PairDevicesProps, State> {
       case "paired":
         return device ? (
           <Paired
-            deviceName={device.name}
-            deviceId={device.id}
+            device={device}
             genuine={!skipCheck}
             onContinue={this.onDone}
           />


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/102012099-b6dfec00-3d48-11eb-80eb-422fcf356591.png)

A recently discovered bug was preventing the `autoSelectOnAdd` functionality from working, presumably in the whole app. The pairing flow will eventually return just the device id instead of the expected `Device` and in doing so would fail any subsequent device action linked to the particular screen. This meant that the manager flow, ~the onboarding flow~, and the swap flows would fail to connect to a newly paired device. 

This isn't a dead end, since the user can close the bottom modal, and select the newly paired device. Which would then connect without issues. But it does align with many of the connectivity issues we've been reporting/experiencing lately. Basically, if you pair a new device on the current develop it will give you an error when trying to connect, until you dismiss the modal and connect again.

This pr fixes that.

In the same process, I've identified a few wording inconsistencies that were introduced in the LL-3860 task, were we had a gazillion wording changes, some of which have been identified as incorrect, at least to me.

### Type

Bug fixes

### Context

Slack

### Parts of the app affected / Test plan

First make sure you can reproduce the issue on develop so that you see what I'm talking about.
- Unpair a nano x
- Go to the manager/swap flow
- Add a new nano x
- On the pair success screen (where you have an option to rename it) click on continue
- The bottom modal will open automatically upon returning to the flow screen
- The connection will fail.

Then on this branch try the same process
- Unpair a nano x
- Go to the manager/swap flow
- Add a new nano x
- On the pair success screen (where you have an option to rename it) click on continue
- The bottom modal will open automatically upon returning to the flow screen
- The connection will work.
