### PR TITLE
LL-6317 Send flow step amount: Continue CTA shouldn't be hidden by keyboard

### DIFF
--- a/src/components/KeyboardView.js
+++ b/src/components/KeyboardView.js
@@ -1,6 +1,8 @@
 // @flow
-import React, { PureComponent } from "react";
+import React from "react";
 import { KeyboardAvoidingView, Platform, NativeModules } from "react-native";
+import * as ExperimentalHeader from "../screens/Settings/Experimental/ExperimentalHeader";
+import useExperimental from "../screens/Settings/Experimental/useExperimental";
 
 const { DeviceInfo } = NativeModules;
 
@@ -9,19 +11,13 @@ type Props = {
   children: React$Node,
 };
 
-class KeyboardView extends PureComponent<Props> {
-  static defaultProps = {
-    style: {
-      flex: 1,
-    },
-  };
-
-  render(): React$Node {
-    const { style, children } = this.props;
+const KeyboardView = React.memo<Props>(
+  ({ style = { flex: 1 }, children }: *) => {
+    const isExperimental = useExperimental();
     let behavior;
-    let keyboardVerticalOffset = 0;
+    let keyboardVerticalOffset = isExperimental ? ExperimentalHeader.HEIGHT : 0;
     if (Platform.OS === "ios") {
-      keyboardVerticalOffset = DeviceInfo.isIPhoneX_deprecated ? 88 : 64;
+      keyboardVerticalOffset += DeviceInfo.isIPhoneX_deprecated ? 88 : 64;
       behavior = "padding";
     }
 
@@ -35,7 +31,7 @@ class KeyboardView extends PureComponent<Props> {
         {children}
       </KeyboardAvoidingView>
     );
-  }
-}
+  },
+);
 
 export default KeyboardView;

--- a/src/components/KeyboardView.js
+++ b/src/components/KeyboardView.js
@@ -1,7 +1,7 @@
 // @flow
 import React from "react";
 import { KeyboardAvoidingView, Platform, NativeModules } from "react-native";
-import * as ExperimentalHeader from "../screens/Settings/Experimental/ExperimentalHeader";
+import { HEIGHT as ExperimentalHeaderHeight } from "../screens/Settings/Experimental/ExperimentalHeader";
 import useExperimental from "../screens/Settings/Experimental/useExperimental";
 
 const { DeviceInfo } = NativeModules;
@@ -15,7 +15,7 @@ const KeyboardView = React.memo<Props>(
   ({ style = { flex: 1 }, children }: *) => {
     const isExperimental = useExperimental();
     let behavior;
-    let keyboardVerticalOffset = isExperimental ? ExperimentalHeader.HEIGHT : 0;
+    let keyboardVerticalOffset = isExperimental ? ExperimentalHeaderHeight : 0;
     if (Platform.OS === "ios") {
       keyboardVerticalOffset += DeviceInfo.isIPhoneX_deprecated ? 88 : 64;
       behavior = "padding";

--- a/src/screens/Settings/Experimental/ExperimentalHeader.js
+++ b/src/screens/Settings/Experimental/ExperimentalHeader.js
@@ -12,6 +12,7 @@ import ExperimentalIcon from "../../../icons/Experimental";
 import { rejections } from "../../../logic/debugReject";
 
 const { cond, set, Clock, Value, interpolate, eq } = Animated;
+export const HEIGHT = Platform.OS === "ios" ? 70 : 30;
 
 function ExperimentalHeader({ isExperimental }: { isExperimental: boolean }) {
   const { colors } = useTheme();
@@ -41,7 +42,7 @@ function ExperimentalHeader({ isExperimental }: { isExperimental: boolean }) {
   // interpolated height from opening anim state for list container
   const height = interpolate(openingAnim, {
     inputRange: [0, 1],
-    outputRange: [0, Platform.OS === "ios" ? 70 : 30],
+    outputRange: [0, HEIGHT],
     extrapolate: Extrapolate.CLAMP,
   });
 


### PR DESCRIPTION
Fixes keyboard covering up the bottom of the visible screen when the `Experimental features` header is displayed.

<details>
  <summary>Iphone 8 📸 </summary>
  
![Simulator Screen Shot - iPhone 8 - 2021-07-09 at 11 25 30](https://user-images.githubusercontent.com/86958797/125060436-ab6d5d00-e0ac-11eb-8e7e-617b6de04451.png)
![Simulator Screen Shot - iPhone 8 - 2021-07-09 at 11 25 54](https://user-images.githubusercontent.com/86958797/125060440-ac9e8a00-e0ac-11eb-931c-18d615a3e5cf.png)

</details>

<details>
  <summary>Iphone 11 📸 </summary>

![Simulator Screen Shot - iPhone 11 - 2021-07-09 at 11 47 45](https://user-images.githubusercontent.com/86958797/125060481-b4f6c500-e0ac-11eb-9a94-4c76f92522e8.png)
![Simulator Screen Shot - iPhone 11 - 2021-07-09 at 11 48 18](https://user-images.githubusercontent.com/86958797/125060483-b627f200-e0ac-11eb-96de-c785938b4f47.png)

</details>

<details>
  <summary>Android 📸 </summary>

![Screenshot_1625823061](https://user-images.githubusercontent.com/86958797/125060514-bfb15a00-e0ac-11eb-9d42-98d2612fb8f2.png)

---

![Screenshot_1625823133](https://user-images.githubusercontent.com/86958797/125060519-c049f080-e0ac-11eb-8264-78e156323710.png)

</details>

### Type

Bug Fix

### Context

[LL-6317]

### Parts of the app affected / Test plan

- Select any input triggering the keyboard on IOS.
- The bottom of the screen should not be hidden by the keyboard any more.

*The original issue was specifically about the "Amount" step of the "Send" flow, but my understanding is that it happens for any input.*


[LL-6317]: https://ledgerhq.atlassian.net/browse/LL-6317