### PR TITLE
LL-4281 Swap operation detail status styling

### DIFF
--- a/src/components/TooltipLabel.js
+++ b/src/components/TooltipLabel.js
@@ -2,17 +2,18 @@
 import React, { useCallback, useState } from "react";
 import { TouchableOpacity, StyleSheet } from "react-native";
 import { useTheme } from "@react-navigation/native";
+import Icon from "react-native-vector-icons/dist/FontAwesome";
 import LText from "./LText";
 import BottomModal from "./BottomModal";
-import Info from "../icons/Info";
 
 type Props = {
   label: React$Node,
   tooltip: React$Node,
+  color: string,
   style?: *,
 };
 
-const TooltipLabel = ({ label, tooltip, style }: Props) => {
+const TooltipLabel = ({ label, tooltip, color = "grey", style }: Props) => {
   const { colors } = useTheme();
   const [isOpened, setIsOpened] = useState();
   const open = useCallback(() => setIsOpened(true), []);
@@ -24,7 +25,7 @@ const TooltipLabel = ({ label, tooltip, style }: Props) => {
         <LText style={{ ...styles.label, ...style }} color="grey">
           {label}
         </LText>
-        <Info size={13} color={colors.grey} />
+        <Icon size={13} color={colors[color]} name={"info-circle"} />
       </TouchableOpacity>
       <BottomModal isOpened={isOpened} onClose={close} style={styles.modal}>
         <LText semiBold style={styles.tooltip}>

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1777,7 +1777,12 @@
         "from": "From",
         "fromAmount": "Amount sent",
         "to": "To",
-        "toAmount": "Amount to receive"
+        "toAmount": "Amount to receive",
+        "statusTooltips": {
+          "refunded": "Please contact the Swap provider with you swap ID for more details",
+          "failed": "Please contact the Swap provider with you swap ID for more details",
+          "hold": "Please contact the Swap provider with you swap ID to solve the situation"
+        }
       },
       "missingApp": {
         "title": "Please install the Exchange app on your device",

--- a/src/screens/Swap/OperationDetails.js
+++ b/src/screens/Swap/OperationDetails.js
@@ -16,10 +16,12 @@ import Icon from "react-native-vector-icons/dist/Ionicons";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
 import { useTheme } from "@react-navigation/native";
+import Config from "react-native-config";
 import { flattenAccountsSelector } from "../../reducers/accounts";
 import CurrencyUnitValue from "../../components/CurrencyUnitValue";
 import LText from "../../components/LText";
 import SectionSeparator from "../../components/SectionSeparator";
+import TooltipLabel from "../../components/TooltipLabel";
 import CurrencyIcon from "../../components/CurrencyIcon";
 import SwapStatusIndicator, { getStatusColor } from "./SwapStatusIndicator";
 import { urls } from "../../config/urls";
@@ -49,13 +51,14 @@ const OperationDetails = ({ route }: Props) => {
   const accounts = useSelector(flattenAccountsSelector);
   const fromAccount = accounts.find(a => a.id === swapOperation.fromAccount.id);
   const swap = fromAccount.swapHistory.find(s => s.swapId === swapId);
-  const status = swap.status;
+  const status = Config.DEBUG_SWAP_STATUS || swap.status;
 
   const fromCurrency = getAccountCurrency(fromAccount);
   const toCurrency = getAccountCurrency(toAccount);
-  const statusColor = getStatusColor(status);
-  const dotStyles = { backgroundColor: statusColor };
-  const textColorStyles = { color: statusColor };
+  const statusColorKey = getStatusColor(status, colors, true);
+  const dotStyles = { backgroundColor: colors[statusColorKey] };
+  const textColorStyles = { color: colors[statusColorKey] };
+  const statusHasTooltip = ["refunded", "hold", "failed"].includes(status);
 
   const openProvider = useCallback(() => {
     Linking.openURL(urls.swap.providers[provider].main);
@@ -79,7 +82,7 @@ const OperationDetails = ({ route }: Props) => {
         <View style={styles.arrow}>
           <Icon name={"ios-arrow-round-forward"} size={30} color={colors.fog} />
         </View>
-        <LText tertiary style={styles.toAmount} color="green">
+        <LText tertiary style={styles.toAmount} color={statusColorKey}>
           <CurrencyUnitValue
             alwaysShowSign
             showCode
@@ -89,7 +92,18 @@ const OperationDetails = ({ route }: Props) => {
         </LText>
         <View style={styles.statusTextWrapper}>
           <View style={[styles.statusDot, dotStyles]} />
-          <LText style={[styles.statusText, textColorStyles]}>{status}</LText>
+          {statusHasTooltip ? (
+            <TooltipLabel
+              label={status}
+              style={{ ...styles.statusText, ...textColorStyles }}
+              color={statusColorKey}
+              tooltip={
+                <Trans
+                  i18nKey={`transfer.swap.operationDetails.statusTooltips.${status}`}
+                />
+              }
+            />
+          ) : null}
         </View>
         <View style={styles.fieldsWrapper}>
           <LText style={styles.label} color="grey">

--- a/src/screens/Swap/OperationDetails.js
+++ b/src/screens/Swap/OperationDetails.js
@@ -103,7 +103,9 @@ const OperationDetails = ({ route }: Props) => {
                 />
               }
             />
-          ) : null}
+          ) : (
+            <LText style={[styles.statusText, textColorStyles]}>{status}</LText>
+          )}
         </View>
         <View style={styles.fieldsWrapper}>
           <LText style={styles.label} color="grey">

--- a/src/screens/Swap/SwapStatusIndicator.js
+++ b/src/screens/Swap/SwapStatusIndicator.js
@@ -8,17 +8,23 @@ import { useTheme } from "@react-navigation/native";
 import IconSwap from "../../icons/Swap";
 import { rgba } from "../../colors";
 
-export const getStatusColor = (status: string, colors: *) => {
+export const getStatusColor = (
+  status: string,
+  colors: *,
+  colorKey?: boolean = false,
+) => {
+  let key = "grey";
+
   if (operationStatusList.pending.includes(status)) {
-    return colors.grey;
+    key = status === "hold" ? "orange" : "wallet";
   }
   if (operationStatusList.finishedOK.includes(status)) {
-    return colors.green;
+    key = "green";
   }
   if (operationStatusList.finishedKO.includes(status)) {
-    return colors.alert;
+    key = "alert";
   }
-  return colors.grey;
+  return colorKey ? key : colors[key];
 };
 
 const SwapStatusIndicator = ({


### PR DESCRIPTION
Introduces better styling for the swap status of a particular operation in the swap operation details screen, also adds tooltips to some of the status to aid the user to the provider's support instead of Ledger's since it's them who will be able to solve any held/failed cases.

> **Note:** Did not use the LLD tooltip since on LLM we don't have a component that does that, I used the bottom modal tooltip replacement as it's done on other parts of the app, updated the icon to use the font-awesome info-circle as per figma though.

### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-4281

### Parts of the app affected / Test plan

I've added a new debug flag to aid QA testing this feature. If you set the DEBUG_SWAP_STATUS flag on your `.env` file and then launch the app, the status of swap operations will be overridden by this value. It is expected that pending status are blue, hold should be orange, KO status red and OK status green.

Only hold, refunded, and failed currently have tooltips.
