### PR TITLE
LL-6084 - Filter ANN by Live versions

### DIFF
--- a/src/screens/NotificationCenter/NotificationsProvider.js
+++ b/src/screens/NotificationCenter/NotificationsProvider.js
@@ -6,6 +6,7 @@ import { AnnouncementProvider } from "@ledgerhq/live-common/lib/notifications/An
 import { ServiceStatusProvider } from "@ledgerhq/live-common/lib/notifications/ServiceStatusProvider";
 import { useToasts } from "@ledgerhq/live-common/lib/notifications/ToastProvider/index";
 import type { Announcement } from "@ledgerhq/live-common/lib/notifications/AnnouncementProvider/types";
+import VersionNumber from "react-native-version-number";
 import { getNotifications, saveNotifications } from "../../db";
 import { useLocale } from "../../context/Locale";
 import { cryptoCurrenciesSelector } from "../../reducers/accounts";
@@ -31,6 +32,7 @@ export default function NotificationsProvider({ children }: Props) {
     getDate: () => new Date(),
     lastSeenDevice: lastSeenDevice || undefined,
     platform: Platform.OS,
+    appVersion: VersionNumber.appVersion ?? undefined,
   };
 
   const onLoad = useCallback(

--- a/src/screens/Settings/Debug/GenerateAnnouncementMockData.js
+++ b/src/screens/Settings/Debug/GenerateAnnouncementMockData.js
@@ -31,6 +31,8 @@ export default function AddMockAnnouncementButton({
 
   const [announcementLink, setAnnouncementLink] = useState();
   const [notifPlatform, setNotifPlatform] = useState("");
+  const [notifAppVersions, setNotifAppVersions] = useState("");
+  const [notifLiveCommonVersions, setNotifLiveCommonVersions] = useState("");
   const [notifCurrencies, setNotifCurrencies] = useState("");
   const [notifDeviceVersion, setNotifDeviceVersion] = useState("");
   const [notifDeviceModelId, setNotifDeviceModelId] = useState("");
@@ -44,6 +46,8 @@ export default function AddMockAnnouncementButton({
     const params = {
       currencies: formatInputValue(notifCurrencies),
       platforms: formatInputValue(notifPlatform),
+      appVersions: formatInputValue(notifAppVersions),
+      liveCommonVersions: formatInputValue(notifLiveCommonVersions),
       languages: formatInputValue(notifLanguages),
     };
 
@@ -86,6 +90,8 @@ export default function AddMockAnnouncementButton({
     notifDeviceVersion,
     notifLanguages,
     notifPlatform,
+    notifAppVersions,
+    notifLiveCommonVersions,
     onClose,
     updateCache,
   ]);
@@ -131,6 +137,20 @@ export default function AddMockAnnouncementButton({
           placeholder="languages separated by ','"
           value={notifLanguages}
           onChangeText={setNotifLanguages}
+        />
+
+        <TextInput
+          style={styles.textInput}
+          placeholder="app versions separated by ','"
+          value={notifAppVersions}
+          onChangeText={setNotifAppVersions}
+        />
+
+        <TextInput
+          style={styles.textInput}
+          placeholder="live-common versions separated by ','"
+          value={notifLiveCommonVersions}
+          onChangeText={setNotifLiveCommonVersions}
         />
 
         <TextInput


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Feature

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

[LL-6084]

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->

Announces.
To test this feature, you will have to wait for the ledger-live-common bump. Current modification from ledger-live-common is [here](https://github.com/LedgerHQ/ledger-live-common/pull/1310). Once this PR is merged, the ledger-live-common package published and updated from this repository, you'll be able to test it.


[LL-6084]: https://ledgerhq.atlassian.net/browse/LL-6084