### PR TITLE
LL-5429 Rename exported logs file

### DIFF
--- a/src/components/GenericErrorView.js
+++ b/src/components/GenericErrorView.js
@@ -14,7 +14,6 @@ import logReport from "../log-report";
 import Button from "./Button";
 import DownloadFileIcon from "../icons/DownloadFile";
 import cleanBuildVersion from "../logic/cleanBuildVersion";
-import { localeIds } from "../languages";
 
 class GenericErrorView extends PureComponent<{
   error: Error,

--- a/src/components/GenericErrorView.js
+++ b/src/components/GenericErrorView.js
@@ -4,6 +4,7 @@ import { View, StyleSheet } from "react-native";
 
 import Share from "react-native-share";
 import { Trans } from "react-i18next";
+import VersionNumber from "react-native-version-number";
 import LText from "./LText";
 import ErrorIcon from "./ErrorIcon";
 import TranslatedError from "./TranslatedError";
@@ -12,6 +13,8 @@ import logger from "../logger";
 import logReport from "../log-report";
 import Button from "./Button";
 import DownloadFileIcon from "../icons/DownloadFile";
+import cleanBuildVersion from "../logic/cleanBuildVersion";
+import { localeIds } from "../languages";
 
 class GenericErrorView extends PureComponent<{
   error: Error,
@@ -30,14 +33,19 @@ class GenericErrorView extends PureComponent<{
 
   onExport = async () => {
     const logs = logReport.getLogs();
-    const message = logs.map(log => JSON.stringify(log)).join("\n");
-    const base64 = Buffer.from(message).toString("base64");
+    const base64 = Buffer.from(JSON.stringify(logs)).toString("base64");
+    const { appVersion, buildVersion } = VersionNumber;
+    const version = `${appVersion || ""}-(${cleanBuildVersion(buildVersion) ||
+      ""})`;
+    const date = new Date().toISOString().split("T")[0];
+
+    const humanReadableName = `ledger-live-mob-${version}-${date}-logs`;
 
     const options = {
       failOnCancel: false,
       saveToFiles: true,
       type: "application/json",
-      filename: "logs",
+      filename: humanReadableName,
       url: `data:application/json;base64,${base64}`,
     };
 

--- a/src/screens/DebugCrash.js
+++ b/src/screens/DebugCrash.js
@@ -6,7 +6,6 @@ import { Sentry } from "react-native-sentry";
 
 import Button from "../components/Button";
 import GenericErrorView from "../components/GenericErrorView";
-import BottomModal from "../components/GenericErrorView";
 
 class DebugBLE extends Component<
   {

--- a/src/screens/DebugCrash.js
+++ b/src/screens/DebugCrash.js
@@ -5,6 +5,8 @@ import { StyleSheet, View } from "react-native";
 import { Sentry } from "react-native-sentry";
 
 import Button from "../components/Button";
+import GenericErrorView from "../components/GenericErrorView";
+import BottomModal from "../components/GenericErrorView";
 
 class DebugBLE extends Component<
   {
@@ -12,10 +14,12 @@ class DebugBLE extends Component<
   },
   {
     renderCrash: boolean,
+    renderErrorModal: boolean,
   },
 > {
   state = {
     renderCrash: false,
+    renderErrorModal: false,
   };
 
   jsCrash = () => {
@@ -27,9 +31,10 @@ class DebugBLE extends Component<
   };
 
   displayRenderCrash = () => this.setState({ renderCrash: true });
+  displayErrorModal = () => this.setState({ renderErrorModal: true });
 
   render() {
-    const { renderCrash } = this.state;
+    const { renderCrash, renderErrorModal } = this.state;
     return (
       <View style={styles.root}>
         <Button
@@ -49,26 +54,40 @@ class DebugBLE extends Component<
         <Button
           event="DebugCrashRender"
           type="primary"
-          title="Render crashing component"
+          title="Render unhandled error"
           onPress={this.displayRenderCrash}
           containerStyle={styles.buttonStyle}
         />
+        <Button
+          event="DebugCrashRender"
+          type="primary"
+          title="Render handled error component"
+          onPress={this.displayErrorModal}
+          containerStyle={styles.buttonStyle}
+        />
         {renderCrash && <CrashingComponent />}
+        {renderErrorModal && <CrashingComponent handled />}
       </View>
     );
   }
 }
 
-const CrashingComponent = () => {
-  throw new Error("DEBUG renderCrash");
+const CrashingComponent = ({ handled }: { handled?: boolean }) => {
+  const error = new Error("DEBUG render crash error");
+  if (handled) {
+    return <GenericErrorView error={error} />;
+  }
+
+  throw error;
 };
 
 const styles = StyleSheet.create({
   root: {
     padding: 16,
+    flex: 1,
   },
   buttonStyle: {
-    marginBottom: 16,
+    marginBottom: 8,
   },
 });
 


### PR DESCRIPTION
Added a more meaningful name for the exported logs on LLM, note that this does not work for iOS since there's a limitation on the library we use so it will continue to default to `file.json` for that platform. On Android however, it will now follow a naming format such as `ledger-live-mob-2.26.0-(arm64-v8a 156)-2021-05-10-logs.json` which should be a lot more meaningful.

> I noticed while looking at the logs that the output was not a valid JSON string so I fixed that, but still, the exported logs are not as useful as the desktop ones and we should add more information to them such as the number of accounts, etc. Perhaps this is a good next iteration to consider cc @gre @cthepot-ledger 

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-5429

### Parts of the app affected / Test plan

Since triggering the generic error component was a pita, I've added a trigger to the Debug Crash screen on the hidden debug menu, which allows QA to render the component without triggering an actual error. Just go to the `Debug menu ⇨ Mock & Test ⇨ Debug crash` and trigger it from there.

![image](https://user-images.githubusercontent.com/4631227/117640461-59c85500-b185-11eb-806d-26f54c19b6e0.png)
