### PR TITLE
LL-5446 (Compound): disable lending entries for live with non enabled accounts

### DIFF
--- a/src/modals/Create.js
+++ b/src/modals/Create.js
@@ -6,7 +6,10 @@ import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 
 import { NavigatorName, ScreenName } from "../const";
-import { accountsCountSelector } from "../reducers/accounts";
+import {
+  accountsCountSelector,
+  hasLendEnabledAccountsSelector,
+} from "../reducers/accounts";
 import IconSend from "../icons/Send";
 import IconReceive from "../icons/Receive";
 import IconExchange from "../icons/Exchange";
@@ -23,6 +26,7 @@ export default function CreateModal({ isOpened, onClose }: ModalProps) {
 
   const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
   const accountsCount = useSelector(accountsCountSelector);
+  const lendingEnabled = useSelector(hasLendEnabledAccountsSelector);
 
   const onNavigate = useCallback(
     (name: string, options?: { [key: string]: any }) => {
@@ -94,12 +98,14 @@ export default function CreateModal({ isOpened, onClose }: ModalProps) {
         Icon={IconSwap}
         onPress={accountsCount > 0 && !readOnlyModeEnabled ? onSwap : null}
       />
-      <BottomModalChoice
-        event="TransferLending"
-        title={t("transfer.lending.titleTransferTab")}
-        Icon={IconLending}
-        onPress={accountsCount > 0 && !readOnlyModeEnabled ? onLending : null}
-      />
+      {lendingEnabled ? (
+        <BottomModalChoice
+          event="TransferLending"
+          title={t("transfer.lending.titleTransferTab")}
+          Icon={IconLending}
+          onPress={accountsCount > 0 && !readOnlyModeEnabled ? onLending : null}
+        />
+      ) : null}
     </BottomModal>
   );
 }

--- a/src/reducers/accounts.js
+++ b/src/reducers/accounts.js
@@ -10,6 +10,11 @@ import type {
   TokenCurrency,
 } from "@ledgerhq/live-common/lib/types";
 import {
+  makeCompoundSummaryForAccount,
+  getAccountCapabilities,
+} from "@ledgerhq/live-common/lib/compound/logic";
+
+import {
   addAccounts,
   canBeMigrated,
   flattenAccounts,
@@ -258,5 +263,26 @@ export const subAccountByCurrencyOrderedScreenSelector = (route: any) => (
   if (!currency) return [];
   return subAccountByCurrencyOrderedSelector(state, { currency });
 };
+
+export const hasLendEnabledAccountsSelector: OutputSelector<
+  State,
+  void,
+  boolean,
+> = createSelector(flattenAccountsSelector, accounts =>
+  accounts.some(account => {
+    if (!account || account.type !== "TokenAccount") return false;
+
+    // check if account already has lending enabled
+    const summary =
+      account.type === "TokenAccount" &&
+      makeCompoundSummaryForAccount(account, undefined);
+
+    const capabilities = summary
+      ? account.type === "TokenAccount" && getAccountCapabilities(account)
+      : null;
+
+    return !!capabilities;
+  }),
+);
 
 export default handleActions(handlers, initialState);

--- a/src/screens/Account/hooks/useActions.js
+++ b/src/screens/Account/hooks/useActions.js
@@ -18,6 +18,7 @@ import WalletConnect from "../../../icons/WalletConnect";
 import Exchange from "../../../icons/Exchange";
 import IconSend from "../../../icons/Send";
 import IconReceive from "../../../icons/Receive";
+import useCompoundAccountEnabled from "../../Lending/shared/useCompoundAccountEnabled";
 
 type Props = {
   account: AccountLike,
@@ -37,8 +38,7 @@ export default function useActions({ account, parentAccount, colors }: Props) {
 
   const accountId = account.id;
 
-  const availableOnCompound =
-    account.type === "TokenAccount" && !!account.compoundBalance;
+  const availableOnCompound = useCompoundAccountEnabled(account, parentAccount);
 
   const canBeSold = isCurrencySupported(currency, "sell");
 

--- a/src/screens/Lending/shared/useCompoundAccountEnabled.js
+++ b/src/screens/Lending/shared/useCompoundAccountEnabled.js
@@ -1,0 +1,23 @@
+// @flow
+import type { AccountLike, Account } from "@ledgerhq/live-common/lib/types";
+import {
+  makeCompoundSummaryForAccount,
+  getAccountCapabilities,
+} from "@ledgerhq/live-common/lib/compound/logic";
+
+export default function useCompoundAccountEnabled(
+  account: AccountLike,
+  parentAccount: ?Account,
+) {
+  if (!account || account.type !== "TokenAccount") return false;
+
+  // check if account already has lending enabled
+  const summary =
+    account.type === "TokenAccount" &&
+    makeCompoundSummaryForAccount(account, parentAccount);
+  const capabilities = summary
+    ? account.type === "TokenAccount" && getAccountCapabilities(account)
+    : null;
+
+  return !!capabilities;
+}

--- a/src/screens/Swap/FormOrHistory/Form/Summary/SummaryBody.js
+++ b/src/screens/Swap/FormOrHistory/Form/Summary/SummaryBody.js
@@ -1,11 +1,8 @@
 // @flow
-import React, { useCallback, useState } from "react";
+import React, { useCallback } from "react";
 import { StyleSheet, View, TouchableOpacity, Linking } from "react-native";
 import { useTheme } from "@react-navigation/native";
-import Icon from "react-native-vector-icons/dist/FontAwesome";
 import { Trans } from "react-i18next";
-
-import { BigNumber } from "bignumber.js";
 
 import type { TransactionStatus } from "@ledgerhq/live-common/lib/types";
 import type {
@@ -40,7 +37,7 @@ const SummaryBody = ({
   const { fromAccount, toAccount } = exchange;
   const fromCurrency = getAccountCurrency(fromAccount);
   const toCurrency = getAccountCurrency(toAccount);
-  const { magnitudeAwareRate, toAmount } = exchangeRate;
+  const { toAmount } = exchangeRate;
   const { amount } = status;
 
   const openProvider = useCallback(() => {


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
(Compound): disable lending entries for live with non enabled accounts
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Feature
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
[LL-5446]
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Compound entry points for accounts should be limited to accounts that have it already enabled.
Also the global entry is shown to apps having at least one lending enabled account.


[LL-5446]: https://ledgerhq.atlassian.net/browse/LL-5446