### PR TITLE
LL-4045 Automatically display keyboard on password screens

### DIFF
--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -1,5 +1,5 @@
 /* @flow */
-import React, { PureComponent } from "react";
+import React, { useEffect, useState, useCallback, useRef } from "react";
 import { View, StyleSheet, TextInput } from "react-native";
 import Icon from "react-native-vector-icons/dist/Feather";
 import Touchable from "./Touchable";
@@ -21,106 +21,111 @@ type Props = {
   colors: *,
 };
 
-class PasswordInput extends PureComponent<Props, { isFocused: boolean }> {
-  state = { isFocused: false };
+const PasswordInput = ({
+  autoFocus,
+  error,
+  secureTextEntry,
+  onChange,
+  onSubmit,
+  onFocus,
+  onBlur,
+  toggleSecureTextEntry,
+  placeholder,
+  inline,
+  password,
+  colors,
+}: Props) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const ref = useRef();
 
-  onFocus = () => {
-    const { onFocus } = this.props;
-    this.setState({ isFocused: true });
-    onFocus && onFocus();
-  };
-  onBlur = () => {
-    const { onBlur } = this.props;
-    this.setState({ isFocused: false });
-    onBlur && onBlur();
-  };
-
-  render() {
-    const {
-      autoFocus,
-      error,
-      secureTextEntry,
-      onChange,
-      onSubmit,
-      toggleSecureTextEntry,
-      placeholder,
-      inline,
-      password,
-      colors,
-    } = this.props;
-
-    let borderColorOverride = {};
-    if (!inline && this.state.isFocused) {
-      if (error) {
-        borderColorOverride = { borderColor: colors.alert };
-      } else {
-        borderColorOverride = { borderColor: colors.live };
-      }
+  useEffect(() => {
+    if (autoFocus) {
+      ref.current?.focus();
     }
+  }, [autoFocus]);
 
-    return (
-      <View
-        style={[
-          styles.container,
-          !inline && {
-            ...styles.nonInlineContainer,
-            backgroundColor: colors.card,
-            borderColor: colors.lightFog,
-          },
-          borderColorOverride,
-        ]}
-      >
-        <TextInput
-          allowFontScaling={false}
-          autoFocus={autoFocus}
-          style={[
-            styles.input,
-            getFontStyle({ semiBold: true }),
-            inline && styles.inlineTextInput,
-            { color: colors.darkBlue },
-          ]}
-          placeholder={placeholder}
-          placeholderTextColor={error ? colors.alert : colors.fog}
-          returnKeyType="done"
-          blurOnSubmit={false}
-          onChangeText={onChange}
-          onSubmitEditing={onSubmit}
-          secureTextEntry={secureTextEntry}
-          textContentType="password"
-          autoCorrect={false}
-          onFocus={this.onFocus}
-          onBlur={this.onBlur}
-          value={password}
-        />
-        {secureTextEntry ? (
-          <Touchable
-            event="PasswordInputToggleUnsecure"
-            style={styles.iconInput}
-            onPress={toggleSecureTextEntry}
-          >
-            <Icon
-              name="eye"
-              size={16}
-              color={inline ? colors.grey : colors.fog}
-            />
-          </Touchable>
-        ) : (
-          <Touchable
-            event="PasswordInputToggleSecure"
-            style={styles.iconInput}
-            onPress={toggleSecureTextEntry}
-          >
-            <Icon
-              name="eye-off"
-              size={16}
-              color={inline ? colors.grey : colors.fog}
-            />
-          </Touchable>
-        )}
-      </View>
-    );
+  const wrappedOnFocus = useCallback(() => {
+    setIsFocused(true);
+    onFocus && onFocus();
+  }, [onFocus]);
+
+  const wrappedOnBlur = useCallback(() => {
+    setIsFocused(false);
+    onBlur && onBlur();
+  }, [onBlur]);
+
+  let borderColorOverride = {};
+  if (!inline && isFocused) {
+    if (error) {
+      borderColorOverride = { borderColor: colors.alert };
+    } else {
+      borderColorOverride = { borderColor: colors.live };
+    }
   }
-}
+
+  return (
+    <View
+      style={[
+        styles.container,
+        !inline && {
+          ...styles.nonInlineContainer,
+          backgroundColor: colors.card,
+          borderColor: colors.lightFog,
+        },
+        borderColorOverride,
+      ]}
+    >
+      <TextInput
+        allowFontScaling={false}
+        autoFocus={autoFocus}
+        ref={ref}
+        style={[
+          styles.input,
+          getFontStyle({ semiBold: true }),
+          inline && styles.inlineTextInput,
+          { color: colors.darkBlue },
+        ]}
+        placeholder={placeholder}
+        placeholderTextColor={error ? colors.alert : colors.fog}
+        returnKeyType="done"
+        blurOnSubmit={false}
+        onChangeText={onChange}
+        onSubmitEditing={onSubmit}
+        secureTextEntry={secureTextEntry}
+        textContentType="password"
+        autoCorrect={false}
+        onFocus={wrappedOnFocus}
+        onBlur={wrappedOnBlur}
+        value={password}
+      />
+      {secureTextEntry ? (
+        <Touchable
+          event="PasswordInputToggleUnsecure"
+          style={styles.iconInput}
+          onPress={toggleSecureTextEntry}
+        >
+          <Icon
+            name="eye"
+            size={16}
+            color={inline ? colors.grey : colors.fog}
+          />
+        </Touchable>
+      ) : (
+        <Touchable
+          event="PasswordInputToggleSecure"
+          style={styles.iconInput}
+          onPress={toggleSecureTextEntry}
+        >
+          <Icon
+            name="eye-off"
+            size={16}
+            color={inline ? colors.grey : colors.fog}
+          />
+        </Touchable>
+      )}
+    </View>
+  );
+};
 
 export default withTheme(PasswordInput);
 const styles = StyleSheet.create({


### PR DESCRIPTION

> The branch number is wrong because I'm a moron.

The current behavior of the keyboard when entering the password screens is not ideal. The autofocus only takes effect on the first screen and will not show the keyboard on the confirmation one. I refactored the component (without judging the logic) into a functional component and will trigger the focus manually when mounting. This seems to solve the issue.



### Type

Bug Fix

### Context
https://ledgerhq.atlassian.net/browse/LL-4045

https://user-images.githubusercontent.com/4631227/135092916-9db9bd0d-f3c7-441b-86bc-9154f48f2738.mp4


<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

- On an instance of LLM without a password setup a password
- Confirm that both screens (password + password confirmation) start with the keyboard open like in the video
- Confirm that we can still set up a password and remove it.
- Test both iOS (have not tested iOS) and Android
