### PR TITLE
LL-7871 Add language to analytics extra properties

### DIFF
--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -14,7 +14,7 @@ import {
   getAndroidVersionCode,
 } from "../logic/cleanBuildVersion";
 import getOrCreateUser from "../user";
-import { analyticsEnabledSelector } from "../reducers/settings";
+import { analyticsEnabledSelector, languageSelector } from "../reducers/settings";
 import { knownDevicesSelector } from "../reducers/ble";
 import type { State } from "../reducers";
 
@@ -28,6 +28,7 @@ const { ANALYTICS_LOGS, ANALYTICS_TOKEN } = Config;
 const extraProperties = store => {
   const state: State = store.getState();
   const { localeIdentifier, preferredLanguages } = Locale.constants();
+  const language = languageSelector(state);
   const devices = knownDevicesSelector(state);
   const lastDevice = devices[devices.length - 1];
   const deviceInfo = lastDevice
@@ -45,6 +46,7 @@ const extraProperties = store => {
     environment: ANALYTICS_LOGS ? "development" : "production",
     localeIdentifier,
     preferredLanguage: preferredLanguages ? preferredLanguages[0] : null,
+    language,
     platformOS: Platform.OS,
     platformVersion: Platform.Version,
     sessionId,

--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -14,7 +14,10 @@ import {
   getAndroidVersionCode,
 } from "../logic/cleanBuildVersion";
 import getOrCreateUser from "../user";
-import { analyticsEnabledSelector, languageSelector } from "../reducers/settings";
+import {
+  analyticsEnabledSelector,
+  languageSelector,
+} from "../reducers/settings";
 import { knownDevicesSelector } from "../reducers/ble";
 import type { State } from "../reducers";
 


### PR DESCRIPTION

<img width="797" alt="Screenshot 2021-10-25 at 15 33 35" src="https://user-images.githubusercontent.com/91890529/138705395-3fcc7c42-abdb-4d16-93e4-f85dfb8c9a13.png">
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

All events emitted should have a property `language` set to the user's preferred language's corresponding key ("en", "fr", etc.)

### Type

Analytics
<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

[LL-7871]

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LL-7871]: https://ledgerhq.atlassian.net/browse/LL-7871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ