### PR TITLE
LL-6906 LL-6907 Allow for a bigger cta for add tokens Language cache bug

### DIFF
--- a/src/components/TabIcon.js
+++ b/src/components/TabIcon.js
@@ -1,7 +1,7 @@
 /* @flow */
 import React from "react";
 import { View, StyleSheet } from "react-native";
-import { Trans } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import LText from "./LText";
 
 type Props = {
@@ -12,6 +12,7 @@ type Props = {
 };
 
 export default function TabIcon({ Icon, i18nKey, color, focused }: Props) {
+  const { t } = useTranslation();
   return (
     <View style={styles.root}>
       <Icon size={20} color={color} />
@@ -22,7 +23,7 @@ export default function TabIcon({ Icon, i18nKey, color, focused }: Props) {
         secondary
         style={[styles.text, { color }]}
       >
-        <Trans i18nKey={i18nKey} />
+        {t(i18nKey)}
       </LText>
     </View>
   );

--- a/src/screens/Account/SubAccountsList.js
+++ b/src/screens/Account/SubAccountsList.js
@@ -141,7 +141,6 @@ export default function SubAccountsList({
             <ReceiveButton accountId={accountId} />
           ) : (
             <Button
-              containerStyle={{ width: 120 }}
               type="lightSecondary"
               event="AccountReceiveToken"
               title={<Trans i18nKey="account.tokens.addTokens" />}


### PR DESCRIPTION
- [LL-6906](https://ledgerhq.atlassian.net/browse/LL-6906) Can't really be tested without changing the wording manually, to do this edit the `src/locales/fr/common.json` and edit `account.tokens.addTokens` to be something longer than just "Tokens", the button cta should grow like in the screenshot instead of being cut-off like on the Jira task.

- [LL-6907](https://ledgerhq.atlassian.net/browse/LL-6907) You simply need to switch between french and english in the settings and make sure that the bottom tab navigation labels are translated (there's the case for "Discover" which is not translated, so this doesn't apply), on develop there seems to be a cache where portfolio and accounts keep the old language when switching, this should not happen in this pr.

### Type

UI Polish + Bug Fix

### Context
https://ledgerhq.atlassian.net/browse/LL-6906
https://ledgerhq.atlassian.net/browse/LL-6907

<img width="480" alt="image" src="https://user-images.githubusercontent.com/4631227/133248059-0d0e8be5-9d7d-451f-a18e-bbf78ea2b507.png">

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
