### PR TITLE
LL-6002 Status, need top margin when Live is up and running

### DIFF
--- a/src/screens/NotificationCenter/Status.js
+++ b/src/screens/NotificationCenter/Status.js
@@ -74,7 +74,20 @@ export default function NotificationCenter() {
             <Trans i18nKey="notificationCenter.status.error.title" />
           </LText>
         </View>
-      ) : null}
+      ) : (
+        <View style={styles.container}>
+          <CheckCircle size={42} color={colors.success} />
+          <LText bold style={styles.title}>
+            <Trans i18nKey="notificationCenter.status.ok.title" />
+          </LText>
+          <LText bold style={[styles.desc]}>
+            <Trans i18nKey="notificationCenter.status.ok.desc">
+              <LText color="grey" />
+              <LText semiBold color="live" onPress={onHelpPageRedirect} />
+            </Trans>
+          </LText>
+        </View>
+      )}
       <FlatList
         contentContainerStyle={styles.listContainer}
         style={{ flex: 1 }}
@@ -91,20 +104,6 @@ export default function NotificationCenter() {
             style={[styles.separator, { backgroundColor: colors.lightFog }]}
           />
         )}
-        ListEmptyComponent={
-          <View style={styles.container}>
-            <CheckCircle size={42} color={colors.success} />
-            <LText bold style={styles.title}>
-              <Trans i18nKey="notificationCenter.status.ok.title" />
-            </LText>
-            <LText bold style={[styles.desc]}>
-              <Trans i18nKey="notificationCenter.status.ok.desc">
-                <LText color="grey" />
-                <LText semiBold color="live" onPress={onHelpPageRedirect} />
-              </Trans>
-            </LText>
-          </View>
-        }
       />
     </SafeAreaView>
   );
@@ -114,8 +113,7 @@ const styles = StyleSheet.create({
   root: { flex: 1, paddingTop: 16 },
   container: {
     flex: 1,
-    flexDirection: "column",
-    justifyContent: "center",
+    justifyContent: "flex-end",
     alignItems: "center",
   },
   incidentContainer: {


### PR DESCRIPTION
Adds some padding in the incidents status view when everything is ok.

<details>
  <summary>Screenshot 📸 </summary>

![Simulator Screen Shot - iPhone 11 - 2021-07-07 at 16 53 10](https://user-images.githubusercontent.com/86958797/124781669-e1430200-df43-11eb-8c0b-19871643e1d1.png)
</details>

### Type

Bug Fix

### Context

[LL-6002]

### Parts of the app affected / Test plan

Navigation Center (top-right bell icon) -> Status Tab
*Reproducible only when the incidents count is 0.*


[LL-6002]: https://ledgerhq.atlassian.net/browse/LL-6002
