### PR TITLE
LL-8135 Fix crash after import

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-community/netinfo": "^6.0.1",
     "@react-navigation/bottom-tabs": "^6.0.9",
+    "@react-navigation/elements": "^1.2.1",
     "@react-navigation/material-top-tabs": "^6.0.6",
     "@react-navigation/native": "^6.0.6",
     "@react-navigation/stack": "^6.0.11",

--- a/src/components/RootNavigator/ImportAccountsNavigator.js
+++ b/src/components/RootNavigator/ImportAccountsNavigator.js
@@ -40,7 +40,7 @@ export default function ImportAccountsNavigator() {
         component={DisplayResult}
         options={{
           title: t("account.import.result.title"),
-          headerLeft: () => <BackButton />,
+          headerLeft: null,
         }}
       />
       <Stack.Screen

--- a/src/components/RootNavigator/ImportAccountsNavigator.js
+++ b/src/components/RootNavigator/ImportAccountsNavigator.js
@@ -40,7 +40,7 @@ export default function ImportAccountsNavigator() {
         component={DisplayResult}
         options={{
           title: t("account.import.result.title"),
-          headerLeft: null,
+          headerLeft: () => <BackButton />,
         }}
       />
       <Stack.Screen

--- a/src/screens/ImportAccounts/DisplayResult.js
+++ b/src/screens/ImportAccounts/DisplayResult.js
@@ -3,7 +3,7 @@ import React, { Component } from "react";
 import { View, StyleSheet, SectionList } from "react-native";
 import SafeAreaView from "react-native-safe-area-view";
 import { useNavigation, useTheme } from "@react-navigation/native";
-import { HeaderBackButton } from "@react-navigation/stack";
+import { HeaderBackButton } from "@react-navigation/elements";
 import groupBy from "lodash/groupBy";
 import concat from "lodash/concat";
 import { connect } from "react-redux";


### PR DESCRIPTION
Due to a missed step in the [migration guide from v5.x to v6.x of `react-navigation` ](https://reactnavigation.org/docs/upgrading-from-5.x/#some-exports-are-now-moved-to-the-element-library) we were using an incorrect import path for the `HeaderBackButton` component, meaning the app would try to wrap undefined and crash whenever we relied on that import.

![image](https://user-images.githubusercontent.com/4631227/141873172-52924380-ce1f-4d89-9f46-43b83529eb6e.png)

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-8135

### Parts of the app affected / Test plan

- Import accounts via live qr
- Make sure the app doesn't crash on the result screen.
