### PR TITLE
LL-4619 Account screen - Remove Operation type from operations list

### DIFF
--- a/src/components/OperationRow.js
+++ b/src/components/OperationRow.js
@@ -158,7 +158,7 @@ export default function OperationRow({
               </View>
             ) : (
               <LText numberOfLines={1} color="grey" style={[styles.bottomRow]}>
-                {text} <OperationRowDate date={operation.date} />
+                <OperationRowDate date={operation.date} />
               </LText>
             )}
           </View>

--- a/src/components/OperationRowDate.js
+++ b/src/components/OperationRowDate.js
@@ -18,5 +18,5 @@ export default function OperationRowDate({ date }: Props) {
     [date, locale],
   );
 
-  return `at ${localeTimeString}`;
+  return localeTimeString;
 }


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
On Mobile accounts operations history, the operation type is displayed twice. Sometimes it makes the operation date non-visible. To be consistent with desktop I remove on mobile accounts the operation type next to transaction date time.

<details>
  <summary>Android screenshots 📸 </summary>

![Screenshot_1625757558](https://user-images.githubusercontent.com/33158502/124948292-d73b0500-e010-11eb-8dda-c2cdaf60bae3.png)
![Screenshot_1625757596](https://user-images.githubusercontent.com/33158502/124948295-d86c3200-e010-11eb-8271-7fc95961379c.png)


</details>

<details>
  <summary>iOS screenshots 📸 </summary>

![Simulator Screen Shot - iPhone 11 - 2021-07-08 at 17 18 53](https://user-images.githubusercontent.com/33158502/124948322-ddc97c80-e010-11eb-927b-547f3952f73d.png)
![Simulator Screen Shot - iPhone 11 - 2021-07-08 at 17 19 15](https://user-images.githubusercontent.com/33158502/124948327-defaa980-e010-11eb-8e5a-b858df5f8912.png)


</details>

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

UI Polish

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

[LL-4619]

### Parts of the app affected / Test plan

Transactions history from account screen on mobile.

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LL-4619]: https://ledgerhq.atlassian.net/browse/LL-4619