### PR TITLE
LL-6369 - Add info panel for platform apps

### DIFF
--- a/src/components/WebPlatformPlayer/InfoPanel.js
+++ b/src/components/WebPlatformPlayer/InfoPanel.js
@@ -1,0 +1,158 @@
+// @flow
+import React, { useCallback } from "react";
+
+import { Trans } from "react-i18next";
+import { useSelector } from "react-redux";
+import { useTheme } from "@react-navigation/native";
+import { StyleSheet, View, TouchableOpacity, Linking } from "react-native";
+import { translateContent } from "@ledgerhq/live-common/lib/platform/logic";
+import type { TranslatableString } from "@ledgerhq/live-common/lib/platform/types";
+
+import { languageSelector } from "../../reducers/settings";
+import ExternalLinkIcon from "../../icons/ExternalLink";
+import AppIcon from "../../screens/Platform/AppIcon";
+import CloseIcon from "../../icons/Close";
+import BottomModal from "../BottomModal";
+import LText from "../LText";
+
+type Props = {
+  name: string,
+  icon?: string | null,
+  description: TranslatableString,
+  url?: string | null,
+  isOpened: boolean,
+  setIsOpened: (isOpened: boolean) => void,
+};
+
+const InfoPanel = ({
+  name,
+  icon,
+  description,
+  url,
+  isOpened,
+  setIsOpened,
+}: Props) => {
+  const settingsLocale = useSelector(languageSelector);
+  const { colors } = useTheme();
+
+  const onClose = useCallback(() => {
+    setIsOpened(false);
+  }, [setIsOpened]);
+  const onLinkPress = useCallback(url => {
+    Linking.openURL(url);
+  }, []);
+
+  return (
+    <BottomModal
+      style={{
+        ...styles.root,
+        backgroundColor: colors.card,
+      }}
+      id="InfoPanelModal"
+      isOpened={isOpened}
+      onClose={onClose}
+    >
+      <TouchableOpacity style={styles.closeIcon} onPress={onClose}>
+        <CloseIcon size={18} />
+      </TouchableOpacity>
+      <View style={{ ...styles.flexRow, ...styles.titleContainer }}>
+        {icon ? (
+          <View style={styles.appIcon}>
+            <AppIcon size={40} name={name} icon={icon} />
+          </View>
+        ) : null}
+        <LText
+          semidbold
+          style={{
+            ...styles.title,
+            color: colors.contrastBackground,
+          }}
+        >
+          {name}
+        </LText>
+      </View>
+      <LText
+        style={{
+          ...styles.basicFontStyle,
+          ...styles.description,
+          color: colors.contrastBackground,
+        }}
+      >
+        {translateContent(description, settingsLocale)}
+      </LText>
+      {url ? (
+        <>
+          <View style={styles.hr} />
+          <LText semibold style={styles.subSectionTitle}>
+            <Trans i18nKey="platform.webPlatformPlayer.infoPanel.website" />
+          </LText>
+          <TouchableOpacity
+            style={styles.flexRow}
+            onPress={() => onLinkPress(url)}
+          >
+            <LText
+              semibold
+              style={{ ...styles.basicFontStyle, color: colors.live }}
+            >
+              {url}
+            </LText>
+            <View style={styles.externalLinkIcon}>
+              <ExternalLinkIcon size={14} color={colors.live} />
+            </View>
+          </TouchableOpacity>
+        </>
+      ) : null}
+    </BottomModal>
+  );
+};
+
+const styles = StyleSheet.create({
+  root: {
+    paddingHorizontal: 24,
+    paddingVertical: 30,
+    position: "relative",
+  },
+  flexRow: {
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  basicFontStyle: {
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  titleContainer: {
+    marginBottom: 16,
+  },
+  appIcon: {
+    paddingRight: 12,
+  },
+  title: {
+    fontSize: 22,
+  },
+  description: {
+    opacity: 0.5,
+  },
+  hr: {
+    borderBottomColor: "rgba(20, 37, 51, 0.1)",
+    borderBottomWidth: 1,
+    paddingTop: 32,
+    marginBottom: 32,
+  },
+  subSectionTitle: {
+    textTransform: "capitalize",
+    fontWeight: "600",
+    marginBottom: 4,
+  },
+  externalLinkIcon: {
+    paddingLeft: 6,
+  },
+  closeIcon: {
+    position: "absolute",
+    top: 8,
+    right: 16,
+    opacity: 0.5,
+  },
+});
+
+export default InfoPanel;

--- a/src/components/WebPlatformPlayer/index.js
+++ b/src/components/WebPlatformPlayer/index.js
@@ -45,6 +45,8 @@ import { NavigatorName, ScreenName } from "../../const";
 import { broadcastSignedTx } from "../../logic/screenTransactionHooks";
 import { accountsSelector } from "../../reducers/accounts";
 import UpdateIcon from "../../icons/Update";
+import InfoIcon from "../../icons/Info";
+import InfoPanel from "./InfoPanel";
 
 import * as tracking from "./tracking";
 
@@ -73,6 +75,30 @@ const ReloadButton = ({
   );
 };
 
+const InfoPanelButton = ({
+  loading,
+  setIsInfoPanelOpened,
+}: {
+  loading: boolean,
+  setIsInfoPanelOpened: (isInfoPanelOpened: boolean) => void,
+}) => {
+  const { colors } = useTheme();
+
+  const onPress = () => {
+    setIsInfoPanelOpened(true);
+  };
+
+  return (
+    <TouchableOpacity
+      style={styles.buttons}
+      disabled={loading}
+      onPress={onPress}
+    >
+      <InfoIcon size={18} color={colors.grey} />
+    </TouchableOpacity>
+  );
+};
+
 const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
   const targetRef: { current: null | WebView } = useRef(null);
   const accounts = useSelector(accountsSelector);
@@ -81,6 +107,7 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
 
   const [loadDate, setLoadDate] = useState(Date.now());
   const [widgetLoaded, setWidgetLoaded] = useState(false);
+  const [isInfoPanelOpened, setIsInfoPanelOpened] = useState(false);
 
   const uri = useMemo(() => {
     const url = new URL(manifest.url);
@@ -424,10 +451,18 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
   useEffect(() => {
     navigation.setOptions({
       headerRight: () => (
-        <ReloadButton onReload={handleReload} loading={!widgetLoaded} />
+        <View style={styles.headerRight}>
+          <ReloadButton onReload={handleReload} loading={!widgetLoaded} />
+          <InfoPanelButton
+            onReload={handleReload}
+            loading={!widgetLoaded}
+            isInfoPanelOpened={isInfoPanelOpened}
+            setIsInfoPanelOpened={setIsInfoPanelOpened}
+          />
+        </View>
       ),
     });
-  }, [navigation, widgetLoaded, handleReload]);
+  }, [navigation, widgetLoaded, handleReload, isInfoPanelOpened]);
 
   useEffect(() => {
     tracking.platformLoad(manifest);
@@ -435,6 +470,14 @@ const WebPlatformPlayer = ({ manifest, inputs }: Props) => {
 
   return (
     <SafeAreaView style={[styles.root]}>
+      <InfoPanel
+        name={manifest.name}
+        icon={manifest.icon}
+        url={manifest.homepageUrl}
+        description={manifest.content.description}
+        isOpened={isInfoPanelOpened}
+        setIsOpened={setIsInfoPanelOpened}
+      />
       <WebView
         ref={targetRef}
         startInLoadingState={true}
@@ -465,6 +508,11 @@ const styles = StyleSheet.create({
   root: {
     flex: 1,
   },
+  headerRight: {
+    display: "flex",
+    flexDirection: "row",
+    paddingRight: 8,
+  },
   center: {
     flex: 1,
     flexDirection: "column",
@@ -485,7 +533,8 @@ const styles = StyleSheet.create({
     height: "100%",
   },
   buttons: {
-    padding: 16,
+    paddingVertical: 8,
+    paddingHorizontal: 8,
   },
 });
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -3679,6 +3679,11 @@
       "legalAdvice": "This application is not operated by Ledger. Ledger is not responsible for any loss of funds or quality of service of such application.\n\nAlways make sure to carefully verify the information displayed on your device.",
       "checkbox": "Do not remind me again.",
       "CTA": "Continue"
+    },
+    "webPlatformPlayer": {
+      "infoPanel": {
+        "website": "website"
+      }
     }
   }
 }


### PR DESCRIPTION
Add a "drawer" for platform apps when you're clicking on an info button at the top of the app.

### Screenshots
<details>
  <summary>iOS 📸 </summary>

<img src="https://user-images.githubusercontent.com/86959861/125473981-80be2f19-bb36-4e74-be7e-3fdd4eca531d.png" width="400" />
&nbsp;
<img src="https://user-images.githubusercontent.com/86959861/125473987-19e841fb-cdc2-44e0-b769-09873f3b1d6c.png" width="400" />
</details>

<details>
  <summary>Android 📸 </summary>

<img src="https://user-images.githubusercontent.com/86959861/125476031-39f1f42e-e5c1-4bc2-b712-cd67f97f9d02.png" width="400" />
&nbsp;
<img src="https://user-images.githubusercontent.com/86959861/125476035-d3f674d1-e4fb-4a61-b05c-ef5c375cda87.png" width="400" />
</details>

### Type

Feature

### Context

[LL-6362](https://ledgerhq.atlassian.net/browse/LL-6362)

### Parts of the app affected / Test plan

Any platform app.
For test purposes, the icon and url are not mandatory.
