### PR TITLE
pass correct remote when pushing android tags

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,7 +52,7 @@ lane :beta do |options|
   system "yarn -s --frozen-lockfile"
 
   Fastlane::LaneManager.cruise_lane('ios', 'beta', { :remote => "upstream"}, 'production')
-  Fastlane::LaneManager.cruise_lane('android', 'beta')
+  Fastlane::LaneManager.cruise_lane('android', 'beta', { :remote => "upstream"})
 
 end
 


### PR DESCRIPTION
Just a small fix to make sure the remote is `upstream` when pushing git tags in android workflow