### PR TITLE
LL-1944 Fix iOS/Android sharing in general

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.VIBRATE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" /> <!-- react-native-share base64 sharing (swap history/logs export)-->
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" /> <!-- Needed by Flipper 🐬 -->
     <uses-sdk
         android:targetSdkVersion="27"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -363,8 +363,8 @@ PODS:
     - React
   - RNScreens (2.15.0):
     - React-Core
-  - RNShare (3.7.0):
-    - React
+  - RNShare (5.1.0):
+    - React-Core
   - RNSVG (12.0.3):
     - React
   - RNVectorIcons (6.6.0):
@@ -666,7 +666,7 @@ SPEC CHECKSUMS:
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
   RNReanimated: c2bb7438b57a3d987bb2e4e6e4bca94787e30b02
   RNScreens: 2ad555d4d9fa10b91bb765ca07fe9b29d59573f0
-  RNShare: a1d5064df7a0ebe778d001869b3f0a124bf0a491
+  RNShare: fed99fd743f80ca255903c1da46fc9a6430efab6
   RNSVG: 7e16ddfc6e00d5aa69c9eb83e699bcce5dcb85d4
   RNVectorIcons: 0bb4def82230be1333ddaeee9fcba45f0b288ed4
   Sentry: 4e8a17b61ddd116f89536cc81d567fdee1ebca96

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "react-native-safe-area-view": "^1.1.1",
     "react-native-screens": "^2.15.0",
     "react-native-sentry": "0.43.2",
-    "react-native-share": "^3.7.0",
+    "react-native-share": "^5.0.0",
     "react-native-simple-store": "^2.0.2",
     "react-native-slider": "^0.11.0",
     "react-native-splash-screen": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9426,10 +9426,10 @@ react-native-sentry@0.43.2:
     "@sentry/wizard" "^0.13.0"
     raven-js "^3.27.1"
 
-react-native-share@^3.7.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-3.7.0.tgz#5b5bcc87530ddaaabcb8b70a9366dce88a6f9495"
-  integrity sha512-MCTGiPcBfelrnX/7n82N5eQAl31F6xljqFK2CWbPDTSt7bbJUZH3Znvy8KYePLYqAr7HVrk621eanQN6vSFMzA==
+react-native-share@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-5.1.0.tgz#6431f0aa6952e13fc74afbc756c2b37f06cb7feb"
+  integrity sha512-QGMWOPlwboAGd/5uUh2l0jXIDhZ2q8J4CIa063NDE7ihsZRQlF/w6kd90i3bi6GF6aedvhynqZPmezwqjiyU7g==
 
 react-native-simple-store@^2.0.2:
   version "2.0.2"


### PR DESCRIPTION
When investigating the cause of the LL-1944 sharing bug on iOS I accidentally uncovered that the export for **Android** of swap history is currently not working at all. We will get prompt with a failed to share toast message due to having an outdated library and most importantly a missing permission. This sharing intent of a base64 generated file on the fly requires the external storage permission as described in https://react-native-share.github.io/react-native-share/docs/install and we simply didn't have that.

This means **current develop version has a broken swap history export**

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-1944

### Parts of the app affected / Test plan

- Try exporting logs for both iOS and Android from the debug screen, it is expected that a file is generated with the data.
- Try exporting the swap history for both iOS and Android, it is expected that a file is generated with the data.