### PR TITLE
LL-8170 - exclude empty buttons generated by separator components

### DIFF
--- a/src/components/FabActions.js
+++ b/src/components/FabActions.js
@@ -97,10 +97,25 @@ function FabAccountActions({ account, parentAccount }: FabAccountActionsProps) {
     ...useActions({ account, parentAccount, colors }),
   ];
 
-  const buttons = allActions.slice(0, 2);
+  // Do not display separators as buttons. (they do not have a label)
+  //
+  // First, count the index at which there are 2 valid buttons.
+  let counter = 0;
+  const sliceIndex =
+    allActions.findIndex(action => {
+      if (action.label) counter++;
+      return counter === 2;
+    }) + 1;
+
+  // Then slice from 0 to the index and ignore invalid button elements.
+  // Chaining methods should not be a big deal given the size of the actions array.
+  const buttons = allActions
+    .slice(0, sliceIndex || undefined)
+    .filter(action => !!action.label)
+    .slice(0, 2);
 
   const actions = {
-    default: allActions.slice(2),
+    default: sliceIndex ? allActions.slice(sliceIndex) : [],
     lending: useLendingActions({ account }),
   };
 


### PR DESCRIPTION
#### Prevents "empty" buttons in the account page.

<img width="300" alt="Capture d’écran 2021-11-22 à 09 34 49" src="https://user-images.githubusercontent.com/86958797/142828807-27a5da6f-a257-417c-8111-f727ce0b351a.png">

The issue arises when separator components are in the first 2 elements of the actions array they are converted into empty buttons.

### Type

Bug Fix

### Context

[LL-8170]

### Parts of the app affected / Test plan

- Read only mode (Onboarding without paring a device, import data from LLD)
- Ethereum Account screen


[LL-8170]: https://ledgerhq.atlassian.net/browse/LL-8170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ