### PR TITLE
LL-7547 Use firmware's name instead of version on update banner

### DIFF
--- a/src/components/FirmwareUpdateBanner.js
+++ b/src/components/FirmwareUpdateBanner.js
@@ -52,7 +52,7 @@ const FirmwareUpdateBanner = () => {
       );
 
       setShowBanner(Boolean(fw));
-      setVersion(fw?.final?.version ?? "");
+      setVersion(fw?.final?.name ?? "");
     }
 
     getLatestFirmwareForDevice();


### PR DESCRIPTION
The firmware update banner was using the firmware's version instead of its name.
The PR changes it to use the name.

### Type
Bug Fix

### Context
[LL-7547]

### Parts of the app affected / Test plan
Firmware update banner
![image](https://user-images.githubusercontent.com/91940736/136526050-9a2d2e5e-3b66-4749-91fd-da8fde54103a.png)


[LL-7547]: https://ledgerhq.atlassian.net/browse/LL-7547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ