### PR TITLE
LL-4396 (Onboarding): fix button tap styling

### DIFF
--- a/src/components/AnimatedHeader.js
+++ b/src/components/AnimatedHeader.js
@@ -5,7 +5,7 @@ import {
   StyleSheet,
   Platform,
   SafeAreaView,
-  Pressable,
+  TouchableOpacity,
 } from "react-native";
 import { useNavigation, useTheme } from "@react-navigation/native";
 import Animated from "react-native-reanimated";
@@ -36,13 +36,13 @@ const BackButton = ({
   navigation: *,
   action?: () => void,
 }) => (
-  <Pressable
+  <TouchableOpacity
     hitSlop={hitSlop}
     style={styles.buttons}
     onPress={() => (action ? action() : navigation.goBack())}
   >
     <ArrowLeft size={18} color={colors.darkBlue} />
-  </Pressable>
+  </TouchableOpacity>
 );
 
 const CloseButton = ({
@@ -54,13 +54,13 @@ const CloseButton = ({
   navigation: *,
   action?: () => void,
 }) => (
-  <Pressable
+  <TouchableOpacity
     hitSlop={hitSlop}
     onPress={() => (action ? action() : navigation.popToTop())}
     style={styles.buttons}
   >
     <Close size={18} color={colors.darkBlue} />
-  </Pressable>
+  </TouchableOpacity>
 );
 
 type Props = {

--- a/src/components/OnboardingStepperView/OnboardingInfoModal.js
+++ b/src/components/OnboardingStepperView/OnboardingInfoModal.js
@@ -4,7 +4,7 @@ import {
   SafeAreaView,
   View,
   StyleSheet,
-  Pressable,
+  TouchableOpacity,
   Platform,
   ScrollView,
   Linking,
@@ -63,9 +63,13 @@ export default function OnboardingInfoModal({ navigation, route }: Props) {
     <SafeAreaView style={[styles.root, { backgroundColor: primaryColor }]}>
       <View style={[styles.header]}>
         <View style={styles.topHeader}>
-          <Pressable hitSlop={hitSlop} style={styles.buttons} onPress={close}>
+          <TouchableOpacity
+            hitSlop={hitSlop}
+            style={styles.buttons}
+            onPress={close}
+          >
             <Close size={18} color={textColor} />
-          </Pressable>
+          </TouchableOpacity>
         </View>
       </View>
       <ScrollView style={styles.root}>
@@ -82,7 +86,7 @@ export default function OnboardingInfoModal({ navigation, route }: Props) {
               </LText>
             )}
             {link && (
-              <Pressable
+              <TouchableOpacity
                 style={styles.desc}
                 onPress={() => {
                   Linking.canOpenURL(link.url) && Linking.openURL(link.url);
@@ -91,7 +95,7 @@ export default function OnboardingInfoModal({ navigation, route }: Props) {
                 <LText semiBold style={[styles.link, { color: colors.live }]}>
                   {link.label}
                 </LText>
-              </Pressable>
+              </TouchableOpacity>
             )}
             {bullets && (
               <View style={styles.bulletContainer}>
@@ -136,7 +140,7 @@ export default function OnboardingInfoModal({ navigation, route }: Props) {
                           {label}
                         </LText>
                         {bulletLink && (
-                          <Pressable
+                          <TouchableOpacity
                             onPress={() => {
                               Linking.canOpenURL(bulletLink.url) &&
                                 Linking.openURL(bulletLink.url);
@@ -148,7 +152,7 @@ export default function OnboardingInfoModal({ navigation, route }: Props) {
                             >
                               {bulletLink.label}
                             </LText>
-                          </Pressable>
+                          </TouchableOpacity>
                         )}
                       </View>
                     </View>

--- a/src/components/OnboardingStepperView/OnboardingStepView.js
+++ b/src/components/OnboardingStepperView/OnboardingStepView.js
@@ -1,6 +1,12 @@
 // @flow
 import React, { useCallback, useMemo, useState } from "react";
-import { View, StyleSheet, Pressable, Image, ScrollView } from "react-native";
+import {
+  View,
+  StyleSheet,
+  TouchableOpacity,
+  Image,
+  ScrollView,
+} from "react-native";
 import { useTheme } from "@react-navigation/native";
 import { normalize } from "../../helpers/normalizeSize";
 import { TrackScreen } from "../../analytics";
@@ -185,7 +191,7 @@ export function InfoStepView({
           </View>
         )}
         {ctaText && (
-          <Pressable
+          <TouchableOpacity
             style={[
               styles.ctaButton,
               {
@@ -206,7 +212,7 @@ export function InfoStepView({
             >
               {ctaText}
             </LText>
-          </Pressable>
+          </TouchableOpacity>
         )}
         {ctaWarningModal && (
           <ConfirmationModal

--- a/src/components/OnboardingStepperView/index.js
+++ b/src/components/OnboardingStepperView/index.js
@@ -5,7 +5,7 @@ import {
   View,
   StyleSheet,
   Dimensions,
-  Pressable,
+  TouchableOpacity,
   Platform,
 } from "react-native";
 import { TabView, SceneMap } from "react-native-tab-view";
@@ -122,22 +122,22 @@ export default function OnboardingStepperView({
       <View style={[styles.header]}>
         <View style={styles.topHeader}>
           {hideBackButton ? null : (
-            <Pressable
+            <TouchableOpacity
               hitSlop={hitSlop}
               style={styles.buttons}
               onPress={onBack}
             >
               <ArrowLeft size={18} color={sceneColors[1]} />
-            </Pressable>
+            </TouchableOpacity>
           )}
           {currentScene?.sceneInfoKey && (
-            <Pressable
+            <TouchableOpacity
               hitSlop={hitSlop}
               style={styles.buttons}
               onPress={openInfoModal}
             >
               <Question size={20} color={sceneColors[1]} />
-            </Pressable>
+            </TouchableOpacity>
           )}
         </View>
         <View style={styles.indicatorContainer}>

--- a/src/components/RootNavigator/BaseOnboardingNavigator.js
+++ b/src/components/RootNavigator/BaseOnboardingNavigator.js
@@ -3,7 +3,7 @@ import React, { useCallback, useMemo } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@react-navigation/native";
-import { Pressable } from "react-native";
+import { TouchableOpacity } from "react-native";
 import { ScreenName, NavigatorName } from "../../const";
 import PairDevices from "../../screens/PairDevices";
 import EditDeviceName from "../../screens/EditDeviceName";
@@ -30,13 +30,13 @@ export const ErrorHeaderInfo = ({ route, navigation, colors }: *) => {
   }, [navigation]);
 
   return route.params.hasError ? (
-    <Pressable
+    <TouchableOpacity
       style={{ marginRight: 24 }}
       hitSlop={hitSlop}
       onPress={openInfoModal}
     >
       <Question size={20} color={colors.grey} />
-    </Pressable>
+    </TouchableOpacity>
   ) : null;
 };
 

--- a/src/screens/Onboarding/OnboardingQuiz.js
+++ b/src/screens/Onboarding/OnboardingQuiz.js
@@ -1,6 +1,12 @@
 // @flow
 import React, { useCallback, useState } from "react";
-import { StyleSheet, View, Dimensions, Image, Pressable } from "react-native";
+import {
+  StyleSheet,
+  View,
+  Dimensions,
+  Image,
+  TouchableOpacity,
+} from "react-native";
 import { TabView, SceneMap } from "react-native-tab-view";
 import Svg, { Ellipse } from "react-native-svg";
 import { useTheme } from "@react-navigation/native";
@@ -165,7 +171,7 @@ function OnboardingQuizz({ navigation, route }: *) {
         </Svg>
         <View style={styles.dotContainer}>
           {quizScenes.map((k, i) => (
-            <Pressable
+            <TouchableOpacity
               key={i}
               style={[
                 styles.dot,
@@ -175,7 +181,7 @@ function OnboardingQuizz({ navigation, route }: *) {
               ]}
             >
               <View />
-            </Pressable>
+            </TouchableOpacity>
           ))}
         </View>
       </View>

--- a/src/screens/Onboarding/steps/newDeviceInfo.js
+++ b/src/screens/Onboarding/steps/newDeviceInfo.js
@@ -1,7 +1,13 @@
 // @flow
 
 import React, { useCallback, useState } from "react";
-import { StyleSheet, View, Dimensions, Pressable, Image } from "react-native";
+import {
+  StyleSheet,
+  View,
+  Dimensions,
+  TouchableOpacity,
+  Image,
+} from "react-native";
 import { Trans } from "react-i18next";
 import { TabView, SceneMap } from "react-native-tab-view";
 import Svg, { Ellipse } from "react-native-svg";
@@ -132,7 +138,7 @@ function OnboardingStepNewDevice({ navigation, route }: *) {
         </Svg>
         <View style={styles.dotContainer}>
           {[0, 1, 2, 3, 4].map(k => (
-            <Pressable
+            <TouchableOpacity
               key={k}
               style={[
                 styles.dot,
@@ -143,7 +149,7 @@ function OnboardingStepNewDevice({ navigation, route }: *) {
               onPress={() => setIndex(k)}
             >
               <View />
-            </Pressable>
+            </TouchableOpacity>
           ))}
         </View>
       </View>


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(Onboarding): switch from Pressable to TouchableOpacity for built in on press opacity styling since Pressable does not make sense here.
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI Polish
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-4396
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Onboarding buttons should now react in opacity when pressed
