### PR TITLE
LL-4388 Styling fix for iOS monospace unicode on 𝚝BTC

### DIFF
--- a/src/components/AccountGraphCard.js
+++ b/src/components/AccountGraphCard.js
@@ -260,6 +260,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "center",
     alignItems: "center",
+    marginTop: 10,
     marginBottom: 20,
   },
   pillsContainer: {

--- a/src/components/AssetGraphCard.js
+++ b/src/components/AssetGraphCard.js
@@ -234,6 +234,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "center",
     alignItems: "center",
+    marginTop: 10,
     marginBottom: 20,
   },
   pillsContainer: {

--- a/src/screens/Account/ListHeaderComponent.js
+++ b/src/screens/Account/ListHeaderComponent.js
@@ -223,12 +223,10 @@ const styles = StyleSheet.create({
   },
   balanceContainer: {
     alignItems: "flex-start",
-    marginBottom: 10,
   },
   balanceText: {
     fontSize: normalize(21),
     paddingBottom: 4,
-    lineHeight: 24,
     flexWrap: "wrap",
   },
   balanceSubText: {

--- a/src/screens/Asset/index.js
+++ b/src/screens/Asset/index.js
@@ -13,6 +13,7 @@ import type {
   PortfolioRange,
   Unit,
 } from "@ledgerhq/live-common/lib/types";
+import { isCountervalueEnabled } from "@ledgerhq/live-common/lib/countervalues/modules";
 import React, { PureComponent, useMemo } from "react";
 import { StyleSheet, View, SectionList } from "react-native";
 import { useRoute, useTheme } from "@react-navigation/native";
@@ -92,8 +93,8 @@ class Asset extends PureComponent<AssetProps, any> {
     counterValueUnit: Unit,
     item: Item,
   }) => {
-    const { switchCountervalueFirst } = this.props;
-    const countervalueAvailable = true;
+    const { switchCountervalueFirst, currency } = this.props;
+    const countervalueAvailable = isCountervalueEnabled(currency);
     const items = [
       { unit: cryptoCurrencyUnit, value: item.value },
       countervalueAvailable && item.countervalue
@@ -300,7 +301,6 @@ const styles = StyleSheet.create({
   },
   balanceText: {
     fontSize: 22,
-    lineHeight: 24,
   },
   balanceSubText: {
     fontSize: 16,


### PR DESCRIPTION
The is a small _issue_, dont really know what to call it since the specs for inner bound rendering on css are so hard to understand, that makes the presence of a monospace unicode lowercase t in the ticker for bitcoin testnet, slightly displace the rest of the ticker enough to make it cut-off the top.
![image](https://user-images.githubusercontent.com/4631227/106137544-254b0300-616b-11eb-974b-7831deae02d0.png)

Removing the hardcoded line-height here fixes the issue and doesn't seem to cause any obvious UI regression.

This pr also hides the countervalue for currencies that dont have a countervalue (ie tBTC) in the account screen but also in the asset distribution screen.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-4388

