### PR TITLE
LL-6956 Fix first pairing failure bug

### DIFF
--- a/src/screens/PairDevices/index.js
+++ b/src/screens/PairDevices/index.js
@@ -43,7 +43,7 @@ type PairDevicesProps = {
 };
 
 type RouteParams = {
-  onDone?: (deviceId: string) => void,
+  onDone?: (device: Device) => void,
 };
 
 type BleDevice = {
@@ -205,7 +205,7 @@ function PairDevicesInner({ navigation, route }: Props) {
   const onDone = useCallback(
     (device: Device) => {
       navigation.goBack();
-      route.params?.onDone?.(device.deviceId);
+      route.params?.onDone?.(device);
     },
     [navigation, route],
   );


### PR DESCRIPTION
We've had this bug forever and it impacts 100% of our new pairings, impacting the UX of all our new users negatively. Just returning the full device instead of the deviceId allows the subsequent device action to actually connect when entering the manager and solves the issue. Just had to add a bunch of traces to see where it was breaking.

### Type

Bug fix 🐛 

### Context

[<!-- e.g. GitHub issue #45 / contextual discussion -->](https://ledgerhq.atlassian.net/browse/LL-6956)