### PR TITLE
fix(AccountActions): wait BottomModal hide before navigate to avoid kb blur - LL-4696

### DIFF
--- a/src/screens/Account/AccountActions.js
+++ b/src/screens/Account/AccountActions.js
@@ -55,6 +55,7 @@ export default function AccountActions({ account, parentAccount }: Props) {
 
   const onNavigate = useCallback(
     (name: string, options?: NavOptions) => {
+      setNext();
       navigation.navigate(name, {
         ...options,
         params: {
@@ -86,7 +87,8 @@ export default function AccountActions({ account, parentAccount }: Props) {
 
   const goToNext = useCallback(() => {
     if (next) {
-      onNavigate(...next);
+      // workaround for bottom modal + text input autoFocus issue
+      setTimeout(() => onNavigate(...next), 0);
     }
   }, [onNavigate, next]);
 

--- a/src/screens/Account/AccountActions.js
+++ b/src/screens/Account/AccountActions.js
@@ -37,6 +37,7 @@ type NavOptions = {
 export default function AccountActions({ account, parentAccount }: Props) {
   const { colors } = useTheme();
   const [displayedActions, setDisplayedActions] = useState();
+  const [next, setNext] = useState();
   const navigation = useNavigation();
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const mainAccount = getMainAccount(account, parentAccount);
@@ -54,7 +55,6 @@ export default function AccountActions({ account, parentAccount }: Props) {
 
   const onNavigate = useCallback(
     (name: string, options?: NavOptions) => {
-      setDisplayedActions();
       navigation.navigate(name, {
         ...options,
         params: {
@@ -83,6 +83,12 @@ export default function AccountActions({ account, parentAccount }: Props) {
       screen: ScreenName.ReceiveConnectDevice,
     });
   }, [onNavigate]);
+
+  const goToNext = useCallback(() => {
+    if (next) {
+      onNavigate(...next);
+    }
+  }, [onNavigate, next]);
 
   return (
     <View style={styles.root}>
@@ -114,6 +120,7 @@ export default function AccountActions({ account, parentAccount }: Props) {
           <BottomModal
             isOpened={!!displayedActions}
             onClose={() => setDisplayedActions()}
+            onModalHide={() => goToNext()}
             containerStyle={styles.modal}
           >
             {displayedActions === "lending" && (
@@ -128,7 +135,8 @@ export default function AccountActions({ account, parentAccount }: Props) {
                     key={i}
                     onSelect={({ navigationParams, enableActions }) => {
                       if (navigationParams) {
-                        onNavigate(...navigationParams);
+                        setNext(navigationParams);
+                        setDisplayedActions();
                       }
                       if (enableActions) {
                         setDisplayedActions(enableActions);


### PR DESCRIPTION
fixes https://ledgerhq.atlassian.net/browse/LL-4696

### Type

Bug Fix

### Context

AccountActions are displayed as a BottomModal list of choices, that redirects to different flows / screens.
Since BottomModal is animated, it is finally hidden after the screen is display.
For some reason, if the next screen uses a keyboard (autofocus), the BottomModal animation end leads to Keyboard being dismissed. This can have other unwanted bugs.

### Parts of the app affected / Test plan

To avoid any conflict, this AccountActions components retains the next screen to go to, and waits for the Modal to be hidden before transitioning to next screen.

This leads to a slight delay, but avoids conflicts.

For Polkadot (and others having additional actions):
* tap on the more button
* tap on bond
* the bottom modal closes
* the bond flow starts

**I did not test on Android (only iOS).**

### Notes

This delay can be unwanted.
Other solution would be to add ref capabilities to CurrencyInput, then trigger the focus manually after a slight delay.
It's more complicated and specifically fixes the issue only for Polkadot - issue could reappear on other coins/flows.

I was unable to find why the keyboard is dismissed. `react-native-modal` uses a `InteractionManager.createInteractionHandle();` that could have this kind of side-effect.