### PR TITLE
LL-5174 - Change navigation in OperationDetails to prevent navigation stack infinite loop

### DIFF
--- a/src/screens/OperationDetails/Content.js
+++ b/src/screens/OperationDetails/Content.js
@@ -76,15 +76,16 @@ export default function Content({
   const [isModalOpened, setIsModalOpened] = useState(false);
 
   const onPress = useCallback(() => {
-    navigation.navigate(NavigatorName.Accounts);
-    // setTimeout is the way to make sure that it navigates to accounts screen first
-    // then stack account screen on top
-    setTimeout(() =>
-      navigation.navigate(ScreenName.Account, {
+    navigation.navigate(NavigatorName.Accounts, {
+      screen: ScreenName.Account,
+      initial: false,
+      // Set to false so it still adds `Accounts` as the previous route in the stack history
+      // even if you're targeting another navigation stack from your current one
+      params: {
         accountId: account.id,
-        parentId: parentAccount && parentAccount.id,
-      }),
-    );
+        parentId: parentAccount?.id,
+      },
+    });
   }, [account.id, navigation, parentAccount]);
 
   const onPressInfo = useCallback(() => {


### PR DESCRIPTION
Pressing on the Account on the OperationDetails view was opening a View with the same animation as a Drawer + it could lead to an infinite stacking of views when coming from the portfolio. 


### Videos
<details>
  <summary>iOS 📸 </summary>

https://user-images.githubusercontent.com/86959861/125322718-5cd6f180-e33e-11eb-95d2-5d07ca53c88a.mp4

</details>

<details>
  <summary>Android 📸 </summary>

https://user-images.githubusercontent.com/86959861/125324955-b2140280-e340-11eb-937f-ee709c847f7c.mp4
</details>

### Type

Bug Fix

### Context

[LL-5174](https://ledgerhq.atlassian.net/browse/LL-5174)

### Parts of the app affected / Test plan

Portfolio -> Transaction -> Click on Account ID
Portfolio -> Assets -> Long Press on Asset -> Transaction -> Click on Account ID
Accounts -> Account -> Transaction -> Click on Account ID

