### PR TITLE
(ReactNavigation): enable react native screens optimizations

### DIFF
--- a/android/app/src/main/java/com/ledger/live/MainActivity.java
+++ b/android/app/src/main/java/com/ledger/live/MainActivity.java
@@ -54,7 +54,7 @@ public class MainActivity extends ReactActivity {
                 this.importDataString = extras.getString("importDataString");
             }
         }
-        super.onCreate(savedInstanceState);
+        super.onCreate(null);
 
         /**
          * Addresses an inconvenient side-effect of using `password-visible`, that

--- a/index.js
+++ b/index.js
@@ -13,9 +13,12 @@ import { AppRegistry } from "react-native";
 import { Sentry } from "react-native-sentry";
 import Config from "react-native-config";
 
+import { enableScreens } from "react-native-screens";
 import App from "./src";
 import { getEnabled } from "./src/components/HookSentry";
 import logReport from "./src/log-report";
+
+enableScreens(true);
 
 if (Config.SENTRY_DSN && !__DEV__ && !Config.MOCK) {
   Sentry.config(Config.SENTRY_DSN, {

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "react-native-redash": "^15.11.1",
     "react-native-safe-area-context": "^0.7.3",
     "react-native-safe-area-view": "^1.1.1",
-    "react-native-screens": "^2.15.0",
+    "react-native-screens": "^3.3.0",
     "react-native-sentry": "0.43.2",
     "react-native-share": "^5.0.0",
     "react-native-simple-store": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10498,10 +10498,10 @@ react-native-safe-modules@^1.0.3:
   dependencies:
     dedent "^0.6.0"
 
-react-native-screens@^2.15.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-2.15.0.tgz#9b97c1881c4fcdf304bf363f0013225901625f44"
-  integrity sha512-qTSQPy0WKHtlb8xt5gY0Gt6sdvfQUQAnFSqgsggW9UEvySbkHzpqOrOYNA79Ca8oXO0dCFwp6X8buIiDefa7+Q==
+react-native-screens@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.3.0.tgz#d4464a96620b85d09e46bd6865b5f48456c244f0"
+  integrity sha512-ni11jC6I9cFVXdLIDwkgafDHw/STXUNzkR5Fx3w8Wikdzi8gfTEan2kiOm7aS42d2F/LXddZ6i74Z2em0L6LPQ==
 
 react-native-sentry@0.43.2:
   version "0.43.2"


### PR DESCRIPTION
enable react native screens as per https://reactnavigation.org/docs/react-native-screens
should optimize some rendering in heavy navigation stack pages

### Type

Code Quality Improvement

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

Heavy stack pages navigation

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
