### PR TITLE
LL-5273 Allow access to swap feature without the device wall

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@ledgerhq/hw-app-xrp": "5.51.1",
     "@ledgerhq/hw-transport": "5.51.1",
     "@ledgerhq/hw-transport-http": "5.51.1",
-    "@ledgerhq/live-common": "19.9.0",
+    "@ledgerhq/live-common": "19.9.0-beta.2",
     "@ledgerhq/logs": "5.50.0",
     "@ledgerhq/react-native-hid": "5.51.1",
     "@ledgerhq/react-native-hw-transport-ble": "5.51.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@ledgerhq/hw-app-xrp": "5.51.1",
     "@ledgerhq/hw-transport": "5.51.1",
     "@ledgerhq/hw-transport-http": "5.51.1",
-    "@ledgerhq/live-common": "19.9.0-beta.2",
+    "@ledgerhq/live-common": "19.9.1",
     "@ledgerhq/logs": "5.50.0",
     "@ledgerhq/react-native-hid": "5.51.1",
     "@ledgerhq/react-native-hw-transport-ble": "5.51.1",

--- a/src/components/DeviceAction/index.js
+++ b/src/components/DeviceAction/index.js
@@ -27,6 +27,7 @@ import SkipLock from "../behaviour/SkipLock";
 
 type Props<R, H, P> = {
   onResult?: (payload: *) => Promise<void> | void,
+  onError?: (payload: *) => Promise<void> | void,
   renderOnResult?: (payload: P) => React$Node,
   action: Action<R, H, P>,
   request?: R,
@@ -38,6 +39,7 @@ export default function DeviceAction<R, H, P>({
   request = null,
   device: selectedDevice,
   onResult,
+  onError,
   renderOnResult,
 }: Props<R, H, P>) {
   const { colors, dark } = useTheme();
@@ -178,6 +180,7 @@ export default function DeviceAction<R, H, P>({
   }
 
   if (!isLoading && error) {
+    onError && onError(error);
     return renderError({
       t,
       navigation,

--- a/src/components/DeviceAction/index.js
+++ b/src/components/DeviceAction/index.js
@@ -111,11 +111,13 @@ export default function DeviceAction<R, H, P>({
   }
 
   if (requiresAppInstallation) {
-    const { appName } = requiresAppInstallation;
+    const { appName, appNames: maybeAppNames } = requiresAppInstallation;
+    const appNames = maybeAppNames?.length ? maybeAppNames : [appName];
+
     return renderRequiresAppInstallation({
       t,
       navigation,
-      appName,
+      appNames,
       colors,
       theme,
     });

--- a/src/components/DeviceAction/rendering.js
+++ b/src/components/DeviceAction/rendering.js
@@ -21,7 +21,7 @@ import Circle from "../Circle";
 import { MANAGER_TABS } from "../../screens/Manager/Manager";
 
 type RawProps = {
-  t: (key: string, options?: { [key: string]: string }) => string,
+  t: (key: string, options?: { [key: string]: string | number }) => string,
   colors?: *,
   theme?: "light" | "dark",
 };
@@ -51,16 +51,21 @@ export function renderRequestQuitApp({
 export function renderRequiresAppInstallation({
   t,
   navigation,
-  appName,
+  appNames,
 }: {
   ...RawProps,
   navigation: any,
-  appName: string,
+  appNames: string[],
 }) {
+  const appNamesCSV = appNames.join(", ");
+
   return (
     <View style={styles.wrapper}>
       <LText style={styles.text} semiBold>
-        {t("DeviceAction.appNotInstalled", { appName })}
+        {t("DeviceAction.appNotInstalled", {
+          appName: appNamesCSV,
+          count: appNames.length,
+        })}
       </LText>
       <View style={styles.actionContainer}>
         <Button

--- a/src/components/DeviceAction/rendering.js
+++ b/src/components/DeviceAction/rendering.js
@@ -72,7 +72,12 @@ export function renderRequiresAppInstallation({
           event="DeviceActionRequiresAppInstallationOpenManager"
           type="primary"
           title={t("DeviceAction.button.openManager")}
-          onPress={() => navigation.navigate(NavigatorName.Manager)}
+          onPress={() =>
+            navigation.navigate(NavigatorName.Manager, {
+              screen: ScreenName.Manager,
+              params: { searchQuery: appNamesCSV },
+            })
+          }
           containerStyle={styles.button}
         />
       </View>

--- a/src/components/StepHeader.js
+++ b/src/components/StepHeader.js
@@ -13,9 +13,11 @@ export default function StepHeader({ title, subtitle }: Props) {
   return (
     <TouchableWithoutFeedback onPress={scrollToTop}>
       <View style={styles.root}>
-        <LText style={styles.subtitle} color="grey">
-          {subtitle}
-        </LText>
+        {subtitle ? (
+          <LText style={styles.subtitle} color="grey">
+            {subtitle}
+          </LText>
+        ) : null}
         <LText semiBold secondary numberOfLines={1} style={styles.title}>
           {title}
         </LText>
@@ -27,12 +29,12 @@ export default function StepHeader({ title, subtitle }: Props) {
 const styles = StyleSheet.create({
   root: {
     flexDirection: "column",
+    justifyContent: "center",
     flex: 1,
     paddingVertical: 5,
   },
   title: {
     textAlign: "center",
-    flexGrow: 1,
     fontSize: 16,
   },
   subtitle: {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -2380,6 +2380,7 @@
     "outdatedDesc": "An important update is available for the {{appName}} application on your device. Please go to the Manager to update it.",
     "quitApp": "Quit the application on your device",
     "appNotInstalled": "Please install the {{appName}} app",
+    "appNotInstalled_plural": "Please install the {{appName}} apps",
     "verifyAddress": {
       "title": "Verify address on device",
       "description": "Please verify that the {{currencyName}} address to be shown in Ledger Live matches the one on your Ledger device."

--- a/src/screens/Swap/Confirmation.js
+++ b/src/screens/Swap/Confirmation.js
@@ -137,6 +137,7 @@ const Confirmation = ({
                 key={"initSwap"}
                 action={swapAction}
                 device={deviceMeta.device}
+                onError={onError}
                 request={{
                   exchange,
                   exchangeRate,

--- a/src/screens/Swap/Connect.js
+++ b/src/screens/Swap/Connect.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import { Trans } from "react-i18next";
 import { View, StyleSheet } from "react-native";
 import connectManager from "@ledgerhq/live-common/lib/hw/connectManager";
@@ -15,6 +15,16 @@ const action = createAction(connectManager);
 
 const Connect = ({ setResult }: { setResult: (result: any) => void }) => {
   const [device, setDevice] = useState(null);
+  const [result, setLocalResult] = useState();
+
+  const onModalHide = useCallback(() => {
+    if (result) {
+      // Nb need this in order to wait for the first modal to hide
+      // see https://github.com/react-native-modal/react-native-modal#i-cant-show-multiple-modals-one-after-another
+      setResult(result);
+    }
+  }, [result, setResult]);
+
   const { colors } = useTheme();
   return (
     <View style={[styles.root, { backgroundColor: colors.background }]}>
@@ -25,8 +35,9 @@ const Connect = ({ setResult }: { setResult: (result: any) => void }) => {
       <SelectDevice onSelect={setDevice} autoSelectOnAdd />
       <DeviceActionModal
         onClose={setDevice}
-        device={device}
-        onResult={setResult}
+        onModalHide={onModalHide}
+        device={result ? null : device}
+        onResult={setLocalResult}
         action={action}
         request={null}
       />

--- a/src/screens/Swap/Form/Summary/index.js
+++ b/src/screens/Swap/Form/Summary/index.js
@@ -43,6 +43,7 @@ const SwapFormSummary = ({ navigation, route }: Props) => {
   const reset = useCallback(() => {
     setConfirmed(false);
     setAcceptedDisclaimer(false);
+    setDeviceMeta(null);
   }, [setAcceptedDisclaimer, setConfirmed]);
 
   const onRatesExpired = useCallback(() => {

--- a/src/screens/Swap/Form/Summary/index.js
+++ b/src/screens/Swap/Form/Summary/index.js
@@ -12,6 +12,7 @@ import DisclaimerModal from "../DisclaimerModal";
 import Button from "../../../../components/Button";
 import Confirmation from "../../Confirmation";
 import SummaryBody from "./SummaryBody";
+import Connect from "../../Connect";
 import { ScreenName } from "../../../../const";
 import CountdownTimer from "../../../../components/CountdownTimer";
 import { Track, TrackScreen } from "../../../../analytics";
@@ -31,13 +32,13 @@ const SwapFormSummary = ({ navigation, route }: Props) => {
     exchangeRate,
     transaction,
     status,
-    deviceMeta,
     rateExpiration,
   } = route.params;
 
   const { colors } = useTheme();
 
   const [confirmed, setConfirmed] = useState(false);
+  const [deviceMeta, setDeviceMeta] = useState();
   const [acceptedDisclaimer, setAcceptedDisclaimer] = useState(false);
   const reset = useCallback(() => {
     setConfirmed(false);
@@ -53,20 +54,33 @@ const SwapFormSummary = ({ navigation, route }: Props) => {
     }
   }, [exchangeRate.tradeMethod, navigation, reset]);
 
+  const showDeviceConnect = confirmed && acceptedDisclaimer && !deviceMeta;
+  const padding = showDeviceConnect ? 0 : 16;
+
   return status && transaction ? (
     <SafeAreaView
-      style={[styles.root, { backgroundColor: colors.background }]}
+      style={[
+        styles.root,
+        {
+          backgroundColor: colors.background,
+          padding,
+        },
+      ]}
       forceInset={forceInset}
     >
       <TrackScreen category="Swap" name="Summary" />
-      <SummaryBody
-        exchange={exchange}
-        exchangeRate={exchangeRate}
-        status={status}
-      />
+      {!showDeviceConnect ? (
+        <SummaryBody
+          exchange={exchange}
+          exchangeRate={exchangeRate}
+          status={status}
+        />
+      ) : (
+        <Connect setResult={setDeviceMeta} />
+      )}
 
       {confirmed ? (
-        acceptedDisclaimer ? (
+        acceptedDisclaimer && deviceMeta ? (
           <>
             <Track onUpdate event={"SwapAcceptedSummaryDisclaimer"} />
             <Confirmation
@@ -82,14 +96,14 @@ const SwapFormSummary = ({ navigation, route }: Props) => {
               onCancel={reset}
             />
           </>
-        ) : (
+        ) : !acceptedDisclaimer ? (
           <DisclaimerModal
             provider={exchangeRate.provider}
             onContinue={() => setAcceptedDisclaimer(true)}
             onClose={() => setConfirmed(false)}
           />
-        )
-      ) : (
+        ) : null
+      ) : !showDeviceConnect ? (
         <View style={styles.buttonWrapper}>
           {exchangeRate.tradeMethod === "fixed" ? (
             <View
@@ -116,7 +130,7 @@ const SwapFormSummary = ({ navigation, route }: Props) => {
             containerStyle={styles.button}
           />
         </View>
-      )}
+      ) : null}
     </SafeAreaView>
   ) : null;
 };

--- a/src/screens/Swap/Form/index.js
+++ b/src/screens/Swap/Form/index.js
@@ -5,7 +5,6 @@ import React, { useCallback, useMemo } from "react";
 import { TouchableOpacity, StyleSheet, View } from "react-native";
 import { Trans } from "react-i18next";
 import { useSelector } from "react-redux";
-import { getCurrenciesWithStatus } from "@ledgerhq/live-common/lib/exchange/swap/logic";
 import type { CurrenciesStatus } from "@ledgerhq/live-common/lib/exchange/swap/logic";
 import type {
   Exchange,
@@ -38,7 +37,6 @@ import SectionSeparator, {
 import CurrencyIcon from "../../../components/CurrencyIcon";
 import LText from "../../../components/LText";
 import Button from "../../../components/Button";
-import { flattenAccountsSelector } from "../../../reducers/accounts";
 import { flattenedSwapSupportedCurrenciesSelector } from "../../../reducers/settings";
 import { TrackScreen } from "../../../analytics";
 
@@ -54,7 +52,6 @@ export type SwapRouteParams = {
   providers: any,
   installedApps: any,
   target: "from" | "to",
-  deviceMeta: DeviceMeta,
   rateExpiration?: Date,
 };
 
@@ -63,36 +60,21 @@ export type DeviceMeta = {
   device: Device,
   deviceInfo: DeviceInfo,
 };
+
 const Form = ({
   providers,
-  deviceMeta,
   defaultAccount,
   defaultParentAccount,
 }: {
   providers: any,
-  deviceMeta: DeviceMeta,
   defaultAccount: ?AccountLike,
   defaultParentAccount: ?Account,
 }) => {
   const { colors } = useTheme();
   const { navigate } = useNavigation();
-  const { result } = deviceMeta;
-  const { installed: installedApps } = result;
   const route = useRoute();
-  const accounts = useSelector(flattenAccountsSelector);
   const flattenedCurrencies = useSelector(
     flattenedSwapSupportedCurrenciesSelector,
-  );
-
-  const currenciesStatus = useMemo(
-    () =>
-      getCurrenciesWithStatus({
-        // $FlowFixMe
-        accounts,
-        installedApps,
-        selectableCurrencies: flattenedCurrencies,
-      }),
-    [accounts, installedApps, flattenedCurrencies],
   );
 
   const exchange = useMemo(
@@ -116,28 +98,18 @@ const Form = ({
       navigate(ScreenName.SwapFormSelectCrypto, {
         target,
         providers,
-        installedApps,
         exchange: exchange || {},
         selectableCurrencies: flattenedCurrencies,
-        currenciesStatus,
       });
     },
-    [
-      navigate,
-      providers,
-      installedApps,
-      exchange,
-      flattenedCurrencies,
-      currenciesStatus,
-    ],
+    [navigate, providers, exchange, flattenedCurrencies],
   );
 
   const onContinue = useCallback(() => {
     navigate(ScreenName.SwapFormAmount, {
       ...route.params,
-      deviceMeta,
     });
-  }, [navigate, deviceMeta, route.params]);
+  }, [navigate, route.params]);
 
   const canContinue = useMemo(() => {
     if (!exchange) return false;

--- a/src/screens/Swap/Swap.js
+++ b/src/screens/Swap/Swap.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import { StyleSheet, View, ActivityIndicator } from "react-native";
 import { getProviders } from "@ledgerhq/live-common/lib/exchange/swap";
 import { SwapNoAvailableProviders } from "@ledgerhq/live-common/lib/errors";
@@ -16,11 +16,9 @@ import {
   swapProvidersSelector,
 } from "../../reducers/settings";
 import { setSwapProviders } from "../../actions/settings";
-import MissingOrOutdatedSwapApp from "./MissingOrOutdatedSwapApp";
 import Landing from "./Landing";
 import NotAvailable from "./NotAvailable";
 import Form from "./Form";
-import Connect from "./Connect";
 
 const Swap = ({
   defaultAccount,
@@ -34,7 +32,6 @@ const Swap = ({
   const providers = useSelector(swapProvidersSelector);
   const hasAcceptedSwapKYC = useSelector(hasAcceptedSwapKYCSelector);
   const [hasUpToDateProviders, setHasUpToDateProviders] = useState(false);
-  const [deviceMeta, setDeviceMeta] = useState();
 
   useEffect(() => {
     if (hasAcceptedSwapKYC) {
@@ -51,17 +48,6 @@ const Swap = ({
     }
   }, [dispatch, hasAcceptedSwapKYC]);
 
-  const onSetResult = useCallback(
-    data => {
-      if (!data) return;
-      setDeviceMeta(data);
-    },
-    [setDeviceMeta],
-  );
-
-  const exchangeApp = deviceMeta?.result?.installed.find(
-    a => a.name === "Exchange",
-  );
   return (
     <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>
       {!hasAcceptedSwapKYC ? (
@@ -72,20 +58,13 @@ const Swap = ({
         </View>
       ) : !providers?.length ? (
         <NotAvailable />
-      ) : !deviceMeta?.result?.installed ? (
-        <Connect setResult={onSetResult} />
-      ) : !exchangeApp ? (
-        <MissingOrOutdatedSwapApp />
-      ) : !exchangeApp.updated ? (
-        <MissingOrOutdatedSwapApp outdated />
-      ) : deviceMeta ? (
+      ) : (
         <Form
-          deviceMeta={deviceMeta}
           providers={providers}
           defaultAccount={defaultAccount}
           defaultParentAccount={defaultParentAccount}
         />
-      ) : null}
+      )}
     </SafeAreaView>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,14 +1126,31 @@
   dependencies:
     commander "^2.20.0"
 
-"@ledgerhq/cryptoassets@5.51.0", "@ledgerhq/cryptoassets@^5.51.0":
+"@ledgerhq/cryptoassets@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-5.50.0.tgz#16b1ebc414381b61ffcac5595880cd1eb940dfba"
+  integrity sha512-+VGfu+OHyPLBMasprOHkaesBHkE2R5DAdYQqSuAC1vW2WPZ6tyLyZqytmconl4npDzI6Z8EXxOmdnnXYdOArJw==
+  dependencies:
+    invariant "2"
+
+"@ledgerhq/cryptoassets@^5.50.0", "@ledgerhq/cryptoassets@^5.51.0":
   version "5.51.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-5.51.0.tgz#3781914720ac3a8311ac492fa036806d36337abb"
   integrity sha512-62GLlkQfbdxS9nqY64YuLq2udDZX4T+xpxH1b8JKAhc4Wocr2CfU4Jbb/W85ZTbYV/phNUQ0tel3dhW885WUpQ==
   dependencies:
     invariant "2"
 
-"@ledgerhq/devices@5.51.1", "@ledgerhq/devices@^5.51.1":
+"@ledgerhq/devices@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.50.0.tgz#4bfc375d9781fff6bd772b7914211df547574649"
+  integrity sha512-VU3i48egHwUSHqNPKa8dNXLxD6gvmPKbKkp2pGL8tNNGXT44iHWplEAQy7et7+Fa48Sh7G2WPBvCbQg9K/SeCw==
+  dependencies:
+    "@ledgerhq/errors" "^5.50.0"
+    "@ledgerhq/logs" "^5.50.0"
+    rxjs "^6.6.7"
+    semver "^7.3.5"
+
+"@ledgerhq/devices@5.51.1", "@ledgerhq/devices@^5.50.0", "@ledgerhq/devices@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.51.1.tgz#d741a4a5d8f17c2f9d282fd27147e6fe1999edb7"
   integrity sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==
@@ -1148,7 +1165,7 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.50.0.tgz#e3a6834cb8c19346efca214c1af84ed28e69dad9"
   integrity sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow==
 
-"@ledgerhq/hw-app-algorand@^5.51.1":
+"@ledgerhq/hw-app-algorand@^5.50.0":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-algorand/-/hw-app-algorand-5.51.1.tgz#62f6c85afeef6f0e62b9cc34a9bef7a223bdfe42"
   integrity sha512-Y24sCVyQq+g9B5GfaaEpLvxwixWYbRN1FtCFZOrSoM8cxpNsC/werIPw22S6WuHd+YyxJV+mGemKM+2+u3nnnw==
@@ -1157,7 +1174,7 @@
     "@ledgerhq/hw-transport" "^5.51.1"
     bip32-path "^0.4.2"
 
-"@ledgerhq/hw-app-btc@5.51.1", "@ledgerhq/hw-app-btc@^5.51.1":
+"@ledgerhq/hw-app-btc@5.51.1", "@ledgerhq/hw-app-btc@^5.50.0":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-5.51.1.tgz#f5425a7fcc56df47af2ba8aa26c9c38a5973c0d8"
   integrity sha512-/39HZZBl2yuZMIhe029uf44c7YTtKOtHaHCH8ZxOOXF0+/PvU6p5l8BLFZ1KjhVrJ5xKTBKxB/KACKZTAp4hgg==
@@ -1170,7 +1187,7 @@
     semver "^7.3.5"
     sha.js "2"
 
-"@ledgerhq/hw-app-cosmos@^5.51.1":
+"@ledgerhq/hw-app-cosmos@^5.50.0":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-cosmos/-/hw-app-cosmos-5.51.1.tgz#ced2dac2fcd464eda50ab4c5b558fe798e897bf6"
   integrity sha512-e9hutrWxDOPzS5Lo32z8stXhvBFXzfZi/b6/6BWnkUGVqAo5NzDF9C5lCimy88f+uao9U+gi27fGHXDCMea49A==
@@ -1178,6 +1195,17 @@
     "@ledgerhq/errors" "^5.50.0"
     "@ledgerhq/hw-transport" "^5.51.1"
     bip32-path "^0.4.2"
+
+"@ledgerhq/hw-app-eth@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-5.50.0.tgz#f11583d005b327403816ade54f6b8157834dddc9"
+  integrity sha512-z3uSJ5z/59zoRrccVLnw1ea2WyJ0tof6tp2rvQX8H/Prxb9hXGXua91F+PwuuNdKDR8pgMzQXJMWUb9qlE2R0A==
+  dependencies:
+    "@ledgerhq/cryptoassets" "^5.50.0"
+    "@ledgerhq/errors" "^5.50.0"
+    "@ledgerhq/hw-transport" "^5.50.0"
+    bignumber.js "^9.0.1"
+    rlp "^2.2.6"
 
 "@ledgerhq/hw-app-eth@5.51.1":
   version "5.51.1"
@@ -1190,7 +1218,7 @@
     bignumber.js "^9.0.1"
     rlp "^2.2.6"
 
-"@ledgerhq/hw-app-polkadot@^5.51.1":
+"@ledgerhq/hw-app-polkadot@^5.50.0":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-polkadot/-/hw-app-polkadot-5.51.1.tgz#e3a2331dc3bc46b5b1d4f3990e8e632fdf4bbcce"
   integrity sha512-rMToDZl6s2HVNul+nlcnr2P8XbPdfKJcbIVXgw5ouWVKbRHtxk6UlFTq4Plr1+Ikb3vS8/V9V33ZdG/BFOTqQA==
@@ -1199,7 +1227,7 @@
     "@ledgerhq/hw-transport" "^5.51.1"
     bip32-path "^0.4.2"
 
-"@ledgerhq/hw-app-str@^5.51.1":
+"@ledgerhq/hw-app-str@^5.50.0":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-str/-/hw-app-str-5.51.1.tgz#af480c020a0c3383d674a20c115f291fcbd4029e"
   integrity sha512-Cr5iJTS2LEWe7gR0NLJai66kS2s7Lwf6NfdUmp7O2ln84lFOKfkLGzgiJcOvIPMlfATRNLF45ow8B1s637Gdeg==
@@ -1209,7 +1237,7 @@
     sha.js "^2.3.6"
     tweetnacl "^1.0.3"
 
-"@ledgerhq/hw-app-tezos@^5.51.1":
+"@ledgerhq/hw-app-tezos@^5.50.0":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-tezos/-/hw-app-tezos-5.51.1.tgz#5a05b064f27ac5c64758fd860f6fa3696256e2f3"
   integrity sha512-h3RgUmtPgZVaxwC/Xrcatz3jw7OE9pt+OMFayOFP1TqQEB91C35L0B/Eh1NUcazec5A40Ve4QkgYgGi7/90peQ==
@@ -1219,13 +1247,21 @@
     bs58check "^2.1.2"
     invariant "^2.2.4"
 
-"@ledgerhq/hw-app-trx@5.51.1":
-  version "5.51.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-trx/-/hw-app-trx-5.51.1.tgz#7f003334793354be43b1dfee632d26a2a7626cfa"
-  integrity sha512-QRYb2308bBJwq1mc/P0Sg+0ptaLWnhm6EuggggcwEZ/ynVvvdsAt3LZdsTi9moMBjfpHhAnQiE9Z6S8ADGrgSQ==
+"@ledgerhq/hw-app-trx@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-trx/-/hw-app-trx-5.50.0.tgz#cc7b86d83b91c09f5ce35dbe8af20f17a44760c6"
+  integrity sha512-BONBAqIO929web3kObomCBEnYO/Wuyl9Rq/gCr/iXw7Zj4Ur1FV1w3+0W+K51rBKscgsUjJIMWkRbLSGkdAjTA==
   dependencies:
     "@ledgerhq/errors" "^5.50.0"
-    "@ledgerhq/hw-transport" "^5.51.1"
+    "@ledgerhq/hw-transport" "^5.50.0"
+
+"@ledgerhq/hw-app-xrp@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-xrp/-/hw-app-xrp-5.50.0.tgz#ecc0e50e0247dd25754f829189479dd49be71275"
+  integrity sha512-9LycuIDH+arJY9TOSU2C/K4X1mipZMkLzgiL2h9CRwC89NUrjJncFeqngKLm7y+9RYlycFcPIC9Amk3EkKdpFw==
+  dependencies:
+    "@ledgerhq/hw-transport" "^5.50.0"
+    bip32-path "0.4.2"
 
 "@ledgerhq/hw-app-xrp@5.51.1":
   version "5.51.1"
@@ -1246,7 +1282,7 @@
     axios "^0.21.1"
     ws "6"
 
-"@ledgerhq/hw-transport-mocker@^5.51.1":
+"@ledgerhq/hw-transport-mocker@^5.50.0":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-5.51.1.tgz#01adf00abe33c130588d4975e510a6021161a71a"
   integrity sha512-CPw6nG4tYjfCmbFwHACEUM45P3K/s0XlOOqaT/R/GKZ6Uq+MdFB2UC6tPtDuZXjat3jkYJqRD5brteePLV/jFw==
@@ -1254,7 +1290,7 @@
     "@ledgerhq/hw-transport" "^5.51.1"
     "@ledgerhq/logs" "^5.50.0"
 
-"@ledgerhq/hw-transport-node-speculos@^5.51.1":
+"@ledgerhq/hw-transport-node-speculos@^5.50.0":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-speculos/-/hw-transport-node-speculos-5.51.1.tgz#58ce94e84a8cc5aeedc9bed45782538587991ccc"
   integrity sha512-+W08BZYjaxSKCUZu9Id58y6Iy/WgIpkb9xyzBxUvbG7aBLsSZJOn0Q5cpj1mDrG8GlR7MZ0VtvFxd1TBNRmwoA==
@@ -1264,7 +1300,16 @@
     "@ledgerhq/logs" "^5.50.0"
     rxjs "6"
 
-"@ledgerhq/hw-transport@5.51.1", "@ledgerhq/hw-transport@^5.51.1":
+"@ledgerhq/hw-transport@5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.50.0.tgz#8a132dbdfd1baed7cedf2e0984e7d234b499f46a"
+  integrity sha512-VlcVGgp+Ae4hrUFzSroPJS4i7iBWEYVat91pCl8LyrN+xD8sjamHje69JCdDYY+Cb5++0pbSZt3FGiV0ml3xGA==
+  dependencies:
+    "@ledgerhq/devices" "^5.50.0"
+    "@ledgerhq/errors" "^5.50.0"
+    events "^3.3.0"
+
+"@ledgerhq/hw-transport@5.51.1", "@ledgerhq/hw-transport@^5.50.0", "@ledgerhq/hw-transport@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz#8dd14a8e58cbee4df0c29eaeef983a79f5f22578"
   integrity sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==
@@ -1273,31 +1318,31 @@
     "@ledgerhq/errors" "^5.50.0"
     events "^3.3.0"
 
-"@ledgerhq/live-common@19.9.0":
-  version "19.9.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-19.9.0.tgz#0b0f634b1b8d2239ccc5ff8fd32a7b353bd116ff"
-  integrity sha512-RD5aJfIU7OFY/78bnu8gPr/zM3442ynELn844YMJYQ+tFWs2UT2d3W8BNFU78ZgqBlNtdYVEz1DOBF3aS78DzA==
+"@ledgerhq/live-common@19.9.0-beta.2":
+  version "19.9.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-19.9.0-beta.2.tgz#84b7313c0dfc92c26e2e0d0865527c28e2c6f91f"
+  integrity sha512-/MMz2oxZ5hQhgjqMH3ZKz6M28MXGtEA5ql2uTB604g4YpnuDMJCrEfRqtaNAvmM2+g5i6XssZpYTNgANb9vN+A==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
-    "@ledgerhq/cryptoassets" "5.51.0"
-    "@ledgerhq/devices" "5.51.1"
+    "@ledgerhq/cryptoassets" "5.50.0"
+    "@ledgerhq/devices" "5.50.0"
     "@ledgerhq/errors" "5.50.0"
-    "@ledgerhq/hw-app-algorand" "^5.51.1"
-    "@ledgerhq/hw-app-btc" "^5.51.1"
-    "@ledgerhq/hw-app-cosmos" "^5.51.1"
-    "@ledgerhq/hw-app-eth" "5.51.1"
-    "@ledgerhq/hw-app-polkadot" "^5.51.1"
-    "@ledgerhq/hw-app-str" "^5.51.1"
-    "@ledgerhq/hw-app-tezos" "^5.51.1"
-    "@ledgerhq/hw-app-trx" "5.51.1"
-    "@ledgerhq/hw-app-xrp" "5.51.1"
-    "@ledgerhq/hw-transport" "5.51.1"
-    "@ledgerhq/hw-transport-mocker" "^5.51.1"
-    "@ledgerhq/hw-transport-node-speculos" "^5.51.1"
+    "@ledgerhq/hw-app-algorand" "^5.50.0"
+    "@ledgerhq/hw-app-btc" "^5.50.0"
+    "@ledgerhq/hw-app-cosmos" "^5.50.0"
+    "@ledgerhq/hw-app-eth" "5.50.0"
+    "@ledgerhq/hw-app-polkadot" "^5.50.0"
+    "@ledgerhq/hw-app-str" "^5.50.0"
+    "@ledgerhq/hw-app-tezos" "^5.50.0"
+    "@ledgerhq/hw-app-trx" "5.50.0"
+    "@ledgerhq/hw-app-xrp" "5.50.0"
+    "@ledgerhq/hw-transport" "5.50.0"
+    "@ledgerhq/hw-transport-mocker" "^5.50.0"
+    "@ledgerhq/hw-transport-node-speculos" "^5.50.0"
     "@ledgerhq/logs" "5.50.0"
     "@polkadot/types" "3.11.1"
     "@walletconnect/client" "1.4.1"
-    "@xstate/react" "^1.3.3"
+    "@xstate/react" "^1.3.2"
     async "^3.2.0"
     axios "0.21.1"
     bchaddrjs "^0.5.2"
@@ -1320,14 +1365,14 @@
     lodash "^4.17.21"
     lru-cache "5.1.1"
     numeral "^2.0.6"
-    prando "^6.0.1"
+    prando "^5.1.2"
     redux "^4.1.0"
     reselect "^4.0.0"
     ripemd160 "^2.0.2"
     ripple-binary-codec "^1.1.2"
     ripple-bs58check "^2.0.2"
     ripple-lib "1.9.4"
-    rxjs "6"
+    rxjs "^6.6.7"
     rxjs-compat "^6.6.7"
     secp256k1 "^4.0.2"
     semver "^7.3.5"
@@ -1335,7 +1380,7 @@
     stellar-sdk "^8.1.1"
     triple-beam "^1.3.0"
     winston "^3.3.3"
-    xstate "^4.19.1"
+    xstate "^4.18.0"
 
 "@ledgerhq/logs@5.50.0", "@ledgerhq/logs@^5.50.0":
   version "5.50.0"
@@ -2250,7 +2295,7 @@
     js-sha3 "0.8.0"
     query-string "6.13.5"
 
-"@xstate/react@^1.3.3":
+"@xstate/react@^1.3.2":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.3.3.tgz#5faf7604b8076d06883348f93b241c38ed0e71f6"
   integrity sha512-10QfCZr3dxahYmpykQ5iGtzjtKJ5dkiu1P4JyD0dGnmQLbBD6XDKCnzfOe5MWD8CocErgsaEMmsTMVsnxIAuYQ==
@@ -9338,11 +9383,6 @@ prando@^5.1.2:
   resolved "https://registry.yarnpkg.com/prando/-/prando-5.1.2.tgz#1c7f9b8f543bf335d44a2aadcaa1b3163f3b8fb8"
   integrity sha512-PaJxPMw8UugKUeUq27oZ8dqW2CgysXf2MjmlyCcRq+Es8Bcxgac7+nO6/tRGKmLOnUG1GPbAATNAZmzwD1hbIA==
 
-prando@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/prando/-/prando-6.0.1.tgz#ffa8de84c2adc4975dd9df37ae4ada0458face53"
-  integrity sha512-ghUWxQ1T9IJmPu6eshc3VU0OwveUtXQ33ZLXYUcz1Oc5ppKLDXKp0TBDj6b0epwhEctzcQSNGR2iHyvQSn4W5A==
-
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -10553,7 +10593,7 @@ rxjs@5.5.2:
   dependencies:
     symbol-observable "^1.0.1"
 
-rxjs@6, rxjs@^6.4.0, rxjs@^6.6.6:
+rxjs@6, rxjs@^6.4.0, rxjs@^6.6.6, rxjs@^6.6.7:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -12342,7 +12382,7 @@ xregexp@^4.3.0:
   dependencies:
     "@babel/runtime-corejs3" "^7.8.3"
 
-xstate@^4.19.1:
+xstate@^4.18.0:
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.19.1.tgz#6d6b5388b11a0297894be0caaef2299891c6fb6a"
   integrity sha512-tnBh6ue9MiyoMkE2+w1IqfvJm4nBe3S4Ky/RLvlo9vka8FdO4WyyT3M7PA0pQoM/FZ9aJVWFOlsNw0Nc7E+4Bw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,31 +1126,14 @@
   dependencies:
     commander "^2.20.0"
 
-"@ledgerhq/cryptoassets@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-5.50.0.tgz#16b1ebc414381b61ffcac5595880cd1eb940dfba"
-  integrity sha512-+VGfu+OHyPLBMasprOHkaesBHkE2R5DAdYQqSuAC1vW2WPZ6tyLyZqytmconl4npDzI6Z8EXxOmdnnXYdOArJw==
-  dependencies:
-    invariant "2"
-
-"@ledgerhq/cryptoassets@^5.50.0", "@ledgerhq/cryptoassets@^5.51.0":
+"@ledgerhq/cryptoassets@5.51.0", "@ledgerhq/cryptoassets@^5.51.0":
   version "5.51.0"
   resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-5.51.0.tgz#3781914720ac3a8311ac492fa036806d36337abb"
   integrity sha512-62GLlkQfbdxS9nqY64YuLq2udDZX4T+xpxH1b8JKAhc4Wocr2CfU4Jbb/W85ZTbYV/phNUQ0tel3dhW885WUpQ==
   dependencies:
     invariant "2"
 
-"@ledgerhq/devices@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.50.0.tgz#4bfc375d9781fff6bd772b7914211df547574649"
-  integrity sha512-VU3i48egHwUSHqNPKa8dNXLxD6gvmPKbKkp2pGL8tNNGXT44iHWplEAQy7et7+Fa48Sh7G2WPBvCbQg9K/SeCw==
-  dependencies:
-    "@ledgerhq/errors" "^5.50.0"
-    "@ledgerhq/logs" "^5.50.0"
-    rxjs "^6.6.7"
-    semver "^7.3.5"
-
-"@ledgerhq/devices@5.51.1", "@ledgerhq/devices@^5.50.0", "@ledgerhq/devices@^5.51.1":
+"@ledgerhq/devices@5.51.1", "@ledgerhq/devices@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/devices/-/devices-5.51.1.tgz#d741a4a5d8f17c2f9d282fd27147e6fe1999edb7"
   integrity sha512-4w+P0VkbjzEXC7kv8T1GJ/9AVaP9I6uasMZ/JcdwZBS3qwvKo5A5z9uGhP5c7TvItzcmPb44b5Mw2kT+WjUuAA==
@@ -1165,7 +1148,7 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-5.50.0.tgz#e3a6834cb8c19346efca214c1af84ed28e69dad9"
   integrity sha512-gu6aJ/BHuRlpU7kgVpy2vcYk6atjB4iauP2ymF7Gk0ez0Y/6VSMVSJvubeEQN+IV60+OBK0JgeIZG7OiHaw8ow==
 
-"@ledgerhq/hw-app-algorand@^5.50.0":
+"@ledgerhq/hw-app-algorand@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-algorand/-/hw-app-algorand-5.51.1.tgz#62f6c85afeef6f0e62b9cc34a9bef7a223bdfe42"
   integrity sha512-Y24sCVyQq+g9B5GfaaEpLvxwixWYbRN1FtCFZOrSoM8cxpNsC/werIPw22S6WuHd+YyxJV+mGemKM+2+u3nnnw==
@@ -1174,7 +1157,7 @@
     "@ledgerhq/hw-transport" "^5.51.1"
     bip32-path "^0.4.2"
 
-"@ledgerhq/hw-app-btc@5.51.1", "@ledgerhq/hw-app-btc@^5.50.0":
+"@ledgerhq/hw-app-btc@5.51.1", "@ledgerhq/hw-app-btc@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-5.51.1.tgz#f5425a7fcc56df47af2ba8aa26c9c38a5973c0d8"
   integrity sha512-/39HZZBl2yuZMIhe029uf44c7YTtKOtHaHCH8ZxOOXF0+/PvU6p5l8BLFZ1KjhVrJ5xKTBKxB/KACKZTAp4hgg==
@@ -1187,7 +1170,7 @@
     semver "^7.3.5"
     sha.js "2"
 
-"@ledgerhq/hw-app-cosmos@^5.50.0":
+"@ledgerhq/hw-app-cosmos@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-cosmos/-/hw-app-cosmos-5.51.1.tgz#ced2dac2fcd464eda50ab4c5b558fe798e897bf6"
   integrity sha512-e9hutrWxDOPzS5Lo32z8stXhvBFXzfZi/b6/6BWnkUGVqAo5NzDF9C5lCimy88f+uao9U+gi27fGHXDCMea49A==
@@ -1195,17 +1178,6 @@
     "@ledgerhq/errors" "^5.50.0"
     "@ledgerhq/hw-transport" "^5.51.1"
     bip32-path "^0.4.2"
-
-"@ledgerhq/hw-app-eth@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-5.50.0.tgz#f11583d005b327403816ade54f6b8157834dddc9"
-  integrity sha512-z3uSJ5z/59zoRrccVLnw1ea2WyJ0tof6tp2rvQX8H/Prxb9hXGXua91F+PwuuNdKDR8pgMzQXJMWUb9qlE2R0A==
-  dependencies:
-    "@ledgerhq/cryptoassets" "^5.50.0"
-    "@ledgerhq/errors" "^5.50.0"
-    "@ledgerhq/hw-transport" "^5.50.0"
-    bignumber.js "^9.0.1"
-    rlp "^2.2.6"
 
 "@ledgerhq/hw-app-eth@5.51.1":
   version "5.51.1"
@@ -1218,7 +1190,7 @@
     bignumber.js "^9.0.1"
     rlp "^2.2.6"
 
-"@ledgerhq/hw-app-polkadot@^5.50.0":
+"@ledgerhq/hw-app-polkadot@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-polkadot/-/hw-app-polkadot-5.51.1.tgz#e3a2331dc3bc46b5b1d4f3990e8e632fdf4bbcce"
   integrity sha512-rMToDZl6s2HVNul+nlcnr2P8XbPdfKJcbIVXgw5ouWVKbRHtxk6UlFTq4Plr1+Ikb3vS8/V9V33ZdG/BFOTqQA==
@@ -1227,7 +1199,7 @@
     "@ledgerhq/hw-transport" "^5.51.1"
     bip32-path "^0.4.2"
 
-"@ledgerhq/hw-app-str@^5.50.0":
+"@ledgerhq/hw-app-str@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-str/-/hw-app-str-5.51.1.tgz#af480c020a0c3383d674a20c115f291fcbd4029e"
   integrity sha512-Cr5iJTS2LEWe7gR0NLJai66kS2s7Lwf6NfdUmp7O2ln84lFOKfkLGzgiJcOvIPMlfATRNLF45ow8B1s637Gdeg==
@@ -1237,7 +1209,7 @@
     sha.js "^2.3.6"
     tweetnacl "^1.0.3"
 
-"@ledgerhq/hw-app-tezos@^5.50.0":
+"@ledgerhq/hw-app-tezos@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-tezos/-/hw-app-tezos-5.51.1.tgz#5a05b064f27ac5c64758fd860f6fa3696256e2f3"
   integrity sha512-h3RgUmtPgZVaxwC/Xrcatz3jw7OE9pt+OMFayOFP1TqQEB91C35L0B/Eh1NUcazec5A40Ve4QkgYgGi7/90peQ==
@@ -1247,21 +1219,13 @@
     bs58check "^2.1.2"
     invariant "^2.2.4"
 
-"@ledgerhq/hw-app-trx@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-trx/-/hw-app-trx-5.50.0.tgz#cc7b86d83b91c09f5ce35dbe8af20f17a44760c6"
-  integrity sha512-BONBAqIO929web3kObomCBEnYO/Wuyl9Rq/gCr/iXw7Zj4Ur1FV1w3+0W+K51rBKscgsUjJIMWkRbLSGkdAjTA==
+"@ledgerhq/hw-app-trx@5.51.1":
+  version "5.51.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-trx/-/hw-app-trx-5.51.1.tgz#7f003334793354be43b1dfee632d26a2a7626cfa"
+  integrity sha512-QRYb2308bBJwq1mc/P0Sg+0ptaLWnhm6EuggggcwEZ/ynVvvdsAt3LZdsTi9moMBjfpHhAnQiE9Z6S8ADGrgSQ==
   dependencies:
     "@ledgerhq/errors" "^5.50.0"
-    "@ledgerhq/hw-transport" "^5.50.0"
-
-"@ledgerhq/hw-app-xrp@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-xrp/-/hw-app-xrp-5.50.0.tgz#ecc0e50e0247dd25754f829189479dd49be71275"
-  integrity sha512-9LycuIDH+arJY9TOSU2C/K4X1mipZMkLzgiL2h9CRwC89NUrjJncFeqngKLm7y+9RYlycFcPIC9Amk3EkKdpFw==
-  dependencies:
-    "@ledgerhq/hw-transport" "^5.50.0"
-    bip32-path "0.4.2"
+    "@ledgerhq/hw-transport" "^5.51.1"
 
 "@ledgerhq/hw-app-xrp@5.51.1":
   version "5.51.1"
@@ -1282,7 +1246,7 @@
     axios "^0.21.1"
     ws "6"
 
-"@ledgerhq/hw-transport-mocker@^5.50.0":
+"@ledgerhq/hw-transport-mocker@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-mocker/-/hw-transport-mocker-5.51.1.tgz#01adf00abe33c130588d4975e510a6021161a71a"
   integrity sha512-CPw6nG4tYjfCmbFwHACEUM45P3K/s0XlOOqaT/R/GKZ6Uq+MdFB2UC6tPtDuZXjat3jkYJqRD5brteePLV/jFw==
@@ -1290,7 +1254,7 @@
     "@ledgerhq/hw-transport" "^5.51.1"
     "@ledgerhq/logs" "^5.50.0"
 
-"@ledgerhq/hw-transport-node-speculos@^5.50.0":
+"@ledgerhq/hw-transport-node-speculos@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport-node-speculos/-/hw-transport-node-speculos-5.51.1.tgz#58ce94e84a8cc5aeedc9bed45782538587991ccc"
   integrity sha512-+W08BZYjaxSKCUZu9Id58y6Iy/WgIpkb9xyzBxUvbG7aBLsSZJOn0Q5cpj1mDrG8GlR7MZ0VtvFxd1TBNRmwoA==
@@ -1300,16 +1264,7 @@
     "@ledgerhq/logs" "^5.50.0"
     rxjs "6"
 
-"@ledgerhq/hw-transport@5.50.0":
-  version "5.50.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.50.0.tgz#8a132dbdfd1baed7cedf2e0984e7d234b499f46a"
-  integrity sha512-VlcVGgp+Ae4hrUFzSroPJS4i7iBWEYVat91pCl8LyrN+xD8sjamHje69JCdDYY+Cb5++0pbSZt3FGiV0ml3xGA==
-  dependencies:
-    "@ledgerhq/devices" "^5.50.0"
-    "@ledgerhq/errors" "^5.50.0"
-    events "^3.3.0"
-
-"@ledgerhq/hw-transport@5.51.1", "@ledgerhq/hw-transport@^5.50.0", "@ledgerhq/hw-transport@^5.51.1":
+"@ledgerhq/hw-transport@5.51.1", "@ledgerhq/hw-transport@^5.51.1":
   version "5.51.1"
   resolved "https://registry.yarnpkg.com/@ledgerhq/hw-transport/-/hw-transport-5.51.1.tgz#8dd14a8e58cbee4df0c29eaeef983a79f5f22578"
   integrity sha512-6wDYdbWrw9VwHIcoDnqWBaDFyviyjZWv6H9vz9Vyhe4Qd7TIFmbTl/eWs6hZvtZBza9K8y7zD8ChHwRI4s9tSw==
@@ -1318,31 +1273,31 @@
     "@ledgerhq/errors" "^5.50.0"
     events "^3.3.0"
 
-"@ledgerhq/live-common@19.9.0-beta.2":
-  version "19.9.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-19.9.0-beta.2.tgz#84b7313c0dfc92c26e2e0d0865527c28e2c6f91f"
-  integrity sha512-/MMz2oxZ5hQhgjqMH3ZKz6M28MXGtEA5ql2uTB604g4YpnuDMJCrEfRqtaNAvmM2+g5i6XssZpYTNgANb9vN+A==
+"@ledgerhq/live-common@19.9.1":
+  version "19.9.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-19.9.1.tgz#52c515f834a07fcd1416130c0ec51c7c834379f0"
+  integrity sha512-7xfOnleYSUTuqdXzhXaMP5hd8uppleSikge5Jy2x9obchTzto2HrhFj6AzEToW8MJNbW0udZ+GSTSusglcOjOw==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
-    "@ledgerhq/cryptoassets" "5.50.0"
-    "@ledgerhq/devices" "5.50.0"
+    "@ledgerhq/cryptoassets" "5.51.0"
+    "@ledgerhq/devices" "5.51.1"
     "@ledgerhq/errors" "5.50.0"
-    "@ledgerhq/hw-app-algorand" "^5.50.0"
-    "@ledgerhq/hw-app-btc" "^5.50.0"
-    "@ledgerhq/hw-app-cosmos" "^5.50.0"
-    "@ledgerhq/hw-app-eth" "5.50.0"
-    "@ledgerhq/hw-app-polkadot" "^5.50.0"
-    "@ledgerhq/hw-app-str" "^5.50.0"
-    "@ledgerhq/hw-app-tezos" "^5.50.0"
-    "@ledgerhq/hw-app-trx" "5.50.0"
-    "@ledgerhq/hw-app-xrp" "5.50.0"
-    "@ledgerhq/hw-transport" "5.50.0"
-    "@ledgerhq/hw-transport-mocker" "^5.50.0"
-    "@ledgerhq/hw-transport-node-speculos" "^5.50.0"
+    "@ledgerhq/hw-app-algorand" "^5.51.1"
+    "@ledgerhq/hw-app-btc" "^5.51.1"
+    "@ledgerhq/hw-app-cosmos" "^5.51.1"
+    "@ledgerhq/hw-app-eth" "5.51.1"
+    "@ledgerhq/hw-app-polkadot" "^5.51.1"
+    "@ledgerhq/hw-app-str" "^5.51.1"
+    "@ledgerhq/hw-app-tezos" "^5.51.1"
+    "@ledgerhq/hw-app-trx" "5.51.1"
+    "@ledgerhq/hw-app-xrp" "5.51.1"
+    "@ledgerhq/hw-transport" "5.51.1"
+    "@ledgerhq/hw-transport-mocker" "^5.51.1"
+    "@ledgerhq/hw-transport-node-speculos" "^5.51.1"
     "@ledgerhq/logs" "5.50.0"
     "@polkadot/types" "3.11.1"
     "@walletconnect/client" "1.4.1"
-    "@xstate/react" "^1.3.2"
+    "@xstate/react" "^1.3.3"
     async "^3.2.0"
     axios "0.21.1"
     bchaddrjs "^0.5.2"
@@ -1362,17 +1317,18 @@
     expect "^26.6.2"
     invariant "^2.2.2"
     isomorphic-ws "^4.0.1"
+    json-rpc-2.0 "^0.2.16"
     lodash "^4.17.21"
     lru-cache "5.1.1"
     numeral "^2.0.6"
-    prando "^5.1.2"
+    prando "^6.0.1"
     redux "^4.1.0"
     reselect "^4.0.0"
     ripemd160 "^2.0.2"
     ripple-binary-codec "^1.1.2"
     ripple-bs58check "^2.0.2"
     ripple-lib "1.9.4"
-    rxjs "^6.6.7"
+    rxjs "6"
     rxjs-compat "^6.6.7"
     secp256k1 "^4.0.2"
     semver "^7.3.5"
@@ -1380,7 +1336,7 @@
     stellar-sdk "^8.1.1"
     triple-beam "^1.3.0"
     winston "^3.3.3"
-    xstate "^4.18.0"
+    xstate "^4.19.1"
 
 "@ledgerhq/logs@5.50.0", "@ledgerhq/logs@^5.50.0":
   version "5.50.0"
@@ -2295,7 +2251,7 @@
     js-sha3 "0.8.0"
     query-string "6.13.5"
 
-"@xstate/react@^1.3.2":
+"@xstate/react@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.3.3.tgz#5faf7604b8076d06883348f93b241c38ed0e71f6"
   integrity sha512-10QfCZr3dxahYmpykQ5iGtzjtKJ5dkiu1P4JyD0dGnmQLbBD6XDKCnzfOe5MWD8CocErgsaEMmsTMVsnxIAuYQ==
@@ -7161,6 +7117,11 @@ json-parse-better-errors@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
   integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
 
+json-rpc-2.0@^0.2.16:
+  version "0.2.16"
+  resolved "https://registry.yarnpkg.com/json-rpc-2.0/-/json-rpc-2.0-0.2.16.tgz#8ee70443f09abc26a9d339f382c930f3d84cf635"
+  integrity sha512-nXKBcNZxkoeyKpotT/T3tciv+e7EQb13nuDRLD2tff8Vs39VpPTOvL0BOXM3mN5QE10BlVEq5LDSV344m4zpeg==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -9383,6 +9344,11 @@ prando@^5.1.2:
   resolved "https://registry.yarnpkg.com/prando/-/prando-5.1.2.tgz#1c7f9b8f543bf335d44a2aadcaa1b3163f3b8fb8"
   integrity sha512-PaJxPMw8UugKUeUq27oZ8dqW2CgysXf2MjmlyCcRq+Es8Bcxgac7+nO6/tRGKmLOnUG1GPbAATNAZmzwD1hbIA==
 
+prando@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/prando/-/prando-6.0.1.tgz#ffa8de84c2adc4975dd9df37ae4ada0458face53"
+  integrity sha512-ghUWxQ1T9IJmPu6eshc3VU0OwveUtXQ33ZLXYUcz1Oc5ppKLDXKp0TBDj6b0epwhEctzcQSNGR2iHyvQSn4W5A==
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
@@ -10593,7 +10559,7 @@ rxjs@5.5.2:
   dependencies:
     symbol-observable "^1.0.1"
 
-rxjs@6, rxjs@^6.4.0, rxjs@^6.6.6, rxjs@^6.6.7:
+rxjs@6, rxjs@^6.4.0, rxjs@^6.6.6:
   version "6.6.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
   integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
@@ -12382,7 +12348,7 @@ xregexp@^4.3.0:
   dependencies:
     "@babel/runtime-corejs3" "^7.8.3"
 
-xstate@^4.18.0:
+xstate@^4.19.1:
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.19.1.tgz#6d6b5388b11a0297894be0caaef2299891c6fb6a"
   integrity sha512-tnBh6ue9MiyoMkE2+w1IqfvJm4nBe3S4Ky/RLvlo9vka8FdO4WyyT3M7PA0pQoM/FZ9aJVWFOlsNw0Nc7E+4Bw==


### PR DESCRIPTION
When accessing the swap feature we currently require users to have the exchange app installed and up to date and when inside the form we limit the selectors depending on whether they have the applications installed or not. This means we are capping the feature before users can access it. This feature allows the user to enter the swap form and request a form without knowing that they need the exchange app and, once the inline install is no longer experimental, they will be able to fulfill that requirement without leaving the form.

### Type
Feature

### Context
https://ledgerhq.atlassian.net/browse/LL-5273

### Parts of the app affected / Test plan
- Without experimental inline install, try cases with/without all required apps/accounts
- With experimental inline install, try cases with/without all required apps/accounts