### PR TITLE
LL-8037 Use rebranded checkbox and switch components

### DIFF
--- a/src/components/CheckBox.tsx
+++ b/src/components/CheckBox.tsx
@@ -1,0 +1,29 @@
+// @flow
+
+import React, { memo, useCallback } from "react";
+
+import { Checkbox as RNCheckbox } from "@ledgerhq/native-ui";
+
+type Props = {
+  isChecked: boolean;
+  onChange?: (value: boolean) => void;
+  disabled?: boolean;
+};
+
+function CheckBox({ isChecked, disabled, onChange, ...props }: Props) {
+  const onPress = useCallback(() => {
+    if (!onChange) return;
+    onChange(!isChecked);
+  }, [isChecked, onChange]);
+
+  return (
+    <RNCheckbox
+      checked={isChecked}
+      onChange={onPress}
+      disabled={disabled}
+      {...props}
+    />
+  );
+}
+
+export default memo<Props>(CheckBox);

--- a/src/components/Switch.tsx
+++ b/src/components/Switch.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { Switch as RNSwitch } from "@ledgerhq/native-ui";
+
+type SwitchProps = {
+  value: boolean;
+  onValueChange?: (value: boolean) => void;
+  disabled?: boolean;
+  label?: string;
+};
+
+export default function Switch({
+  value,
+  onValueChange,
+  ...props
+}: SwitchProps) {
+  return <RNSwitch checked={value} onChange={onValueChange} {...props} />;
+}


### PR DESCRIPTION
This replaces the usage of standard switch and checkbox components for their equivalent in the design system.

### Type
Rebranding

### Context
[LL-8037] 


<img width="308" alt="Screenshot 2021-11-15 at 09 39 14" src="https://user-images.githubusercontent.com/91940736/141761843-91bfc28d-052e-46e3-99a9-330848704c37.png">
<img width="299" alt="Screenshot 2021-11-15 at 09 38 35" src="https://user-images.githubusercontent.com/91940736/141761872-a754d49e-e67f-4ccb-bb50-48758f2b7994.png">

