### PR TITLE
LL-6032 (Swap) Capitalize the provider name in the disclaimer modal

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1925,7 +1925,7 @@
           "fees": "Max fees",
           "disclaimer": {
             "title": "Terms and conditions",
-            "desc": "By clicking “Accept”,  I acknowledge and accept that this service is exclusively governed by {{provider}}'s Terms & Conditions.",
+            "desc": "By clicking “Accept”,  I acknowledge and accept that this service is exclusively governed by <0>{{provider}}</0>'s Terms & Conditions.",
             "tos": "Terms & conditions",
             "accept": "Accept",
             "reject": "Close"

--- a/src/screens/Swap/FormOrHistory/Form/DisclaimerModal.js
+++ b/src/screens/Swap/FormOrHistory/Form/DisclaimerModal.js
@@ -39,7 +39,9 @@ const DisclaimerModal = ({
         <Trans
           i18nKey={"transfer.swap.form.summary.disclaimer.desc"}
           values={{ provider }}
-        />
+        >
+          <LText style={styles.capitalize} color="smoke" />
+        </Trans>
       </LText>
       <ExternalLink
         text={<Trans i18nKey="transfer.swap.form.summary.disclaimer.tos" />}
@@ -95,6 +97,7 @@ const styles = StyleSheet.create({
   firstButton: {
     marginTop: 24,
   },
+  capitalize: { textTransform: "capitalize" },
 });
 
 export default DisclaimerModal;


### PR DESCRIPTION
Just the capital 'C'

![image](https://user-images.githubusercontent.com/4631227/124258836-232c0c80-db2e-11eb-8592-026469a66688.png)
### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LL-6032

### Parts of the app affected / Test plan

- Access the swap feature (make sure you are not pointing to v3 still like I was)
- Reach the summary step
- Continue. On this confirmation modal you will see the wording above, make sure the provider is capitalized, ie no "changelly" but rather "Changelly"