### PR TITLE
LL-6430 App is crashing when user try to open new notifications

### DIFF
--- a/src/screens/NotificationCenter/NewsRow.js
+++ b/src/screens/NotificationCenter/NewsRow.js
@@ -59,7 +59,7 @@ export default function NewsRow({
     if (isDeepLink) {
       handler(url.href);
     } else Linking.openURL(url.href);
-  }, [handler, link.href, utmCampaign]);
+  }, [handler, link?.href, utmCampaign]);
 
   return (
     <View


### PR DESCRIPTION
As all notifications aren't designed to embed a link, array dependencies from openUrl function triggered an error.

### Type

Bug Fix

### Context

~~[Slack message](https://ledger.slack.com/archives/C01S86NNMR7/p1626445268155400) (awaiting real bug ticket)~~
[LL-6430]

### Parts of the app affected / Test plan

Click on the notification icon when the backend is sending new notification without any link inside.
<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LL-6430]: https://ledgerhq.atlassian.net/browse/LL-6430