### PR TITLE
LL-4768 Prevent sync if no network

### DIFF
--- a/android/app/src/main/java/com/ledger/live/MainApplication.java
+++ b/android/app/src/main/java/com/ledger/live/MainApplication.java
@@ -4,6 +4,7 @@ import android.app.Application;
 import android.content.Context;
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
+import com.reactnativecommunity.netinfo.NetInfoPackage;
 import com.reactnativecommunity.webview.RNCWebViewPackage;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'ledgerlivemobile'
+include ':@react-native-community_netinfo'
+project(':@react-native-community_netinfo').projectDir = new File(rootProject.projectDir, '../node_modules/@react-native-community/netinfo/android')
 include ':react-native-webview'
 project(':react-native-webview').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-webview/android')
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -17,6 +17,8 @@ target 'ledgerlivemobile' do
 
   pod 'react-native-webview', :path => '../node_modules/react-native-webview'
 
+  pod 'react-native-netinfo', :path => '../node_modules/@react-native-community/netinfo'
+
   target 'ledgerlivemobileTests' do
     inherit! :search_paths
     # Pods for testing

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@react-native-community/async-storage": "^1.12.1",
     "@react-native-community/clipboard": "^1.5.1",
     "@react-native-community/masked-view": "^0.1.7",
-    "@react-native-community/netinfo": "^5.5.1",
+    "@react-native-community/netinfo": "^6.0.0",
     "@react-navigation/bottom-tabs": "^5.11.2",
     "@react-navigation/material-top-tabs": "^5.3.10",
     "@react-navigation/native": "^5.8.10",

--- a/src/components/accountSyncRefreshControl.js
+++ b/src/components/accountSyncRefreshControl.js
@@ -7,6 +7,7 @@ import {
 } from "@ledgerhq/live-common/lib/bridge/react";
 import type { Sync } from "@ledgerhq/live-common/lib/bridge/react/types";
 import { useCountervaluesPolling } from "@ledgerhq/live-common/lib/countervalues/react";
+import { useNetInfo } from "@react-native-community/netinfo";
 import { SYNC_DELAY } from "../constants";
 
 type Props = {
@@ -25,6 +26,7 @@ export default (ScrollListLike: any) => {
     forwardedRef,
     ...scrollListLikeProps
   }: Props) {
+    const { isInternetReachable, isConnected } = useNetInfo();
     const { pending: isPending } = useAccountSyncState({ accountId });
     const setSyncBehavior = useBridgeSync();
     const { poll } = useCountervaluesPolling();
@@ -32,6 +34,7 @@ export default (ScrollListLike: any) => {
     const [refreshing, setRefreshing] = useState(false);
 
     function onPress() {
+      if (!isInternetReachable || !isConnected) return;
       poll();
       setSyncBehavior({
         type: "SYNC_ONE_ACCOUNT",

--- a/src/components/globalSyncRefreshControl.js
+++ b/src/components/globalSyncRefreshControl.js
@@ -4,6 +4,7 @@ import { RefreshControl } from "react-native";
 import { useBridgeSync } from "@ledgerhq/live-common/lib/bridge/react";
 import { useCountervaluesPolling } from "@ledgerhq/live-common/lib/countervalues/react";
 import { useTheme } from "@react-navigation/native";
+import { useNetInfo } from "@react-native-community/netinfo";
 import { SYNC_DELAY } from "../constants";
 
 type Props = {
@@ -15,12 +16,14 @@ type Props = {
 
 export default (ScrollListLike: any) => {
   function Inner({ forwardedRef, ...scrollListLikeProps }: Props) {
+    const { isInternetReachable, isConnected } = useNetInfo();
     const { colors, dark } = useTheme();
     const [refreshing, setRefreshing] = useState(false);
     const setSyncBehavior = useBridgeSync();
     const { poll } = useCountervaluesPolling();
 
     function onRefresh() {
+      if (!isInternetReachable || !isConnected) return;
       poll();
       setSyncBehavior({
         type: "SYNC_ALL_ACCOUNTS",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1703,10 +1703,10 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.7.tgz#a65ce0702f55cb67fd777995de6fc7b3e5781903"
   integrity sha512-9KbP7LTLFz9dx1heURJbO6nuVMdSjDez8znlrUzaB1nUwKVsTTwlKRuHxGUYIIkReLWrJQeCv9tidy+84z2eCw==
 
-"@react-native-community/netinfo@^5.5.1":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-5.5.1.tgz#6433d4d9d5fbe836f019e5a88a6a24b6e2dc50b9"
-  integrity sha512-6NKX/WzzC5FP2RSzoq+7CW/iIiRL2S6yN0JKiGvZ8EWAzJ43dbX5KG4kRa1JiKopAal5Vyh80dymbygeylwekQ==
+"@react-native-community/netinfo@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-6.0.0.tgz#2a4d7190b508dd0c2293656c9c1aa068f6f60a71"
+  integrity sha512-Z9M8VGcF2IZVOo2x+oUStvpCW/8HjIRi4+iQCu5n+PhC7OqCQX58KYAzdBr///alIfRXiu6oMb+lK+rXQH1FvQ==
 
 "@react-navigation/bottom-tabs@^5.11.2":
   version "5.11.2"


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(Network): prevent sync if no network - workarround for ios sync crash
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug Fix
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
LL-4768
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Workarround the ios sync crash bug on libcore related coins if no network
