### PR TITLE
LL 6884 - Add discover deeplink

### DIFF
--- a/deep-links-test-page.html
+++ b/deep-links-test-page.html
@@ -150,6 +150,18 @@
         <p>ledgerlive://swap</p>
         <p>🔗</p>
       </button>
+
+      <div class="separator"></div>
+      <button class="link" onclick="onClick('ledgerlive:\/\/discover')">
+        <p>ledgerlive://discover</p>
+        <p>🔗</p>
+      </button>
+
+      <div class="separator"></div>
+      <button class="link" onclick="onClick('ledgerlive:\/\/discover\/paraswap')">
+        <p>ledgerlive://discover/paraswap</p>
+        <p>🔗</p>
+      </button>
     </div>
     <script>
       let currency = "bitcoin";

--- a/src/index.js
+++ b/src/index.js
@@ -246,11 +246,11 @@ const linking = {
          */
         [ScreenName.WalletConnectDeeplinkingSelectAccount]: "wc",
         [NavigatorName.Main]: {
-          /**
-           * ie: "ledgerlive://portfolio" -> will redirect to the portfolio
-           */
           initialRouteName: ScreenName.Portfolio,
           screens: {
+            /**
+             * ie: "ledgerlive://portfolio" -> will redirect to the portfolio
+             */
             [ScreenName.Portfolio]: "portfolio",
             [NavigatorName.Accounts]: {
               screens: {
@@ -259,6 +259,16 @@ const linking = {
                  * ie: "ledgerlive://account?currency=bitcoin" will open the first bitcoin account
                  */
                 [ScreenName.Accounts]: "account",
+              },
+            },
+            [NavigatorName.Platform]: {
+              screens: {
+                /**
+                 * @params ?platform: string
+                 * ie: "ledgerlive://discover" will open the catalog
+                 * ie: "ledgerlive://discover/paraswap?theme=light" will open the catalog and the paraswap dapp with a light theme as parameter
+                 */
+                [ScreenName.PlatformCatalog]: "discover/:platform?",
               },
             },
           },

--- a/src/screens/Platform/App.js
+++ b/src/screens/Platform/App.js
@@ -1,28 +1,31 @@
+// @flow
+
 import React from "react";
 import { usePlatformApp } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider";
-
+import type { StackScreenProps } from "@react-navigation/stack";
 import { useTheme } from "@react-navigation/native";
 import TrackScreen from "../../analytics/TrackScreen";
 import WebPlatformPlayer from "../../components/WebPlatformPlayer";
 
-const PlatformApp = ({ route }: { route: { params: Props } }) => {
+const PlatformApp = ({ route }: StackScreenProps) => {
   const { dark } = useTheme();
-  const appId = route.params.platform;
+  const { platform: appId, ...params } = route.params;
   const { manifests } = usePlatformApp();
   const manifest = manifests.get(appId);
   const themeType = dark ? "dark" : "light";
 
-  return (
+  return manifest ? (
     <>
       <TrackScreen category="Platform" name="App" />
       <WebPlatformPlayer
         manifest={manifest}
         inputs={{
           theme: themeType,
+          ...params,
         }}
       />
     </>
-  );
+  ) : null;
 };
 
 export default PlatformApp;

--- a/src/screens/Platform/index.js
+++ b/src/screens/Platform/index.js
@@ -26,6 +26,7 @@ import AnimatedHeaderView from "../../components/AnimatedHeader";
 type RouteParams = {
   defaultAccount: ?AccountLike,
   defaultParentAccount: ?Account,
+  platform?: ?string,
 };
 
 type DisclaimerOpts = $Diff<DisclaimerProps, { isOpened: boolean }> | null;
@@ -33,7 +34,7 @@ type DisclaimerOpts = $Diff<DisclaimerProps, { isOpened: boolean }> | null;
 const DAPP_DISCLAIMER_ID = "PlatformAppDisclaimer";
 
 const PlatformCatalog = ({ route }: { route: { params: RouteParams } }) => {
-  const { params: routeParams } = route;
+  const { platform, ...routeParams } = route.params ?? {};
   const { colors } = useTheme();
   const navigation = useNavigation();
 
@@ -83,6 +84,19 @@ const PlatformCatalog = ({ route }: { route: { params: RouteParams } }) => {
   const handleDeveloperCTAPress = useCallback(() => {
     Linking.openURL(urls.platform.developerPage);
   }, []);
+
+  // platform can be predefined when coming from a deeplink
+  if (platform) {
+    const manifest = filteredManifests.find(m => m.id === platform);
+
+    if (manifest) {
+      navigation.navigate(ScreenName.PlatformApp, {
+        ...routeParams,
+        platform: manifest.id,
+        name: manifest.name,
+      });
+    }
+  }
 
   return (
     <AnimatedHeaderView


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
Adding deeplinks to the platform catalog and dapps

#### Video
<details>
    <summary> iOS</summary>


https://user-images.githubusercontent.com/86959861/132313597-7c727b3e-70bc-4bd6-a792-1106149f4e27.mov


</details>

### Type

Feature

### Context

[LL-6884](https://ledgerhq.atlassian.net/browse/LL-6884)

### Parts of the app affected / Test plan

Deep Links:

`ledgerlive://discover`
`ledgerlive://discover/paraswap` (or any other app id)
`ledgerlive://discover/paraswap?theme=dark` (or any other param that would make sense to pass to the dapp)
