### PR TITLE
LL-4378 (Button): fix loader animation on send flow

### DIFF
--- a/src/families/tezos/DelegationFlow/Summary.js
+++ b/src/families/tezos/DelegationFlow/Summary.js
@@ -381,6 +381,7 @@ export default function DelegationSummary({ navigation, route }: Props) {
           containerStyle={styles.continueButton}
           onPress={onContinue}
           disabled={bridgePending || !!bridgeError}
+          pending={bridgePending}
         />
       </View>
     </SafeAreaView>

--- a/src/screens/SendFunds/02-SelectRecipient.js
+++ b/src/screens/SendFunds/02-SelectRecipient.js
@@ -216,6 +216,7 @@ export default function SendSelectRecipient({ navigation, route }: Props) {
               type="primary"
               title={<Trans i18nKey="common.continue" />}
               disabled={bridgePending || !!status.errors.recipient}
+              pending={bridgePending}
               onPress={onPressContinue}
             />
           </View>

--- a/src/screens/SendFunds/04-Summary.js
+++ b/src/screens/SendFunds/04-Summary.js
@@ -260,6 +260,7 @@ function SendSummary({ navigation, route: initialRoute }: Props) {
             containerStyle={styles.continueButton}
             onPress={() => setContinuing(true)}
             disabled={bridgePending || !!transactionError}
+            pending={bridgePending}
           />
         )}
       </View>


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(Button): rewrite in function style + cleanup of loader animation + loader can now be driven by props like a previous version supposedly



https://user-images.githubusercontent.com/11752937/106003506-8cf14780-60b2-11eb-8978-f89fed12c31d.mp4


### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI Polish
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-4378
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Send flow buttons should now show a loader while bridge pending
+ Tezos delegation summary
