### PR TITLE
LL-4520 (Modals): block opening two modals at same time

### DIFF
--- a/src/components/BottomModal.js
+++ b/src/components/BottomModal.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { createRef, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { View, StyleSheet, Platform } from "react-native";
 import ReactNativeModal from "react-native-modal";
 import type { ViewStyleProp } from "react-native/Libraries/StyleSheet/StyleSheet";
@@ -11,7 +11,7 @@ import ButtonUseTouchable from "../context/ButtonUseTouchable";
 import getWindowDimensions from "../logic/getWindowDimensions";
 import DebugRejectSwitch from "./DebugRejectSwitch";
 
-const isModalOpenedref = createRef();
+let isModalOpenedref = false;
 
 export type Props = {
   id?: string,
@@ -57,18 +57,18 @@ const BottomModal = ({
   // workarround to make sure no double modal can be opened at same time
   useEffect(
     () => () => {
-      isModalOpenedref.current = false;
+      isModalOpenedref = false;
     },
     [],
   );
 
   useEffect(() => {
-    if (!!isModalOpenedref.current && isOpened) {
+    if (!!isModalOpenedref && isOpened) {
       onClose();
     } else {
       setIsOpen(isOpened);
     }
-    isModalOpenedref.current = isOpened;
+    isModalOpenedref = isOpened;
   }, [isOpened, onClose]);
 
   return (

--- a/src/components/BottomModal.js
+++ b/src/components/BottomModal.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React from "react";
+import React, { createRef, useEffect, useState } from "react";
 import { View, StyleSheet, Platform } from "react-native";
 import ReactNativeModal from "react-native-modal";
 import type { ViewStyleProp } from "react-native/Libraries/StyleSheet/StyleSheet";
@@ -10,6 +10,8 @@ import StyledStatusBar from "./StyledStatusBar";
 import ButtonUseTouchable from "../context/ButtonUseTouchable";
 import getWindowDimensions from "../logic/getWindowDimensions";
 import DebugRejectSwitch from "./DebugRejectSwitch";
+
+const isModalOpenedref = createRef();
 
 export type Props = {
   id?: string,
@@ -44,6 +46,7 @@ const BottomModal = ({
   ...rest
 }: Props) => {
   const { colors } = useTheme();
+  const [open, setIsOpen] = useState(false);
   const backDropProps = preventBackdropClick
     ? {}
     : {
@@ -51,12 +54,29 @@ const BottomModal = ({
         onBackButtonPress: onClose,
       };
 
+  // workarround to make sure no double modal can be opened at same time
+  useEffect(
+    () => () => {
+      isModalOpenedref.current = false;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!!isModalOpenedref.current && isOpened) {
+      onClose();
+    } else {
+      setIsOpen(isOpened);
+    }
+    isModalOpenedref.current = isOpened;
+  }, [isOpened, onClose]);
+
   return (
     <ButtonUseTouchable.Provider value={true}>
       <ReactNativeModal
         {...rest}
         {...backDropProps}
-        isVisible={isOpened}
+        isVisible={open}
         deviceWidth={width}
         deviceHeight={height}
         useNativeDriver
@@ -71,7 +91,7 @@ const BottomModal = ({
           ]}
         >
           <View style={style}>
-            {isOpened && id ? <TrackScreen category={id} /> : null}
+            {open && id ? <TrackScreen category={id} /> : null}
             <StyledStatusBar
               backgroundColor={
                 Platform.OS === "android" ? "rgba(0,0,0,0.7)" : "transparent"


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(Modals): block opening two modals at same time
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug fix
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-4520
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Tap quick on two modal buttons per instance in the accounts page header buttons or the transfer button at the same time.
It should no longer open both modals.
