### PR TITLE
LL6301 - Swap v2 entry point

### DIFF
--- a/src/components/RootNavigator/SwapNavigator.js
+++ b/src/components/RootNavigator/SwapNavigator.js
@@ -4,6 +4,7 @@ import React, { useMemo } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { useTranslation } from "react-i18next";
 import { useTheme } from "@react-navigation/native";
+import useEnv from "@ledgerhq/live-common/lib/hooks/useEnv";
 import { ScreenName } from "../../const";
 import SwapFormOrHistory from "../../screens/Swap/FormOrHistory";
 import SwapSummary from "../../screens/Swap/FormOrHistory/Form/Summary";
@@ -12,6 +13,7 @@ import SwapFormAmount from "../../screens/Swap/FormOrHistory/Form/Amount";
 import SwapKYC from "../../screens/Swap/KYC";
 import SwapKYCStates from "../../screens/Swap/KYC/StateSelect";
 import Swap from "../../screens/Swap";
+import Swap2 from "../../screens/Swap2";
 import SwapOperationDetails from "../../screens/Swap/FormOrHistory/OperationDetails";
 import { BackButton } from "../../screens/OperationDetails";
 import SwapPendingOperation from "../../screens/Swap/FormOrHistory/Form/PendingOperation";
@@ -24,10 +26,27 @@ import StepHeader from "../StepHeader";
 export default function SwapNavigator() {
   const { t } = useTranslation();
   const { colors } = useTheme();
+  const isSwapV2Enabled = useEnv("EXPERIMENTAL_SWAP") && __DEV__;
   const stackNavigationConfig = useMemo(
     () => getStackNavigatorConfig(colors, true),
     [colors],
   );
+
+  if (isSwapV2Enabled) {
+    return (
+      <Stack.Navigator screenOptions={stackNavigationConfig}>
+        <Stack.Screen
+          name={ScreenName.Swap}
+          component={Swap2}
+          options={{
+            headerStyle: styles.headerNoShadow,
+            title: t("transfer.swap.landing.header"),
+          }}
+        />
+      </Stack.Navigator>
+    );
+  }
+
   return (
     <Stack.Navigator screenOptions={stackNavigationConfig}>
       <Stack.Screen

--- a/src/experimental.js
+++ b/src/experimental.js
@@ -54,6 +54,12 @@ export const experimentalFeatures: Feature[] = [
     description:
       "Try an upcoming version of Ledger's blockchain explorers. Changing this setting may affect the account balance and synchronization as well as the send feature.",
   },
+  {
+    type: "toggle",
+    name: "EXPERIMENTAL_SWAP",
+    title: "New SWAP interface ",
+    description: "Use the new experimental swap interface",
+  },
 ];
 
 const storageKey = "experimentalFlags";

--- a/src/experimental.js
+++ b/src/experimental.js
@@ -54,12 +54,16 @@ export const experimentalFeatures: Feature[] = [
     description:
       "Try an upcoming version of Ledger's blockchain explorers. Changing this setting may affect the account balance and synchronization as well as the send feature.",
   },
-  {
-    type: "toggle",
-    name: "EXPERIMENTAL_SWAP",
-    title: "New SWAP interface ",
-    description: "Use the new experimental swap interface",
-  },
+  ...(__DEV__
+    ? [
+        {
+          type: "toggle",
+          name: "EXPERIMENTAL_SWAP",
+          title: "New SWAP interface ",
+          description: "Use the new experimental swap interface",
+        },
+      ]
+    : []),
 ];
 
 const storageKey = "experimentalFlags";

--- a/src/screens/Swap2/index.js
+++ b/src/screens/Swap2/index.js
@@ -1,0 +1,22 @@
+// @flow
+
+import { useTheme } from "@react-navigation/native";
+import React from "react";
+import { SafeAreaView, StyleSheet } from "react-native";
+import LText from "../../components/LText";
+
+export default function SwapEntrypoint() {
+  const { colors } = useTheme();
+
+  return (
+    <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>
+      <LText>Swap V2 💸</LText>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
- Created a blank swap v2 entry screen.
- Added an experimental flag to switch between regular and in-progress swap screens. (*only in `__DEV__` mode*)

https://user-images.githubusercontent.com/86958797/130048720-f6a6b098-9b27-4702-be45-dda61bbec3b8.mp4

### Type

Chore

### Context

https://ledgerhq.atlassian.net/browse/LL-6301

### Parts of the app affected / Test plan

Swap V2 landing screen & Experimental flags
