### PR TITLE
LL-4604 navigation crash issue

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ import RootNavigator from "./components/RootNavigator";
 import SetEnvsFromSettings from "./components/SetEnvsFromSettings";
 import CounterValuesProvider from "./components/CounterValuesProvider";
 import type { State } from "./reducers";
-import { navigationRef } from "./rootnavigation";
+import { navigationRef, isReadyRef } from "./rootnavigation";
 import { useTrackingPairs } from "./actions/general";
 import { ScreenName, NavigatorName } from "./const";
 import ExperimentalHeader from "./screens/Settings/Experimental/ExperimentalHeader";
@@ -312,6 +312,13 @@ const DeepLinkingNavigator = ({ children }: { children: React$Node }) => {
       });
   }, [getInitialState, wcContext.initDone]);
 
+  React.useEffect(
+    () => () => {
+      isReadyRef.current = false;
+    },
+    [],
+  );
+
   const theme = useSelector(themeSelector);
 
   if (!isReady) {
@@ -323,6 +330,9 @@ const DeepLinkingNavigator = ({ children }: { children: React$Node }) => {
       theme={themes[theme]}
       initialState={initialState}
       ref={navigationRef}
+      onReady={() => {
+        isReadyRef.current = true;
+      }}
     >
       {children}
     </NavigationContainer>

--- a/src/rootnavigation.js
+++ b/src/rootnavigation.js
@@ -2,6 +2,11 @@ import * as React from "react";
 
 export const navigationRef = React.createRef();
 
+export const isReadyRef = React.createRef();
+
 export function navigate(name, params) {
-  navigationRef.current?.navigate(name, params);
+  if (isReadyRef.current && navigationRef.current) {
+    // Perform navigation if the app has mounted
+    navigationRef.current.navigate(name, params);
+  }
 }

--- a/src/screens/WalletConnect/Provider.js
+++ b/src/screens/WalletConnect/Provider.js
@@ -5,7 +5,7 @@ import ProviderCommon from "@ledgerhq/live-common/lib/walletconnect/Provider";
 import { saveWCSession, getWCSession } from "../../db";
 import { accountScreenSelector } from "../../reducers/accounts";
 import { NavigatorName, ScreenName } from "../../const";
-import { navigate, navigationRef } from "../../rootnavigation";
+import { navigate, isReadyRef } from "../../rootnavigation";
 
 const useAccount = accountId => {
   const { account } = useSelector(
@@ -24,7 +24,7 @@ const Provider = ({ children }: { children: React$Node }) => {
     }
 
     const interval = setInterval(() => {
-      setIsReady(!!navigationRef.current);
+      setIsReady(!!isReadyRef.current);
     }, 500);
 
     // eslint-disable-next-line consistent-return


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(WalletConnect): fix potential crash issue regarding navigation not init
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug fix
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-4604
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
mainly wallet connect could trigger a crash at launch, verify that it never happens and the functionality stays the same

tp reproduce the initial bug start a wallet connect session quit the app without closing the session then go back into it using wallet connect
