### PR TITLE
LL-3067 - fix: allow EarnRewards multiline bullet list item for TRX / DOT

### DIFF
--- a/src/families/polkadot/BondFlow/01-Started.js
+++ b/src/families/polkadot/BondFlow/01-Started.js
@@ -137,7 +137,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
   },
   bulletItemContainer: {
-    height: 48,
+    minHeight: 48,
   },
   bulletItem: {
     fontSize: 14,

--- a/src/screens/FreezeFunds/01-Info.js
+++ b/src/screens/FreezeFunds/01-Info.js
@@ -51,8 +51,8 @@ export default function FreezeInfo({ navigation, route }: Props) {
           <Trans i18nKey="freeze.info.description" />
         </LText>
         <BulletList
-          style={{ paddingHorizontal: 16 }}
-          itemContainerStyle={{ height: 48 }}
+          style={styles.bulletList}
+          itemContainerStyle={styles.bulletItemContainer}
           Bullet={BulletGreenCheck}
           list={[
             <Trans i18nKey="freeze.info.steps.0" />,
@@ -119,6 +119,12 @@ const styles = StyleSheet.create({
     textAlign: "center",
     marginVertical: 16,
     paddingHorizontal: 32,
+  },
+  bulletList: {
+    paddingHorizontal: 16,
+  },
+  bulletItemContainer: {
+    minHeight: 48,
   },
   bulletItem: {
     fontSize: 14,


### PR DESCRIPTION
### Type

UI BugFix

### Context

In EarnRewards modals (on TRON or POLKADOT), bullet list items are cropped if screen is small (e.g. iPhone SE).
Fix allows for bullet list items to go on multiple lines.

### Parts of the app affected / Test plan

<img src="https://user-images.githubusercontent.com/70533374/115446045-ecc13f80-a216-11eb-937f-ca0ab71696eb.png" width="200" /><img src="https://user-images.githubusercontent.com/70533374/115446106-02cf0000-a217-11eb-9fcc-b22897608a77.png" width="200" />

