### PR TITLE
LL-5256 (NotificationCenter): show status incident notif in portfolio

### DIFF
--- a/src/screens/Portfolio/Header.js
+++ b/src/screens/Portfolio/Header.js
@@ -17,6 +17,7 @@ import BellIcon from "../../icons/Bell";
 import { NavigatorName, ScreenName } from "../../const";
 import { scrollToTop } from "../../navigation/utils";
 import LText from "../../components/LText";
+import Warning from "../../icons/WarningOutline";
 
 type Props = {
   showDistribution?: boolean,
@@ -43,11 +44,17 @@ export default function PortfolioHeader({
     navigation.navigate(NavigatorName.NotificationCenter);
   }, [navigation]);
 
+  const onStatusErrorButtonPress = useCallback(() => {
+    navigation.navigate(NavigatorName.NotificationCenter, {
+      screen: ScreenName.NotificationCenterStatus,
+    });
+  }, [navigation]);
+
   const isUpToDate = useSelector(isUpToDateSelector);
   const networkError = useSelector(networkErrorSelector);
   const { pending, error } = useGlobalSyncState();
 
-  const notificationsCount = allIds.length - seenIds.length + incidents.length;
+  const notificationsCount = allIds.length - seenIds.length;
 
   const content =
     pending && !isUpToDate ? (
@@ -100,6 +107,13 @@ export default function PortfolioHeader({
           <BellIcon size={18} color={colors.grey} />
         </Touchable>
       </View>
+      {incidents.length > 0 && (
+        <View style={[styles.distributionButton, styles.marginLeft]}>
+          <Touchable onPress={onStatusErrorButtonPress}>
+            <Warning size={22} color={colors.orange} />
+          </Touchable>
+        </View>
+      )}
     </View>
   );
 }


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(NotificationCenter): show status incident notif in portfolio

![Screenshot_2021-04-27-14-22-06-277_com ledger live debug](https://user-images.githubusercontent.com/11752937/116240779-81bac000-a764-11eb-8ee6-bd97919cf1c4.jpg)


### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
UI Polish
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
[LL-5256]
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Portfolio page should show a warning icon next to notification bell if a status incident is ongoing


[LL-5256]: https://ledgerhq.atlassian.net/browse/LL-5256