### PR TITLE
LL-5171 (AccountCard): fix name + tag overlap issue

### DIFF
--- a/src/components/AccountCard.js
+++ b/src/components/AccountCard.js
@@ -56,7 +56,7 @@ class AccountCard extends PureComponent<Props> {
           currency={currency}
         />
         <View style={styles.accountName}>
-          <View>
+          <View style={styles.accountNameContainer}>
             <LText
               semiBold
               numberOfLines={1}
@@ -128,6 +128,7 @@ const styles = StyleSheet.create({
     marginLeft: 16,
     alignItems: "flex-end",
   },
+  accountNameContainer: { flexShrink: 1 },
 });
 
 export default withTheme(AccountCard);


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(AccountCard): fix name + tag overlap issue

![Screenshot_2021-04-06-18-48-31-502_com ledger live debug](https://user-images.githubusercontent.com/11752937/113748546-e60bd600-9708-11eb-94c3-5b32e5f20b1e.jpg)


### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI Polish
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
[LL-5171]
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Account card  on add flow with long name should no longer overlap on chain type tag 



[LL-5171]: https://ledgerhq.atlassian.net/browse/LL-5171