### PR TITLE
LL-4771 Fix sorting for currency selector

### DIFF
--- a/src/components/FilteredSearchBar.js
+++ b/src/components/FilteredSearchBar.js
@@ -99,6 +99,7 @@ class FilteredSearchBar extends PureComponent<Props, State> {
           fuseOptions={{
             threshold: 0.1,
             keys,
+            shouldSort: false,
           }}
           value={query}
           items={list}


### PR DESCRIPTION
Once we start filtering on mobile on a select currency screen, we lose the marketcap sorting, this was due to a missing `shouldSort: false` option passed to `Fuse` which defaults to alphabetical sorting when not true.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-4771

### Parts of the app affected / Test plan

- Go to an add account flow
- Input "bit" as a search query
- Make sure Bitcoin is on top of the chain, not lower 