### PR TITLE
LL-4353 (OperationDetails): add double countervalues

### DIFF
--- a/src/components/DoubleCountervalue.js
+++ b/src/components/DoubleCountervalue.js
@@ -1,0 +1,187 @@
+// @flow
+import React, { useState, useCallback, memo } from "react";
+import { TouchableOpacity, StyleSheet, View } from "react-native";
+import { BigNumber } from "bignumber.js";
+import { useSelector } from "react-redux";
+import type { Currency } from "@ledgerhq/live-common/lib/types";
+import { useCalculate } from "@ledgerhq/live-common/lib/countervalues/react";
+import { useTheme } from "@react-navigation/native";
+import { Trans } from "react-i18next";
+import { counterValueCurrencySelector } from "../reducers/settings";
+import CurrencyUnitValue from "./CurrencyUnitValue";
+import LText from "./LText";
+import InfoIcon from "../icons/Info";
+import BottomModal from "./BottomModal";
+import { localeIds } from "../languages";
+
+type Props = {
+  // wich market to query
+  currency: Currency,
+  date: Date,
+  compareDate?: Date,
+  value: BigNumber,
+  // display grey placeholder if no value
+  withPlaceholder?: boolean,
+  placeholderProps?: mixed,
+  // as we can't render View inside Text, provide ability to pass
+  // wrapper component from outside
+  Wrapper?: React$ComponentType<*>,
+  subMagnitude?: number,
+  tooltipDateLabel?: React$Node,
+  tooltipCompareDateLabel?: React$Node,
+};
+
+function DoubleCounterValue({
+  value,
+  date,
+  compareDate = new Date(),
+  withPlaceholder,
+  placeholderProps,
+  Wrapper,
+  currency,
+  tooltipDateLabel,
+  tooltipCompareDateLabel,
+  ...props
+}: Props) {
+  const { colors } = useTheme();
+  const [isOpened, setIsOpened] = useState(false);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+
+  const val = value.toNumber();
+
+  const countervalue = useCalculate({
+    from: currency,
+    to: counterValueCurrency,
+    value: val,
+    disableRounding: true,
+    date,
+  });
+
+  const compareCountervalue = useCalculate({
+    from: currency,
+    to: counterValueCurrency,
+    value: val,
+    disableRounding: true,
+    date: compareDate,
+  });
+
+  const onClose = useCallback(() => setIsOpened(false), []);
+  const onOpen = useCallback(() => setIsOpened(true), []);
+
+  if (typeof countervalue !== "number") {
+    return withPlaceholder ? <LText style={styles.placeholder}>-</LText> : null;
+  }
+
+  const inner = (
+    <>
+      <TouchableOpacity style={styles.root} onPress={onOpen}>
+        <LText style={styles.label} color="smoke">
+          <CurrencyUnitValue
+            {...props}
+            currency={currency}
+            unit={counterValueCurrency.units[0]}
+            value={BigNumber(countervalue)}
+          />
+        </LText>
+
+        <InfoIcon size={16} color={colors.grey} />
+      </TouchableOpacity>
+      <BottomModal isOpened={isOpened} onClose={onClose} style={styles.modal}>
+        <View style={styles.row}>
+          <View style={styles.column}>
+            <LText bold style={styles.title}>
+              <Trans i18nKey="common.transactionDate" />
+            </LText>
+            <LText style={styles.subtitle} color="grey">
+              {date.toLocaleDateString(localeIds, {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </LText>
+          </View>
+          <LText semiBold style={styles.amount} color="grey">
+            <CurrencyUnitValue
+              {...props}
+              currency={currency}
+              unit={counterValueCurrency.units[0]}
+              value={BigNumber(countervalue)}
+            />
+          </LText>
+        </View>
+        <View
+          style={[styles.separator, { backgroundColor: colors.lightFog }]}
+        />
+        <View style={styles.row}>
+          <View style={styles.column}>
+            <LText bold style={styles.title}>
+              <Trans i18nKey="common.today" />
+            </LText>
+            <LText style={styles.subtitle} color="grey">
+              {compareDate.toLocaleDateString(localeIds, {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </LText>
+          </View>
+          <LText semiBold style={styles.amount} color="grey">
+            <CurrencyUnitValue
+              {...props}
+              currency={currency}
+              unit={counterValueCurrency.units[0]}
+              value={BigNumber(compareCountervalue)}
+            />
+          </LText>
+        </View>
+      </BottomModal>
+    </>
+  );
+
+  if (Wrapper) {
+    return <Wrapper>{inner}</Wrapper>;
+  }
+
+  return inner;
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 16,
+  },
+  label: {
+    fontSize: 14,
+    marginRight: 8,
+  },
+  modal: {
+    paddingHorizontal: 16,
+    paddingTop: 24,
+    alignItems: "center",
+  },
+  row: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    width: "100%",
+  },
+  column: {
+    flexDirection: "column",
+    justifyContent: "flex-start",
+    alignItems: "flex-start",
+  },
+  title: {
+    fontSize: 13,
+  },
+  subtitle: {
+    fontSize: 12,
+    fontStyle: "italic",
+  },
+  placeholder: { fontSize: 16 },
+  amount: { fontSize: 12 },
+  separator: { width: "100%", height: 1, marginVertical: 16 },
+});
+
+export default memo<Props>(DoubleCounterValue);

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -34,6 +34,7 @@
     "today": "Today",
     "yesterday": "Yesterday",
     "upToDate": "Up to date",
+    "transactionDate": "Transaction date",
     "outdated": "Outdated",
     "satPerByte": "sat/bytes",
     "notAvailable": "Not available",
@@ -1768,7 +1769,7 @@
       },
       "payoutModal": {
         "title": "Payout fees",
-        "description":"Payout fees are not shown on the device and substracted from the amount.",
+        "description": "Payout fees are not shown on the device and substracted from the amount.",
         "cta": "Close"
       },
       "pendingOperation": {

--- a/src/screens/OperationDetails/Content.js
+++ b/src/screens/OperationDetails/Content.js
@@ -38,6 +38,7 @@ import Modal from "./Modal";
 import Section, { styles as sectionStyles } from "./Section";
 import byFamiliesOperationDetails from "../../generated/operationDetails";
 import DefaultOperationDetailsExtra from "./Extra";
+import DoubleCounterValue from "../../components/DoubleCountervalue";
 
 type HelpLinkProps = {
   event: string,
@@ -163,16 +164,14 @@ export default function Content({
         )}
 
         {hasFailed || amount.isZero() ? null : (
-          <LText semiBold style={styles.counterValue} color="smoke">
-            <CounterValue
-              showCode
-              alwaysShowSign
-              currency={currency}
-              value={amount}
-              date={operation.date}
-              subMagnitude={1}
-            />
-          </LText>
+          <DoubleCounterValue
+            showCode
+            alwaysShowSign
+            currency={currency}
+            value={amount}
+            date={operation.date}
+            subMagnitude={1}
+          />
         )}
 
         <View style={styles.confirmationContainer}>


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(OperationDetails): add double countervalues
show countervalues at tx date and today in a tooltip in operation details modal
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Feature
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
[LL-4353]
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
OperationDetails > countervalues > tooltip opens a modal with both countervalues


[LL-4353]: https://ledgerhq.atlassian.net/browse/LL-4353