### PR TITLE
LL-6318 - Ethereum Send flow step Summary: Add margin between GasPrice and GasLimit sections

### DIFF
--- a/src/families/ethereum/EditFeeUnitEthereum.js
+++ b/src/families/ethereum/EditFeeUnitEthereum.js
@@ -72,7 +72,7 @@ export default function EditFeeUnitEthereum({
   const { gasPrice: serverGas } = networkInfo;
 
   return (
-    <View style={styles.root}>
+    <View>
       <View style={[styles.sliderContainer, { backgroundColor: colors.card }]}>
         <View style={styles.gasPriceHeader}>
           <LText style={styles.gasPriceLabel} semiBold>
@@ -111,7 +111,6 @@ export default function EditFeeUnitEthereum({
 }
 
 const styles = StyleSheet.create({
-  root: {},
   sliderContainer: {
     paddingLeft: 0,
   },

--- a/src/families/ethereum/EditFeeUnitEthereum.js
+++ b/src/families/ethereum/EditFeeUnitEthereum.js
@@ -111,9 +111,7 @@ export default function EditFeeUnitEthereum({
 }
 
 const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-  },
+  root: {},
   sliderContainer: {
     paddingLeft: 0,
   },

--- a/src/families/ethereum/EthereumCustomFees.js
+++ b/src/families/ethereum/EthereumCustomFees.js
@@ -72,7 +72,6 @@ export default function EthereumCustomFees({ navigation, route }: Props) {
     parentAccount,
     route.params,
     transaction,
-    gasLimit,
     gasPrice,
   ]);
 
@@ -89,7 +88,10 @@ export default function EthereumCustomFees({ navigation, route }: Props) {
         }}
       />
 
-      <SectionSeparator lineColor={colors.fog} />
+      <SectionSeparator
+        style={styles.sectionSeparator}
+        lineColor={colors.fog}
+      />
 
       <View style={styles.container}>
         <EthereumGasLimit
@@ -124,9 +126,11 @@ const styles = StyleSheet.create({
     flexDirection: "column",
   },
   container: {
-    flex: 4,
+    flex: 1,
   },
-
+  sectionSeparator: {
+    marginTop: 16,
+  },
   accountContainer: {
     flex: 1,
     flexDirection: "row",


### PR DESCRIPTION
Fixes margin issues when a header is present at the top of the page (like when enabling experimental features). 

<details>
  <summary>Screenshot(s) 📸 </summary>
 <br/><br/>

*With "experimental features" header*

![Simulator Screen Shot - iPhone 8 - 2021-07-09 at 08 57 09](https://user-images.githubusercontent.com/86958797/125037611-a7354580-e094-11eb-8590-67428fe3919e.png)

-----

*Without any header*

![Simulator Screen Shot - iPhone 8 - 2021-07-09 at 08 58 42](https://user-images.githubusercontent.com/86958797/125037612-a8667280-e094-11eb-894c-b61f1fa3ab81.png)

</details>

### Type

Bug Fix

### Context

[LL-6318]

### Parts of the app affected / Test plan

- Enable at least one experimental feature 
- Start the send ethereum crypto flow
- Go to the summary step
- Click on `Customize fees`
- Check the margin

[LL-6318]: https://ledgerhq.atlassian.net/browse/LL-6318