### PR TITLE
LL-1944 POC of log view/export for LLM

### DIFF
--- a/src/components/RootNavigator/SettingsNavigator.js
+++ b/src/components/RootNavigator/SettingsNavigator.js
@@ -10,6 +10,7 @@ import DebugCrash from "../../screens/DebugCrash";
 import DebugHttpTransport from "../../screens/DebugHttpTransport";
 import DebugIcons from "../../screens/DebugIcons";
 import DebugLottie from "../../screens/DebugLottie.js";
+import DebugLogs from "../../screens/DebugLogs.js";
 import DebugStore from "../../screens/DebugStore";
 import DebugPlayground from "../../screens/DebugPlayground";
 import Settings from "../../screens/Settings";
@@ -187,6 +188,13 @@ export default function SettingsNavigator() {
         component={DebugHttpTransport}
         options={{
           title: "Debug Http Transport",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugLogs}
+        component={DebugLogs}
+        options={{
+          title: "Debug Logs",
         }}
       />
       <Stack.Screen

--- a/src/const/navigation.js
+++ b/src/const/navigation.js
@@ -34,6 +34,7 @@ export const ScreenName = {
   DebugExport: "DebugExport",
   DebugHttpTransport: "DebugHttpTransport",
   DebugIcons: "DebugIcons",
+  DebugLogs: "DebugLogs",
   DebugLottie: "DebugLottie",
   DebugMocks: "DebugMocks",
   DebugPlayground: "DebugPlayground",

--- a/src/screens/DebugLogs.js
+++ b/src/screens/DebugLogs.js
@@ -1,0 +1,60 @@
+// @flow
+import React, { useEffect, useCallback, useState } from "react";
+import { listen } from "@ledgerhq/logs";
+import { ScrollView, View, Text, StyleSheet } from "react-native";
+import Share from "react-native-share";
+import Button from "../components/Button";
+
+export default function DebugLogs() {
+  const [logs, setLogs] = useState([]);
+  const prependToLogs = useCallback(
+    log => setLogs(currentLogs => [log, ...currentLogs]),
+    [],
+  );
+
+  useEffect(() => listen(prependToLogs), [prependToLogs]);
+
+  const onExport = async () => {
+    const message = JSON.stringify(logs);
+    const options = {
+      failOnCancel: false,
+      saveToFiles: true,
+      type: "text/plain",
+      message,
+    };
+
+    try {
+      await Share.open(options);
+    } catch (err) {
+      // Copied this from the swap history export
+    }
+  };
+
+  return (
+    <View style={styles.wrapper}>
+      <Button
+        event="ConfirmationModalCancel"
+        type="primary"
+        containerStyle={styles.button}
+        title={"Export logs"}
+        onPress={onExport}
+      />
+      <ScrollView>
+        <View>
+          {logs.map(log => (
+            <Text>{JSON.stringify(log)}</Text>
+          ))}
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    padding: 20,
+  },
+  button: {
+    marginBottom: 20,
+  },
+});

--- a/src/screens/Settings/Debug/OpenDebugLogs.js
+++ b/src/screens/Settings/Debug/OpenDebugLogs.js
@@ -1,0 +1,16 @@
+// @flow
+import React from "react";
+import { useNavigation } from "@react-navigation/native";
+import { ScreenName } from "../../../const";
+import SettingsRow from "../../../components/SettingsRow";
+
+export default function OpenDebugLogs() {
+  const navigation = useNavigation();
+
+  return (
+    <SettingsRow
+      title="Debug logs"
+      onPress={() => navigation.navigate(ScreenName.DebugLogs)}
+    />
+  );
+}

--- a/src/screens/Settings/Debug/index.js
+++ b/src/screens/Settings/Debug/index.js
@@ -21,6 +21,7 @@ import AnalyticsConsoleRow from "./AnalyticsConsoleRow";
 import OpenDebugStore from "./OpenDebugStore";
 import OpenDebugPlayground from "./OpenDebugPlayground";
 import OpenLottie from "./OpenDebugLottie";
+import OpenDebugLogs from "./OpenDebugLogs";
 import SkipLock from "../../../components/behaviour/SkipLock";
 import NavigationScrollView from "../../../components/NavigationScrollView";
 
@@ -39,6 +40,7 @@ export function DebugMocks() {
       {accounts.length === 0 ? (
         <GenerateMockAccounts title="Generate 10 mock Accounts" count={10} />
       ) : null}
+      <OpenDebugLogs />
       <OpenDebugCrash />
       <OpenDebugStore />
       <OpenDebugIcons />


### PR DESCRIPTION
I'm not even sure why this was assigned to me in the first place but to get the ball rolling this is at least better than nothing. It providers a screen for us to see the logs (for users, I guess, if we put it out of the debug menu) and a way to export the logs. Currently all very rough with just copying the logs as a huge string but I guess we could generate a file and share that instead.

I think that with some modifications to the way we dispatch the logs [here](https://github.com/LedgerHQ/ledgerjs/blob/fd8137d029835f3e8966d6051fb0e957eab194a5/packages/logs/src/index.js#L24-L29) we could retrieve logs from before accessing the screen, think a buffer of past N logs, or a replay rxjs thingy.

![image](https://user-images.githubusercontent.com/4631227/103665699-04c8c800-4f74-11eb-89f7-136e90c4a3dd.png)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1944

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
