### PR TITLE
LL-8167 - Fix webview crash when navigating away

### DIFF
--- a/src/screens/Exchange/CoinifyWidget.js
+++ b/src/screens/Exchange/CoinifyWidget.js
@@ -420,5 +420,13 @@ const styles = StyleSheet.create({
     flex: 0,
     width: "100%",
     height: "100%",
+    /**
+     * This is required to prevent a crash when navigating back.
+     * The issue is caused by an incompatibility between the
+     * react-native-webview and react-native-screens packages.
+     * See: https://github.com/react-native-webview/react-native-webview/issues/1069
+     * See: https://github.com/software-mansion/react-native-screens/issues/105
+     */
+    opacity: 0.99,
   },
 });


### PR DESCRIPTION
Adds an opacity of `0.99` to the coinify webview in order to prevent a crash when navigating away.
Caused by compatibility issues between `react-native-webview` and `react-native-screens`.

See: 
- https://github.com/react-native-webview/react-native-webview/issues/1069
- https://github.com/software-mansion/react-native-screens/issues/105


### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

Bug Fix

[LL-8167]

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->

portfolio -> click buy


[LL-8167]: https://ledgerhq.atlassian.net/browse/LL-8167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ