### PR TITLE
[LL-6484] [Android] Switch to AAB

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -195,16 +195,13 @@ android {
             matchingFallbacks = ['release']
         }
     }
+
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
-            // For each separate APK per architecture, set a unique version code as described here:
-            // https://developer.android.com/studio/build/configure-apk-splits.html
-            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
-            def abi = output.getFilter(OutputFile.ABI)
-            if (abi != null) {  // null for the universal-debug, universal-release variants
-                output.versionCodeOverride =
-                        versionCodes.get(abi) * 1048576 + defaultConfig.versionCode
+            // because we used split APKs needing some versioning magic before,
+            // the versionCode has to be bumped to a value higher than anything we previously used
+                4 * 1048576 + defaultConfig.versionCode
             }
         }
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -240,7 +240,7 @@ platform :android do
 
     gradle(task: "clean", project_dir: 'android/')
     gradle(
-      task: "assemble",
+      task: "bundle",
       build_type: type,
       print_command: false,
       properties: {


### PR DESCRIPTION
Switch packaging of the Android app from split APKs to single AAB.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-6484
https://android-developers.googleblog.com/2021/06/the-future-of-android-app-bundles-is.html

### Parts of the app affected

Android packaging / release

### Note

Needs new "upload" keystore and key.

### To do

- [x] make it possible to upload, list and install via the Google Play Console
- [ ] make it possible to install production version locally (without going through Play Console)
