### PR TITLE
LL-6597 Swap - Make floating rate default again

### DIFF
--- a/src/screens/Swap/FormOrHistory/Form/Amount.js
+++ b/src/screens/Swap/FormOrHistory/Form/Amount.js
@@ -84,7 +84,7 @@ const SwapFormAmount = ({ navigation, route }: Props) => {
     [fromCurrency, provider, providers, toCurrency],
   );
   const [tradeMethod, setTradeMethod] = useState<"fixed" | "float">(
-    enabledTradeMethods[0] || "fixed",
+    enabledTradeMethods[0] || "float",
   );
 
   const {


### PR DESCRIPTION
With the merger of the Wyre pr I introduced a regression that set the default trade method back to fixed, I assume this was done during development for some reason and I completely missed it.

### Type
Bug fix

### Context
https://ledgerhq.atlassian.net/browse/LL-6597

### Parts of the app affected / Test plan
Check that when selecting a currency pair the default trade method selected is float when available