### PR TITLE
LL-4450 Bring back blur on app switcher iOS

### DIFF
--- a/ios/ledgerlivemobile/AppDelegate.m
+++ b/ios/ledgerlivemobile/AppDelegate.m
@@ -47,6 +47,49 @@ static void InitializeFlipper(UIApplication *application) {
   return YES;
 }
 
+- (void) showOverlay{
+  UIBlurEffect *blurEffect = [UIBlurEffect effectWithStyle:UIBlurEffectStyleRegular];
+  UIVisualEffectView *blurEffectView = [[UIVisualEffectView alloc] initWithEffect:blurEffect];
+  UIImageView *logoView = [[UIImageView alloc]initWithImage:[UIImage imageNamed:@"Blurry"]];
+  logoView.contentMode = UIViewContentModeScaleAspectFit;
+  blurEffectView.frame = [self.window bounds];
+  blurEffectView.tag = 12345;
+  logoView.tag = 12346;
+
+  blurEffectView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  [self.window addSubview:blurEffectView];
+  [self.window addSubview:logoView];
+  [self.window bringSubviewToFront:logoView];
+
+  [logoView setContentHuggingPriority:251 forAxis:UILayoutConstraintAxisHorizontal];
+  [logoView setContentHuggingPriority:251 forAxis:UILayoutConstraintAxisVertical];
+  logoView.frame = CGRectMake(0, 0, 128, 128);
+
+  logoView.center = CGPointMake(self.window.frame.size.width  / 2,self.window.frame.size.height / 2);
+}
+
+- (void) hideOverlay{
+  UIView *blurEffectView = [self.window viewWithTag:12345];
+  UIView *logoView = [self.window viewWithTag:12346];
+
+  [UIView animateWithDuration:0.5 animations:^{
+    blurEffectView.alpha = 0;
+    logoView.alpha = 0;
+  } completion:^(BOOL finished) {
+    // remove when finished fading
+    [blurEffectView removeFromSuperview];
+    [logoView removeFromSuperview];
+  }];
+}
+
+- (void)applicationDidBecomeActive:(UIApplication *)application {
+  [self hideOverlay];
+}
+
+- (void)applicationDidEnterBackground:(UIApplication *)application {
+  [self showOverlay];
+}
+
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
 #if DEBUG


### PR DESCRIPTION
This pr addresses two separate issues. First, we deleted the code that was blurrying the content and adding a logo when in the app switcher mode on iOS devices. This was done as part of https://github.com/LedgerHQ/ledger-live-mobile/commit/694f503a9e94290fae31fb9d1683399ef9f8587e and essentially kills that functionality completely. Keep in mind we killed the auto-lock feature so locking only happens when you access for the first time (?)

Before merging this pr I would like the dev that dropped those lines to explain the reasoning for dropping them, since we might have done that to avoid a bug and could be introducing it again. I couldn't find anything in our jira/slack about this. It seems to work well enough.

~Second issue addresses the _`I can’t enable FaceID on 2.20`_  comment by @dasilvarosa and the only way I can reproduce this screenshot is if I'm not enrolled on the face id feature on the device (on a simulator sadly, my test device doesn't support face id) and then try to enable it in the app. The error message shown in the screenshot is a fallback on version 4.0.0 and there doesn't seem to be support for detecting that we don't have a face id enrolled, but if you can confirm this is the case, we _could_ potentially show a friendlier error message that contemplates that possibility.~

~Something like "Failed to authenticate with your device, have you enrolled a face in settings?"~


### Blur in place 
![image](https://user-images.githubusercontent.com/4631227/105994369-d720fb80-60a7-11eb-9e99-77087580a05a.png)

### Type

Bug fix / Regression

### Context

https://ledgerhq.atlassian.net/browse/LL-4450

### Parts of the app affected / Test plan

- On an iOS device, make sure that if you go to the home, and then launch the app switcher thingy, LLM is blurred with logo
- If you are in the app itself and launch the app drawer it will not be blurred (can't seem to make that happen)