### PR TITLE
LL-8162 - Fix safe area issues

### DIFF
--- a/src/components/AnimatedHeader.js
+++ b/src/components/AnimatedHeader.js
@@ -1,12 +1,7 @@
 // @flow
 import React, { useState, useCallback } from "react";
-import {
-  View,
-  StyleSheet,
-  Platform,
-  SafeAreaView,
-  TouchableOpacity,
-} from "react-native";
+import { View, StyleSheet, Platform, TouchableOpacity } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import {
   useNavigation,
   useTheme,

--- a/src/screens/Portfolio/index.js
+++ b/src/screens/Portfolio/index.js
@@ -1,7 +1,8 @@
 // @flow
 import React, { useRef, useCallback, useMemo } from "react";
 import { useSelector } from "react-redux";
-import { StyleSheet, FlatList, SafeAreaView, View } from "react-native";
+import { StyleSheet, FlatList, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import Animated, { interpolateNode } from "react-native-reanimated";
 import { createNativeWrapper } from "react-native-gesture-handler";
 import { useTranslation } from "react-i18next";


### PR DESCRIPTION
Use `SafeAreaView` from `react-native-safe-area-context` to prevent escaping from the safe area.

React navigation recommends it for various reasons: https://reactnavigation.org/docs/handling-safe-area/

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug Fix

### Context

[LL-8162]

### Parts of the app affected / Test plan

- Portfolio screen empty states
- Portfolio screen when Carousel is displayed
- Platform -> apps catalog screen


[LL-8162]: https://ledgerhq.atlassian.net/browse/LL-8162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ