### PR TITLE
LL-6736 Integrate Manager in URI Scheme

### DIFF
--- a/deep-links-test-page.html
+++ b/deep-links-test-page.html
@@ -152,6 +152,18 @@
       </button>
 
       <div class="separator"></div>
+
+      <button class="link" onclick="onClick('ledgerlive:\/\/discover')">
+        <p>ledgerlive://discover</p>
+        <p>🔗</p>
+      </button>
+
+      <button class="link" onclick="onClick('ledgerlive:\/\/discover\/paraswap')">
+        <p>ledgerlive://discover/paraswap</p>
+        <p>🔗</p>
+      </button>
+
+      <div class="separator"></div>
       
       <button class="link" onclick="onClick('ledgerlive:\/\/manager')">
         <p>ledgerlive://manager</p>

--- a/deep-links-test-page.html
+++ b/deep-links-test-page.html
@@ -170,8 +170,8 @@
         <p>🔗</p>
       </button>
 
-      <button class="link" onclick="onClick('ledgerlive:\/\/manager?installapp=CURRENCY_PARAM')">
-        <p>ledgerlive://manager?installapp=<b class="currencyName">bitcoin</b></p></p>
+      <button class="link" onclick="onClick('ledgerlive:\/\/manager?installApp=CURRENCY_PARAM')">
+        <p>ledgerlive://manager?installApp=<b class="currencyName">bitcoin</b></p></p>
         <p>🔗</p>
       </button>
 

--- a/deep-links-test-page.html
+++ b/deep-links-test-page.html
@@ -152,16 +152,17 @@
       </button>
 
       <div class="separator"></div>
-      <button class="link" onclick="onClick('ledgerlive:\/\/discover')">
-        <p>ledgerlive://discover</p>
+      
+      <button class="link" onclick="onClick('ledgerlive:\/\/manager')">
+        <p>ledgerlive://manager</p>
         <p>🔗</p>
       </button>
 
-      <div class="separator"></div>
-      <button class="link" onclick="onClick('ledgerlive:\/\/discover\/paraswap')">
-        <p>ledgerlive://discover/paraswap</p>
+      <button class="link" onclick="onClick('ledgerlive:\/\/manager?installapp=CURRENCY_PARAM')">
+        <p>ledgerlive://manager?installapp=<b class="currencyName">bitcoin</b></p></p>
         <p>🔗</p>
       </button>
+
     </div>
     <script>
       let currency = "bitcoin";

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -33,6 +33,12 @@ They all are prefixed by **_ledgerlive://_**
 
   `ledgerlive://buy/bitcoin` will redirect to buy page with bitcoin accounts search prefilled
 
+- **_manager_** 🠒 Manager page
+
+  `ledgerlive://manager` will redirect to manager page
+
+  `ledgerlive://manager?installapp=bitcoin` will redirect to manager page with "bitcoin" app search prefilled
+
 - **_swap_** 🠒 Swap Crypto Flow
 
   `ledgerlive://swap` will redirect to swap page

--- a/docs/linking.md
+++ b/docs/linking.md
@@ -37,7 +37,7 @@ They all are prefixed by **_ledgerlive://_**
 
   `ledgerlive://manager` will redirect to manager page
 
-  `ledgerlive://manager?installapp=bitcoin` will redirect to manager page with "bitcoin" app search prefilled
+  `ledgerlive://manager?installApp=bitcoin` will redirect to manager page with "bitcoin" app search prefilled
 
 - **_swap_** 🠒 Swap Crypto Flow
 

--- a/src/index.js
+++ b/src/index.js
@@ -271,6 +271,20 @@ const linking = {
                 [ScreenName.PlatformCatalog]: "discover/:platform?",
               },
             },
+            [NavigatorName.Manager]: {
+              screens: {
+                /**
+                 * ie: "ledgerlive://manager" will open the manager
+                 *
+                 * @params ?installapp: string
+                 * ie: "ledgerlive://manager?installapp=bitcoin" will open the manager with "bitcoin" prefilled in the search input
+                 *
+                 * * @params ?searchQuery: string
+                 * ie: "ledgerlive://manager?searchQuery=bitcoin" will open the manager with "bitcoin" prefilled in the search input
+                 */
+                [ScreenName.Manager]: "manager",
+              },
+            },
           },
         },
         [NavigatorName.ReceiveFunds]: {

--- a/src/index.js
+++ b/src/index.js
@@ -276,8 +276,8 @@ const linking = {
                 /**
                  * ie: "ledgerlive://manager" will open the manager
                  *
-                 * @params ?installapp: string
-                 * ie: "ledgerlive://manager?installapp=bitcoin" will open the manager with "bitcoin" prefilled in the search input
+                 * @params ?installApp: string
+                 * ie: "ledgerlive://manager?installApp=bitcoin" will open the manager with "bitcoin" prefilled in the search input
                  *
                  * * @params ?searchQuery: string
                  * ie: "ledgerlive://manager?searchQuery=bitcoin" will open the manager with "bitcoin" prefilled in the search input

--- a/src/navigation/useDeepLinking.js
+++ b/src/navigation/useDeepLinking.js
@@ -117,6 +117,14 @@ export function useDeepLinkHandler() {
           break;
         }
 
+        case "manager": {
+          navigate(NavigatorName.Manager, {
+            screen: ScreenName.Manager,
+            params: query,
+          });
+          break;
+        }
+
         case "portfolio":
         default:
           navigate(NavigatorName.Main, { screen: ScreenName.Portfolio });

--- a/src/screens/Manager/index.js
+++ b/src/screens/Manager/index.js
@@ -62,7 +62,7 @@ const RemoveDeviceModal = ({
 type RouteParams = {
   searchQuery?: string,
   tab?: ManagerTab,
-  installapp?: string,
+  installApp?: string,
 };
 
 type Props = {
@@ -126,7 +126,7 @@ class ChooseDevice extends Component<
       this.props.navigation.navigate(ScreenName.ManagerMain, {
         ...result,
         ...params,
-        searchQuery: params.searchQuery || params.installapp,
+        searchQuery: params.searchQuery || params.installApp,
       });
   };
 

--- a/src/screens/Manager/index.js
+++ b/src/screens/Manager/index.js
@@ -62,6 +62,7 @@ const RemoveDeviceModal = ({
 type RouteParams = {
   searchQuery?: string,
   tab?: ManagerTab,
+  installapp?: string,
 };
 
 type Props = {
@@ -118,10 +119,14 @@ class ChooseDevice extends Component<
 
   onModalHide = () => {
     const { result } = this.state;
+    const {
+      route: { params = {} },
+    } = this.props;
     result?.result &&
       this.props.navigation.navigate(ScreenName.ManagerMain, {
         ...result,
-        ...this.props.route.params,
+        ...params,
+        searchQuery: params.searchQuery || params.installapp,
       });
   };
 


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

[LL-6736] - Integrate Manager in URI Scheme

`ledgerlive://manager` will point to the manager page 
It should also handle:

`ledgerlive://manager?installapp=appName` → With an anchor link that would redirect the user on click to the App’s position in the Catalog within the manager



https://user-images.githubusercontent.com/91890529/136361446-0ef7712d-b5fa-4ce1-931c-f04599d2192f.mov


### Type

Feature

### Context

[LL-6736]



### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
1. Run `yarn run test-deep-links`
2. On the mobile device open one of the URL of the test-deep-links output.
3. In the mobile browser, open one of the two URIs "ledgerlive://manager"
4. **Expected result:** It should open Ledger Live and navigate to the Manager screen, and in case of the link that has a "installapp" search param it should prefill the search input with the value of the installapp search param.


[LL-6736]: https://ledgerhq.atlassian.net/browse/LL-6736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ