### PR TITLE
Update to live-common 21.16.3 to fix LL-8154

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,11 +55,12 @@
   },
   "dependencies": {
     "@ledgerhq/compressjs": "^1.3.2",
+    "@ledgerhq/cryptoassets": "6.15.1",
     "@ledgerhq/devices": "6.11.2",
     "@ledgerhq/errors": "6.10.0",
     "@ledgerhq/hw-transport": "6.11.2",
     "@ledgerhq/hw-transport-http": "6.11.2",
-    "@ledgerhq/live-common": "^21.16.1",
+    "@ledgerhq/live-common": "21.16.3",
     "@ledgerhq/logs": "6.10.0",
     "@ledgerhq/react-native-hid": "6.11.2",
     "@ledgerhq/react-native-hw-transport-ble": "6.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2093,10 +2093,10 @@
   dependencies:
     commander "^2.20.0"
 
-"@ledgerhq/cryptoassets@6.14.0", "@ledgerhq/cryptoassets@^6.14.0":
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-6.14.0.tgz#736b795e0abf84bce3e3e9c90c1b864e55634cc0"
-  integrity sha512-B6yTpi9oahyEHwOB2CtTDhQSfwPTFBYPTvV2EXmC0rK4WkQ/mItYTAizoRtDd3WGo/2+8jmWKXnHAS0MMflyaQ==
+"@ledgerhq/cryptoassets@6.15.1", "@ledgerhq/cryptoassets@^6.15.1":
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/cryptoassets/-/cryptoassets-6.15.1.tgz#824bcf6019191dcf78bac4aafa346ca646573f31"
+  integrity sha512-YOPTAdOtxBke03ApisBgQxKShLmvzV8YU/uF9i6TpDA5hDCyjNbC2MVQkeTA4oOto+foKff9uwcBbminW8d6pA==
   dependencies:
     invariant "2"
 
@@ -2142,10 +2142,10 @@
     js-sha512 "^0.8.0"
     tweetnacl "^1.0.3"
 
-"@ledgerhq/hw-app-btc@6.15.0":
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-6.15.0.tgz#71618f9c51a0590d99d8f13d44a1f1d0bad876bd"
-  integrity sha512-+aDzukHbpQoIM9gpU0TtsG3tsRuzXm6HkkkycWuk0fMJv6HGK0kZ2v/hioazQmVoxi1UV6vdO4n7NUFBIO6GBQ==
+"@ledgerhq/hw-app-btc@6.15.1":
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-6.15.1.tgz#6e2d451196153e7a619414bd386d829b824226cf"
+  integrity sha512-9qWke/C6YQ9cQAklcdUras+dYzSOGY8UwR/Ce0Je0M/SyfB8iOC15e6LHUVhp73LFOAiSrpKRwbmWGnezbvlLA==
   dependencies:
     "@ledgerhq/hw-transport" "^6.11.2"
     "@ledgerhq/logs" "^6.10.0"
@@ -2168,12 +2168,12 @@
     "@ledgerhq/hw-transport" "^6.11.2"
     bip32-path "^0.4.2"
 
-"@ledgerhq/hw-app-eth@6.15.0":
-  version "6.15.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-6.15.0.tgz#4378d66b4b5a50cfe3addd57d5b6021209d66836"
-  integrity sha512-wzqJjKD7IK+xO18P5L9yRVnuEp/EJ+745tkkRCcJEkceozTbGFr/ILk5ypjBtm/KRnFOQfq6lrU0X9fCX95O+Q==
+"@ledgerhq/hw-app-eth@6.15.1":
+  version "6.15.1"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-eth/-/hw-app-eth-6.15.1.tgz#85aabe6680f6eecb7af77d388ca6f0676b73be2c"
+  integrity sha512-7D+L4vO5T5bjzR6JgdaLZ9HGrS4Qd+sEO4y8x/8IOaIU3dBxDCkLasmlsccPDIF/8C5j7mQ2QeQzYGK6vNrCZA==
   dependencies:
-    "@ledgerhq/cryptoassets" "^6.14.0"
+    "@ledgerhq/cryptoassets" "^6.15.1"
     "@ledgerhq/errors" "^6.10.0"
     "@ledgerhq/hw-transport" "^6.11.2"
     "@ledgerhq/logs" "^6.10.0"
@@ -2288,20 +2288,20 @@
     bignumber.js "^9.0.1"
     json-rpc-2.0 "^0.2.16"
 
-"@ledgerhq/live-common@^21.16.1":
-  version "21.16.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-21.16.1.tgz#0d77c5e09ece0f3ad26b3d8c0775618b745e2287"
-  integrity sha512-b+XqRCc89gSgoB5VW8SKImWWLxjqAhm6PD9l91zTk7gbE1R3XktdwIu32lUz9h/HzdKX7iw7Amj8hFxzvbnnGQ==
+"@ledgerhq/live-common@21.16.3":
+  version "21.16.3"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-21.16.3.tgz#418dc15ae6ae1a5a3dec98599fe7c44756a975ce"
+  integrity sha512-9bGdjwg9AREIm+HCB8iWWdfZ6cJKgYqTHfi5l4+hSw3CnS0SRKaZbNP6qrVZhME3Lp5JvXVCjtnKfk8QaBpBmg==
   dependencies:
     "@crypto-com/chain-jslib" "0.0.19"
     "@ledgerhq/compressjs" "1.3.2"
-    "@ledgerhq/cryptoassets" "6.14.0"
+    "@ledgerhq/cryptoassets" "6.15.1"
     "@ledgerhq/devices" "6.11.2"
     "@ledgerhq/errors" "6.10.0"
     "@ledgerhq/hw-app-algorand" "6.11.2"
-    "@ledgerhq/hw-app-btc" "6.15.0"
+    "@ledgerhq/hw-app-btc" "6.15.1"
     "@ledgerhq/hw-app-cosmos" "6.11.2"
-    "@ledgerhq/hw-app-eth" "6.15.0"
+    "@ledgerhq/hw-app-eth" "6.15.1"
     "@ledgerhq/hw-app-polkadot" "6.11.2"
     "@ledgerhq/hw-app-str" "6.11.2"
     "@ledgerhq/hw-app-tezos" "6.11.2"
@@ -2327,7 +2327,7 @@
     axios-retry "^3.2.4"
     base32-decode "^1.0.0"
     bchaddrjs "^0.5.2"
-    bech32 "^2.0.0"
+    bech32 "^1.1.3"
     bignumber.js "^9.0.1"
     bip32 "^2.0.6"
     bip32-path "^0.4.2"
@@ -2359,7 +2359,7 @@
     performance-now "^2.1.0"
     prando "^6.0.1"
     redux "^4.1.2"
-    reselect "^4.1.2"
+    reselect "^4.1.4"
     ripemd160 "^2.0.2"
     ripple-binary-codec "^1.1.3"
     ripple-bs58check "^2.0.2"
@@ -4467,7 +4467,7 @@ bchaddrjs@^0.5.2:
     cashaddrjs "0.4.4"
     stream-browserify "^3.0.0"
 
-bech32@1.1.4, bech32@^1.1.2, bech32@^1.1.4:
+bech32@1.1.4, bech32@^1.1.2, bech32@^1.1.3, bech32@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.4.tgz#e38c9f37bf179b8eb16ae3a772b40c356d4832e9"
   integrity sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ==
@@ -4476,11 +4476,6 @@ bech32@=1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/bech32/-/bech32-1.1.3.tgz#bd47a8986bbb3eec34a56a097a84b8d3e9a2dfcd"
   integrity sha512-yuVFUvrNcoJi0sv5phmqc6P+Fl1HjRDRNOOkHY2X/3LBy2bIGNSFx4fZ95HMaXHupuS7cZR15AsvtmCIF4UEyg==
-
-bech32@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/bech32/-/bech32-2.0.0.tgz#078d3686535075c8c79709f054b1b226a133b355"
-  integrity sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==
 
 before-after-hook@^2.0.0:
   version "2.2.2"
@@ -12671,10 +12666,15 @@ reselect@4.0.0:
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
   integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
-reselect@^4.0.0, reselect@^4.1.2:
+reselect@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.2.tgz#7bf642992d143d4f3b0f2dca8aa52018808a1d51"
   integrity sha512-wg60ebcPOtxcptIUfrr7Jt3h4BR86cCW3R7y4qt65lnNb4yz4QgrXcbSioVsIOYguyz42+XTHIyJ5TEruzkFgQ==
+
+reselect@^4.1.4:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.1.5.tgz#852c361247198da6756d07d9296c2b51eddb79f6"
+  integrity sha512-uVdlz8J7OO+ASpBYoz1Zypgx0KasCY20H+N8JD13oUMtPvSHQuscrHop4KbXrbsBcdB9Ds7lVK7eRkBIfO43vQ==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION


A recent regression (bigint error when signing Bitcoin transactions with latest app) was fixed in @ledgerhq/live-common@21.16.2 (via ledgerjs hw-app-btc fix)

This PR upgrade live-common from 21.15.0 to 21.16.3 because it's consider the least impacting and most 1-1 with LLD current validated version. **The test impact should only be on the restoration of Bitcoin support**, because the workload was just on Bitcoin JS. (There are also regular ERC20 update in that work load).

- LLD is currently working with 21.16.0. So the 21.15.0 -> 21.16.0 changes shouldn't have surprise. It was only impacting the BTC JS implementation.
- the extra changes between 21.16.0 and 21.16.3 are mostly related to BTC JS as well. (the precise list is in https://github.com/LedgerHQ/ledger-live-common/releases but it's all about either disabled work load OR btcjs)