### PR TITLE
feat(manager): use displayName in applist instead of name

### DIFF
--- a/src/screens/Manager/AppsList/AppRow.js
+++ b/src/screens/Manager/AppsList/AppRow.js
@@ -38,7 +38,7 @@ const AppRow = ({
   setStorageWarning,
   optimisticState,
 }: Props) => {
-  const { name, bytes, version: appVersion } = app;
+  const { name, bytes, version: appVersion, displayName } = app;
   const { installed, deviceInfo } = state;
 
   const isInstalled = useMemo(() => installed.find(i => i.name === name), [
@@ -76,7 +76,7 @@ const AppRow = ({
         <AppIcon app={app} />
         <View style={styles.labelContainer}>
           <LText numberOfLines={1} bold>
-            {name}
+            {displayName}
           </LText>
           <LText numberOfLines={1} style={styles.versionText} color="grey">
             {version}{" "}


### PR DESCRIPTION
use display_name in appList instead of name

needs https://github.com/LedgerHQ/ledger-live-common/pull/1309

### Type

Improvement

### Context

[LL-6299]

### Parts of the app affected / Test plan

Manager => AppList


[LL-6299]: https://ledgerhq.atlassian.net/browse/LL-6299