### PR TITLE
feat(Swap): update success screen wording and UI - LL-5733

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1837,10 +1837,10 @@
         "cta": "Close"
       },
       "pendingOperation": {
-        "description": "Your Swap operation has been sent to the network for confirmation. It may take up to an hour before you receive your swapped crypto assets.",
+        "description": "Your Swap operation has been sent to the network for confirmation. It may take up to an hour before you receive your {{targetCurrency}}.",
         "label": "Your Swap ID:",
-        "title": "Pending operation",
-        "disclaimer": "Please take note of your Swap ID number in case you’d need assistance from {{provider}} later.",
+        "title": "Swap broadcast successfully ",
+        "disclaimer": "Take note of your Swap ID number in case you’d need assistance from {{provider}} support.",
         "cta": "See details"
       },
       "tradeMethod": {

--- a/src/screens/Swap/FormOrHistory/Confirmation.js
+++ b/src/screens/Swap/FormOrHistory/Confirmation.js
@@ -23,6 +23,7 @@ import addToSwapHistory from "@ledgerhq/live-common/lib/exchange/swap/addToSwapH
 import {
   addPendingOperation,
   getMainAccount,
+  getAccountCurrency,
 } from "@ledgerhq/live-common/lib/account";
 
 import { renderLoading } from "../../../components/DeviceAction/rendering";
@@ -56,7 +57,7 @@ const Confirmation = ({
   deviceMeta,
   status,
 }: Props) => {
-  const { fromAccount, fromParentAccount } = exchange;
+  const { fromAccount, fromParentAccount, toAccount } = exchange;
   const [swapData, setSwapData] = useState(null);
   const [signedOperation, setSignedOperation] = useState(null);
   const dispatch = useDispatch();
@@ -68,6 +69,7 @@ const Confirmation = ({
     fromAccount && fromAccount.type === "TokenAccount"
       ? fromAccount.token
       : null;
+  const targetCurrency = getAccountCurrency(toAccount);
   const navigation = useNavigation();
 
   const onComplete = useCallback(
@@ -93,6 +95,7 @@ const Confirmation = ({
       navigation.replace(ScreenName.SwapPendingOperation, {
         swapId,
         provider: exchangeRate.provider,
+        targetCurrency: targetCurrency.name,
       });
     },
     [
@@ -103,6 +106,7 @@ const Confirmation = ({
       fromParentAccount,
       navigation,
       transaction,
+      targetCurrency,
     ],
   );
 

--- a/src/screens/Swap/FormOrHistory/Form/PendingOperation.js
+++ b/src/screens/Swap/FormOrHistory/Form/PendingOperation.js
@@ -9,7 +9,8 @@ import { ScreenName } from "../../../../const";
 import LText from "../../../../components/LText";
 import Alert from "../../../../components/Alert";
 import Button from "../../../../components/Button";
-import IconSwap from "../../../../icons/Swap";
+import IconCheck from "../../../../icons/Check";
+import IconClock from "../../../../icons/Clock";
 import { rgba } from "../../../../colors";
 
 const forceInset = { bottom: "always" };
@@ -25,7 +26,7 @@ const PendingOperation = () => {
     });
   }, [navigation]);
 
-  const { swapId, provider } = route.params;
+  const { swapId, provider, targetCurrency } = route.params;
 
   return (
     <SafeAreaView
@@ -33,39 +34,54 @@ const PendingOperation = () => {
       forceInset={forceInset}
     >
       <View style={styles.wrapper}>
-        <View
-          style={[
-            styles.iconWrapper,
-            { backgroundColor: rgba(colors.live, 0.1) },
-          ]}
-        >
-          <IconSwap color={colors.live} size={20} />
-        </View>
-        <LText secondary style={styles.title}>
-          <Trans i18nKey={"transfer.swap.pendingOperation.title"} />
-        </LText>
-        <View style={styles.swapIDWrapper}>
-          <LText style={styles.swapLabel} color="grey">
-            <Trans i18nKey={"transfer.swap.pendingOperation.label"} />
-          </LText>
-          <LText
-            selectable
-            tertiary
-            style={[styles.swapID, { backgroundColor: colors.lightFog }]}
+        <View style={styles.content}>
+          <View
+            style={[
+              styles.iconWrapper,
+              { backgroundColor: rgba(colors.success, 0.1) },
+            ]}
           >
-            {swapId}
+            <IconCheck color={colors.success} size={20} />
+            <View
+              style={[
+                styles.wrapperClock,
+                { backgroundColor: colors.background },
+              ]}
+            >
+              <IconClock color={colors.grey} size={14} />
+            </View>
+          </View>
+          <LText secondary style={styles.title}>
+            <Trans i18nKey={"transfer.swap.pendingOperation.title"} />
+          </LText>
+          <LText style={styles.description} color="grey">
+            <Trans
+              i18nKey={"transfer.swap.pendingOperation.description"}
+              values={{ targetCurrency }}
+            />
           </LText>
         </View>
-        <LText style={styles.description} color="grey">
-          <Trans i18nKey={"transfer.swap.pendingOperation.description"} />
-        </LText>
 
-        <Alert type="primary">
-          <Trans
-            i18nKey={"transfer.swap.pendingOperation.disclaimer"}
-            values={{ provider }}
-          />
-        </Alert>
+        <View style={styles.disclaimer}>
+          <Alert
+            type="help"
+            vertical
+            bottom={
+              <LText
+                selectable
+                semiBold
+                style={[styles.swapID, { backgroundColor: colors.lightFog }]}
+              >
+                {swapId}
+              </LText>
+            }
+          >
+            <Trans
+              i18nKey={"transfer.swap.pendingOperation.disclaimer"}
+              values={{ provider }}
+            />
+          </Alert>
+        </View>
       </View>
       <View style={styles.continueWrapper}>
         <Button
@@ -85,6 +101,16 @@ const styles = StyleSheet.create({
     padding: 16,
     paddingTop: 32,
   },
+  wrapper: {
+    alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
+  },
+  content: {
+    alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
+  },
   iconWrapper: {
     height: 50,
     width: 50,
@@ -94,20 +120,25 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
   },
-  wrapper: {
-    alignItems: "center",
-    justifyContent: "center",
-    flex: 1,
+  wrapperClock: {
+    borderRadius: 16,
+    position: "absolute",
+    bottom: -2,
+    right: -2,
+    padding: 2,
   },
   title: {
     fontSize: 18,
     lineHeight: 22,
     marginBottom: 16,
   },
+  disclaimer: {
+    marginTop: "auto",
+    marginBottom: 32,
+  },
   swapIDWrapper: {
-    alignItems: "center",
-    flexDirection: "row",
-    marginBottom: 12,
+    backgroundColor: "red",
+    flexGrow: 0,
   },
   swapLabel: {
     fontSize: 14,
@@ -115,9 +146,10 @@ const styles = StyleSheet.create({
   },
   swapID: {
     borderRadius: 4,
-    padding: 4,
+    overflow: "hidden",
     paddingHorizontal: 8,
-    marginLeft: 8,
+    paddingVertical: 4,
+    alignSelf: "center",
   },
   description: {
     fontSize: 13,


### PR DESCRIPTION
### Type

UI Polish

### Context

This PR updates the Swap Confirmation screen to show better that broadcast is successful but operation is still pending.
Icon updated with Clock, wording updated, and Swap ID filled in the Disclaimer alert.

JIRA: [LL-5733](https://ledgerhq.atlassian.net/browse/LL-5733)

### Parts of the app affected / Test plan

At the end of a Successful Swap, should look like this:
<img src="https://user-images.githubusercontent.com/70533374/121403101-e0c24600-c95a-11eb-8cc5-655aced7bf4f.png" width="200" /><img src="https://user-images.githubusercontent.com/70533374/121403104-e15adc80-c95a-11eb-904b-1dc32ff510f1.png" width="200" />

**NOTE: Not tested with a REAL SWAP (i wanted to avoid burning fees since QA should test it for real).**
The part that i have not tested is if the targetCurrency is correctly filled in the description text.

