### PR TITLE
LL-6280 Update counter values translation

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1583,7 +1583,7 @@
       "languageDesc": "Set the language displayed in Ledger Live.",
       "password": "Password lock",
       "passwordDesc": "Set a password to protect Ledger Live data on your phone.",
-      "counterValue": "Countervalue",
+      "counterValue": "Preferred currency",
       "theme": "Theme",
       "themeDesc": "Set the app UI theme",
       "themes": {
@@ -3587,7 +3587,7 @@
         "title": "Discover our Live Catalog",
         "description": "Unlock a new world of crypto possibilities. One secure access to all services – DeFi, NFTs and more to come."
       },
-      "twitterBanner":  {
+      "twitterBanner": {
         "description": "Tell us what's the next service you want to see with the hashtag",
         "tweetText": "The next Ledger App should be..."
       },


### PR DESCRIPTION
As counter values make no sense for our users, we're now displaying the label "preferred currency" which is more natural.

<details>
  <summary>Mobile screenshots</summary>

  
![Simulator Screen Shot - iPhone 11 - 2021-07-15 at 16 11 00](https://user-images.githubusercontent.com/33158502/125802433-c915669e-c109-4d39-ae35-c3d006a0b70f.png)
![Simulator Screen Shot - iPhone 11 - 2021-07-15 at 16 11 02](https://user-images.githubusercontent.com/33158502/125802443-951acc78-84fd-4d03-a31f-fb057adc354b.png)

</details>

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Internationalization

### Context

[LL-6280]

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

Settings -> general

[LL-6281]: https://ledgerhq.atlassian.net/browse/LL-6281

[LL-6280]: https://ledgerhq.atlassian.net/browse/LL-6280