### PR TITLE
LL-5147 Go back to swap after add accounts

### DIFF
--- a/src/components/RootNavigator/AddAccountsNavigator.js
+++ b/src/components/RootNavigator/AddAccountsNavigator.js
@@ -15,7 +15,7 @@ import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import StepHeader from "../StepHeader";
 
 type Route = {
-  params: ?{ currency: *, token?: * },
+  params: ?{ currency: *, token?: *, returnToSwap?: boolean },
 };
 
 const totalSteps = "3";
@@ -25,6 +25,7 @@ export default function AddAccountsNavigator({ route }: { route: Route }) {
   const { t } = useTranslation();
   const currency = route && route.params && route.params.currency;
   const token = route && route.params && route.params.token;
+  const returnToSwap = route && route.params && route.params.returnToSwap;
   const stackNavConfig = useMemo(() => getStackNavigatorConfig(colors), [
     colors,
   ]);
@@ -61,7 +62,9 @@ export default function AddAccountsNavigator({ route }: { route: Route }) {
       <Stack.Screen
         name={ScreenName.AddAccountsSelectDevice}
         component={AddAccountsSelectDevice}
-        initialParams={currency ? { currency, inline: true } : undefined}
+        initialParams={
+          currency ? { currency, inline: true, returnToSwap } : undefined
+        }
         options={{
           headerTitle: () => (
             <StepHeader

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -2302,6 +2302,7 @@
     "retry": "Retry",
     "done": "Done",
     "finalCta": "Continue",
+    "finalCtaForSwap": "Go back to Swap",
     "synchronizing": "Synchronizing",
     "synchronizingDesc": "Your accounts are being synchronized. This can take a while...",
     "noAccountToCreate": "Could not create <1><0>{{currencyName}}</></> account. Restart the process and sync your accounts.",

--- a/src/screens/AddAccounts/02-SelectDevice.js
+++ b/src/screens/AddAccounts/02-SelectDevice.js
@@ -22,6 +22,7 @@ type Props = {
 type RouteParams = {
   currency: CryptoCurrency,
   inline?: boolean,
+  returnToSwap?: boolean,
 };
 
 const action = createAction(connectApp);
@@ -37,10 +38,11 @@ export default function AddAccountsSelectDevice({ navigation, route }: Props) {
   const onResult = useCallback(
     meta => {
       setDevice();
-      const { currency, inline } = route.params;
+      const { currency, inline, returnToSwap } = route.params;
       const arg = {
         currency,
         inline,
+        returnToSwap,
         ...meta,
       };
       if (inline) {

--- a/src/screens/AddAccounts/03-Accounts.js
+++ b/src/screens/AddAccounts/03-Accounts.js
@@ -72,6 +72,7 @@ type RouteParams = {
   currency: CryptoCurrency,
   device: Device,
   inline?: boolean,
+  returnToSwap?: boolean,
 };
 
 type OwnProps = {};
@@ -124,6 +125,7 @@ function AddAccountsAccounts({
     currency,
     device: { deviceId },
     inline,
+    returnToSwap,
   } = route.params || {};
 
   const newAccountSchemes = getPreferredNewAccountScheme(currency);
@@ -435,6 +437,7 @@ function AddAccountsAccounts({
           onContinue={importAccount}
           isDisabled={selectedIds.length === 0}
           colors={colors}
+          returnToSwap={returnToSwap}
         />
       )}
       <GenericErrorBottomModal
@@ -529,6 +532,7 @@ class Footer extends PureComponent<{
   isDisabled: boolean,
   supportLink?: AddAccountSupportLink,
   colors: *,
+  returnToSwap?: boolean,
 }> {
   render() {
     const {
@@ -541,6 +545,7 @@ class Footer extends PureComponent<{
       onRetry,
       onDone,
       colors,
+      returnToSwap,
     } = this.props;
 
     return (
@@ -571,7 +576,13 @@ class Footer extends PureComponent<{
           <Button
             event="AddAccountsSelected"
             type="primary"
-            title={<Trans i18nKey="addAccounts.finalCta" />}
+            title={
+              returnToSwap ? (
+                <Trans i18nKey="addAccounts.finalCtaForSwap" />
+              ) : (
+                <Trans i18nKey="addAccounts.finalCta" />
+              )
+            }
             onPress={isDisabled ? undefined : onContinue}
           />
         )}

--- a/src/screens/Swap/Form/SelectAccount/NoAccountsEmptyState.js
+++ b/src/screens/Swap/Form/SelectAccount/NoAccountsEmptyState.js
@@ -21,8 +21,8 @@ const NoAccountsEmptyState = ({
       navigate(
         NavigatorName.AddAccounts,
         selectedCurrency.type === "TokenCurrency"
-          ? { token: selectedCurrency }
-          : { selectedCurrency },
+          ? { token: selectedCurrency, returnToSwap: true }
+          : { currency: selectedCurrency, returnToSwap: true },
       ),
     [navigate, selectedCurrency],
   );
@@ -53,7 +53,7 @@ const NoAccountsEmptyState = ({
       <View style={styles.buttonContainer}>
         <Button
           containerStyle={styles.button}
-          event="ExchangeStartBuyFlow"
+          event="ExchangeStartSwapFlow"
           type="primary"
           title={<Trans i18nKey={"transfer.swap.emptyState.CTAButton"} />}
           onPress={onAddAccount}


### PR DESCRIPTION
When doing a swap, if we select a destination currency where we dont have any added accounts **yet**, the current flow will lead the user to the `add accounts` flow and leave the swap one. This is a regression, the `add accounts` flow used to be launched inline and go back to swap after completion.

This brings that behaviour back and changes the CTA of the import to "go back to swap.

**Note** There's a discrepancy with what's listed in the Jira ticket. In the specs we reach the success step, but on the implementation we leave the accounts flow after the import step. So one step less, and we are back on Swap, like before.

### Type

Bug Fix + changes

### Context

https://ledgerhq.atlassian.net/browse/LL-5147

### Parts of the app affected / Test plan

- Test the account selection flow on swap as described above
- Test the add account flow to make sure this doesn't affect it. (bad literals, or broken buttons for instance)