### PR TITLE
Unblock the device rename feature

### DIFF
--- a/src/screens/EditDeviceName.js
+++ b/src/screens/EditDeviceName.js
@@ -210,6 +210,7 @@ const styles = StyleSheet.create({
     marginBottom: 10,
   },
   footer: {
+    flex: 1,
     flexDirection: "column",
     padding: 20,
   },


### PR DESCRIPTION
Current develop version hides the button to confirm the rename, this merely makes that button visible again. We should also migrate to device actions for this since it's using the old device job and UI.
![Screen Shot 2021-05-20 at 14 23 00](https://user-images.githubusercontent.com/4631227/118978088-336d9b00-b977-11eb-847c-bc34a2b67d71.png)


### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-5670

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
