### PR TITLE
[BUGFIX] remove duplicated dangerouslyGetParent call

### DIFF
--- a/src/components/WebPlatformPlayer/index.js
+++ b/src/components/WebPlatformPlayer/index.js
@@ -297,7 +297,7 @@ const WebPlatformPlayer = ({ manifest }: Props) => {
                 tracking.platformSignTransactionSuccess(manifest);
                 resolve(signedOperation);
                 const n = navigation.dangerouslyGetParent() || navigation;
-                n.dangerouslyGetParent().pop();
+                n.pop();
               }
             },
             onError: error => {


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

Fix error at the end of sign transaction flow when using ParaSwap dapp in "discover" tab (aka apps catalog)


<details>
<summary>🎥  </summary>



https://user-images.githubusercontent.com/87011321/127208970-c03a960b-2fbf-465a-9054-b08b04df4937.mov




</details>



### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

🐞  Bug Fix

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

https://ledgerhq.atlassian.net/browse/LL-6527

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->

Apps catalog and more precisely the sign transaction flow in the Apps catalog.
Test that it fixes the aforementioned issue in ParaSwap.

Validate that it does not change the behaviour for other dapps using a sign transaction flow (maybe Wyre but not sure)

