### PR TITLE
LL-4578 (ImportDesktopSettings): dev mode by default issue

### DIFF
--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -131,7 +131,8 @@ const handlers: Object = {
   SETTINGS_IMPORT_DESKTOP: (state: SettingsState, { settings }) => {
     const { developerModeEnabled, ...rest } = settings;
 
-    setEnvUnsafe("MANAGER_DEV_MODE", developerModeEnabled);
+    if (developerModeEnabled !== undefined)
+      setEnvUnsafe("MANAGER_DEV_MODE", developerModeEnabled);
 
     return {
       ...state,

--- a/src/screens/Portfolio/index.js
+++ b/src/screens/Portfolio/index.js
@@ -1,8 +1,7 @@
 // @flow
 import React, { useRef, useState, useCallback } from "react";
 import { useSelector } from "react-redux";
-import { StyleSheet, SectionList, FlatList } from "react-native";
-import SafeAreaView from "react-native-safe-area-view";
+import { StyleSheet, SectionList, FlatList, SafeAreaView } from "react-native";
 import Animated from "react-native-reanimated";
 import { createNativeWrapper } from "react-native-gesture-handler";
 import type { SectionBase } from "react-native/Libraries/Lists/SectionList";

--- a/src/screens/Settings/Experimental/ExperimentalHeader.js
+++ b/src/screens/Settings/Experimental/ExperimentalHeader.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { useState } from "react";
-import { StyleSheet } from "react-native";
+import { StyleSheet, Platform } from "react-native";
 import Animated, { Extrapolate } from "react-native-reanimated";
 import { Trans } from "react-i18next";
 import { useTheme } from "@react-navigation/native";
@@ -36,7 +36,7 @@ export default function ExperimentalHeader() {
   // interpolated height from opening anim state for list container
   const height = interpolate(openingAnim, {
     inputRange: [0, 1],
-    outputRange: [0, 30],
+    outputRange: [0, Platform.OS === "ios" ? 70 : 30],
     extrapolate: Extrapolate.CLAMP,
   });
 
@@ -68,7 +68,7 @@ const styles = StyleSheet.create({
   },
   container: {
     position: "absolute",
-    bottom: -38,
+    bottom: Platform.OS === "ios" ? 0 : -30,
     left: 0,
     width: "100%",
     height: 38,


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(ImportDesktopSettings): dev mode by default issue
It should also fix IOS header overlapping issue to be confirmed

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug Fix
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-4578
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
After importing accounts from desktop with settings, the dev mode should not be set on by default anymore
