### PR TITLE
libcore bindings 4.17.0-okhttp3.0

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,7 +3,7 @@ PODS:
   - boost-for-react-native (1.63.0)
   - CocoaAsyncSocket (7.6.4)
   - CocoaLibEvent (1.0.0)
-  - djinni_objc (4.16.3)
+  - djinni_objc (4.17.0-beta.2-stargate)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.63.4)
   - FBReactNativeSpec (0.63.4):
@@ -69,7 +69,7 @@ PODS:
     - DoubleConversion
     - glog
   - glog (0.3.5)
-  - ledger-core-objc (4.16.3):
+  - ledger-core-objc (4.17.0-beta.2-stargate):
     - djinni_objc
   - lottie-ios (3.1.9)
   - lottie-react-native (3.3.2):
@@ -354,7 +354,7 @@ PODS:
     - React
   - RNKeychain (5.0.0):
     - React
-  - RNLibLedgerCore (4.16.3):
+  - RNLibLedgerCore (4.17.0-beta.2-stargate):
     - ledger-core-objc
     - React
   - RNOS (1.2.6):
@@ -604,7 +604,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
-  djinni_objc: f04ed3e34aeabad13c48893d48cd72c9e2275dbd
+  djinni_objc: 8c52e15ba3be0a3a13da838e00e0ae71d52f34a7
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3bb422f41b18121b71783a905c10e58606f7dc3e
   FBReactNativeSpec: f2c97f2529dd79c083355182cc158c9f98f4bd6e
@@ -617,7 +617,7 @@ SPEC CHECKSUMS:
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
   glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
-  ledger-core-objc: 2b7223951d4bcdb999b1c5c75e2359169031e2ba
+  ledger-core-objc: 40b406cfbfa22231244851eda78a2c3f56664693
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
   lottie-react-native: 2a1a82bb326ae51331a5520de0cf706733c6db69
   MultiplatformBleAdapter: 652f47ecd7f5036756517cf66833210709a72eab
@@ -662,7 +662,7 @@ SPEC CHECKSUMS:
   RNCMaskedView: 76c40a1d41c3e2535df09246a2b5487f04de0814
   RNGestureHandler: dde546180bf24af0b5f737c8ad04b6f3fa51609a
   RNKeychain: 589a5504ba18b854fb8c2ba6402387b9529da959
-  RNLibLedgerCore: 4574c3750d377ef7493c6e9be4344ac185de01b9
+  RNLibLedgerCore: 8b26c72a5696188641e68a6c9a9d056b2755f29d
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
   RNReanimated: c2bb7438b57a3d987bb2e4e6e4bca94787e30b02
   RNScreens: 2ad555d4d9fa10b91bb765ca07fe9b29d59573f0

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@ledgerhq/logs": "5.41.0",
     "@ledgerhq/react-native-hid": "5.41.0",
     "@ledgerhq/react-native-hw-transport-ble": "5.41.0",
-    "@ledgerhq/react-native-ledger-core": "4.16.3",
+    "@ledgerhq/react-native-ledger-core": "4.17.0-okhttp3.0",
     "@ledgerhq/react-native-passcode-auth": "^2.1.0",
     "@react-native-community/art": "^1.1.2",
     "@react-native-community/async-storage": "^1.12.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1295,10 +1295,10 @@
     rxjs "^6.6.3"
     uuid "^3.4.0"
 
-"@ledgerhq/react-native-ledger-core@4.16.3":
-  version "4.16.3"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-4.16.3.tgz#5199734029df9a25b77d15af2e21a98812a73b77"
-  integrity sha512-MqqkEHmYYNuElGZc0GTdKB0M0i80KHqE5fTrJivuuiVADUw9PEo9nrOXTNzGW8cA3MCP4YqhgRYyTWr4t6KD0w==
+"@ledgerhq/react-native-ledger-core@4.17.0-okhttp3.0":
+  version "4.17.0-okhttp3.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-4.17.0-okhttp3.0.tgz#bac585da07661d129ce27f55c22f466990bfa88e"
+  integrity sha512-L6RPDKWZYloH/rlEOLp1VEPRzzhsthiGb1LSeXxeJMKzgxAa5PoXncoI4W8dP8Me9qh1ZrmWDrLb57lhPvkIeg==
 
 "@ledgerhq/react-native-passcode-auth@^2.1.0":
   version "2.1.0"


### PR DESCRIPTION
For testing Cosmos sync bug on Android with the rewrite done to the httpclient from https://github.com/LedgerHQ/lib-ledger-core-react-native-bindings/pull/74 to me this pr should never be merged, it's just to test that the attempt at solving the bug works.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-4389

### Parts of the app affected / Test plan

- Sync a cosmos account
- Send with a cosmos account
- Try other libcore crypto