### PR TITLE
LL-9022 - Improve legibility of app sizes in the manager for LNS+

### DIFF
--- a/src/components/ByteSize.js
+++ b/src/components/ByteSize.js
@@ -6,33 +6,38 @@ import type { DeviceModel } from "@ledgerhq/devices";
 const k = 1024; // 1kb unit
 const sizes = ["bytes", "kbUnit", "mbUnit"];
 
-/** formats a byte value into its correct size in kb or mb unit takling in account the device block size */
+/** formats a byte value into its correct size in kb or mb unit talking in account the device block size */
 const ByteSize = ({
   value,
   deviceModel,
-  decimals = 2,
+  decimals = 0,
   firmwareVersion,
+  formatFunction
 }: {
   value: number,
   deviceModel: DeviceModel,
   decimals?: number,
   firmwareVersion: string,
+  formatFunction?: (val: number) => number
 }) => {
   if (!value) return "–";
 
   const blockSize = deviceModel.getBlockSize(firmwareVersion);
+
+  // FIXME it should be on live-common side
   const bytes = Math.ceil(value / blockSize) * blockSize;
 
   const i = Math.floor(Math.log(bytes) / Math.log(k));
 
   const dm = Math.max(0, decimals);
+  const pureSize = parseFloat(bytes / Math.pow(k, i));
+  const formattedSize = formatFunction ? formatFunction(pureSize) : pureSize
+  const size = formattedSize.toFixed(dm)
 
   return (
     <Trans
       i18nKey={`byteSize.${sizes[i]}`}
-      values={{
-        size: parseFloat((bytes / k ** i).toFixed(dm)),
-      }}
+      values={{ size }}
     />
   );
 };

--- a/src/components/ByteSize.js
+++ b/src/components/ByteSize.js
@@ -6,7 +6,7 @@ import type { DeviceModel } from "@ledgerhq/devices";
 const k = 1024; // 1kb unit
 const sizes = ["bytes", "kbUnit", "mbUnit"];
 
-/** formats a byte value into its correct size in kb or mb unit talking in account the device block size */
+/** formats a byte value into its correct size in kb or mb unit taking in account the device block size */
 const ByteSize = ({
   value,
   deviceModel,

--- a/src/components/ByteSize.js
+++ b/src/components/ByteSize.js
@@ -27,11 +27,11 @@ const ByteSize = ({
   // FIXME it should be on live-common side
   const bytes = Math.ceil(value / blockSize) * blockSize;
   const i = Math.floor(Math.log(bytes) / Math.log(k));
-  const pureSize = parseFloat(bytes / k ** i);
+  const rawSize = parseFloat(bytes / k ** i);
   const dm = i > 1 ? Math.max(0, decimals) : 0;
 
   const divider = 10 ** dm;
-  const toFormat = pureSize * divider;
+  const toFormat = rawSize * divider;
   let formattedSize = formatFunction ? formatFunction(toFormat) : toFormat;
   formattedSize /= divider;
 

--- a/src/components/ByteSize.js
+++ b/src/components/ByteSize.js
@@ -26,13 +26,16 @@ const ByteSize = ({
 
   // FIXME it should be on live-common side
   const bytes = Math.ceil(value / blockSize) * blockSize;
-
   const i = Math.floor(Math.log(bytes) / Math.log(k));
+  const pureSize = parseFloat(bytes / k ** i);
+  const dm = i > 1 ? Math.max(0, decimals) : 0;
 
-  const dm = Math.max(0, decimals);
-  const pureSize = parseFloat(bytes / Math.pow(k, i));
-  const formattedSize = formatFunction ? formatFunction(pureSize) : pureSize
-  const size = formattedSize.toFixed(dm)
+  const divider = 10 ** dm;
+  const toFormat = pureSize * divider;
+  let formattedSize = formatFunction ? formatFunction(toFormat) : toFormat;
+  formattedSize /= divider;
+
+  const size = formattedSize.toFixed(dm);
 
   return (
     <Trans

--- a/src/components/ByteSize.js
+++ b/src/components/ByteSize.js
@@ -12,13 +12,13 @@ const ByteSize = ({
   deviceModel,
   decimals = 0,
   firmwareVersion,
-  formatFunction
+  formatFunction,
 }: {
   value: number,
   deviceModel: DeviceModel,
   decimals?: number,
   firmwareVersion: string,
-  formatFunction?: (val: number) => number
+  formatFunction?: (val: number) => number,
 }) => {
   if (!value) return "–";
 
@@ -37,12 +37,7 @@ const ByteSize = ({
 
   const size = formattedSize.toFixed(dm);
 
-  return (
-    <Trans
-      i18nKey={`byteSize.${sizes[i]}`}
-      values={{ size }}
-    />
-  );
+  return <Trans i18nKey={`byteSize.${sizes[i]}`} values={{ size }} />;
 };
 
 export default ByteSize;

--- a/src/screens/Manager/AppsList/AppRow.js
+++ b/src/screens/Manager/AppsList/AppRow.js
@@ -109,6 +109,7 @@ const AppRow = ({
                 value={bytes}
                 deviceModel={state.deviceModel}
                 firmwareVersion={deviceInfo.version}
+                formatFunction={Math.ceil}
               />
             </LText>
           </Touchable>
@@ -125,6 +126,7 @@ const AppRow = ({
               value={bytes}
               deviceModel={state.deviceModel}
               firmwareVersion={deviceInfo.version}
+              formatFunction={Math.ceil}
             />
           </LText>
         )}

--- a/src/screens/Manager/Device/DeviceAppStorage.js
+++ b/src/screens/Manager/Device/DeviceAppStorage.js
@@ -58,6 +58,7 @@ const DeviceAppStorage = ({
               value={freeSpaceBytes}
               deviceModel={deviceModel}
               firmwareVersion={deviceInfo.version}
+              formatFunction={Math.floor}
             />
           </LText>
           <LText style={[styles.storageText, storageWarnStyle]}>
@@ -98,6 +99,7 @@ const DeviceAppStorage = ({
                 value={totalAppsBytes}
                 deviceModel={deviceModel}
                 firmwareVersion={deviceInfo.version}
+                formatFunction={Math.ceil}
               />
             </LText>
             <LText style={styles.storageText}>

--- a/src/screens/Manager/Modals/UpdateAllModal.js
+++ b/src/screens/Manager/Modals/UpdateAllModal.js
@@ -92,6 +92,7 @@ const UpdateAllModal = ({
               value={bytes}
               deviceModel={state.deviceModel}
               firmwareVersion={deviceInfo.version}
+              formatFunction={Math.ceil}
             />
           </LText>
         </View>


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Feature improvement

### Context
https://ledgerhq.atlassian.net/browse/LL-9022

1 - New device has more precise values data about storage (apps, firmware allocation, free space, etc...). We don't really need it on UI side for now. So we have to control the precision and the values to show.
2 - We wanted to better handle the rounding of data being less optimistic. When we are showing data about used space, we want to ceil the value and when it's about free space we will floor it to always unsure user will not be surprised thinking he could install something but when I do it, it fails cause missing few bytes on nano device.

### Parts of the app affected / Test plan

1 - Use a nano SP and go to the manager
2 - Check it works with other devices
