### PR TITLE
fix(Swap): drop the concept of payoutNetworkFees from UI - LL-5931

### DIFF
--- a/src/screens/Swap/FormOrHistory/Form/Summary/SummaryBody.js
+++ b/src/screens/Swap/FormOrHistory/Form/Summary/SummaryBody.js
@@ -20,7 +20,6 @@ import {
 
 import LText from "../../../../../components/LText";
 import CurrencyUnitValue from "../../../../../components/CurrencyUnitValue";
-import InfoModal from "../../../../../components/InfoModal";
 import SectionSeparator, {
   ArrowDownCircle,
 } from "../../../../../components/SectionSeparator";
@@ -41,11 +40,9 @@ const SummaryBody = ({
   const { fromAccount, toAccount } = exchange;
   const fromCurrency = getAccountCurrency(fromAccount);
   const toCurrency = getAccountCurrency(toAccount);
-  const { magnitudeAwareRate, payoutNetworkFees } = exchangeRate;
+  const { magnitudeAwareRate, toAmount } = exchangeRate;
   const { amount } = status;
-  const [payoutFeesDrawerVisibility, setPayoutFeesDrawerVisibility] = useState(
-    false,
-  );
+
   const openProvider = useCallback(() => {
     Linking.openURL(urls.swap.providers[exchangeRate.provider].main);
   }, [exchangeRate.provider]);
@@ -104,47 +101,17 @@ const SummaryBody = ({
       </View>
       <View style={styles.row}>
         <LText primary style={styles.label} color="smoke">
-          <Trans
-            i18nKey={
-              exchangeRate.tradeMethod === "fixed"
-                ? "transfer.swap.form.summary.receive"
-                : "transfer.swap.form.summary.receiveFloat"
-            }
-          />
+          <Trans i18nKey={"transfer.swap.form.summary.receive"} />
         </LText>
         <LText tertiary style={styles.value2}>
           <CurrencyUnitValue
             disableRounding
             showCode
             unit={getAccountUnit(toAccount)}
-            value={amount.times(magnitudeAwareRate)}
+            value={toAmount}
           />
         </LText>
       </View>
-      {exchangeRate.tradeMethod === "float" ? (
-        <View style={styles.row}>
-          <TouchableOpacity
-            onPress={() => setPayoutFeesDrawerVisibility(true)}
-            style={{ flexDirection: "row", alignItems: "center" }}
-          >
-            <LText
-              style={{ ...styles.label, flex: 0, marginRight: 4 }}
-              color="smoke"
-            >
-              <Trans i18nKey="transfer.swap.form.summary.payoutNetworkFees" />
-            </LText>
-            <Icon size={13} color={colors.smoke} name={"info-circle"} />
-          </TouchableOpacity>
-          <LText tertiary style={styles.value2}>
-            <CurrencyUnitValue
-              disableRounding
-              showCode
-              unit={getAccountUnit(toAccount)}
-              value={BigNumber(payoutNetworkFees || 0)}
-            />
-          </LText>
-        </View>
-      ) : null}
       <View style={[styles.rate, { backgroundColor: colors.lightFog }]}>
         <View style={[styles.row, { marginBottom: 0 }]}>
           <LText primary style={styles.label} color="smoke">
@@ -171,13 +138,6 @@ const SummaryBody = ({
           </LText>
         </View>
       </View>
-      <InfoModal
-        isOpened={payoutFeesDrawerVisibility}
-        title={<Trans i18nKey={"transfer.swap.payoutModal.title"} />}
-        desc={<Trans i18nKey={"transfer.swap.payoutModal.description"} />}
-        confirmLabel={<Trans i18nKey={"transfer.swap.payoutModal.cta"} />}
-        onClose={() => setPayoutFeesDrawerVisibility(false)}
-      />
     </>
   );
 };


### PR DESCRIPTION
> This pr is tightly linked to LedgerHQ/ledger-live-common#1244 and they should land on production together. Delivering one of them independently from the other will make the amounts not match for the users doing swaps.

### Type

Feature

### Context

Originally when we delivered the floating rate trading method for swap there was a new concept of payoutNetworkFees, which represents an amount that is charged as a fee on top of the rate provided. We needed to display this because the amount on the device included that amount, but the amount to be received had it deducted.

With the latest code on staging, this is no longer the case and the binary payload amount (which we use on the device verification) deducts this amount, allowing us to drop the UI that referred to this concept altogether.

DEPENDS ON LIVE-COMMON: https://github.com/LedgerHQ/ledger-live-common/pull/1244
LLD PR: https://github.com/LedgerHQ/ledger-live-desktop/pull/3899

### Parts of the app affected / Test plan

* Use yalc version of LLC with branch from PR https://github.com/LedgerHQ/ledger-live-common/pull/1244
* Use .env variable: ```SWAP_API_BASE=https://swap-stg.ledger.com/v2```
* Start swap with floating rate, go to sign step (no need to accept swap)
* Only amount is displayed in the summary screen, and should match the `get estimated` value on device
<img src="https://user-images.githubusercontent.com/70533374/121688178-724cc780-cac3-11eb-8a95-ca875ede5987.png" width="200" />
