### PR TITLE
LL-8271 (Polkadot): fix scrolling issue in device confirm fields

### DIFF
--- a/src/families/polkadot/TransactionConfirmFields.js
+++ b/src/families/polkadot/TransactionConfirmFields.js
@@ -112,12 +112,17 @@ const EstimatedFees = ({ account, transaction }: FieldProps) => {
   );
 };
 
-const Warning = (props: FieldProps) => (
-  <>
-    <EstimatedFees {...props} />
-    <Info {...props} />
-  </>
-);
+const Warning = (props: FieldProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <>
+      <EstimatedFees {...props} />
+      <Info {...props} />
+      <Alert type="secondary">{t("polkadot.networkFees")}</Alert>
+    </>
+  );
+};
 
 const Footer = ({
   transaction,
@@ -125,22 +130,15 @@ const Footer = ({
 }: {
   transaction: Transaction,
   recipientWording: string,
-}) => {
-  const { t } = useTranslation();
-
-  return (
-    <>
+}) => (
+  <>
+    {["send", "nominate"].includes(transaction.mode) ? (
       <View style={styles.container}>
-        <Alert type="secondary">{t("polkadot.networkFees")}</Alert>
+        <Alert type="help">{recipientWording}</Alert>
       </View>
-      {["send", "nominate"].includes(transaction.mode) ? (
-        <View style={styles.container}>
-          <Alert type="help">{recipientWording}</Alert>
-        </View>
-      ) : null}
-    </>
-  );
-};
+    ) : null}
+  </>
+);
 
 const fieldComponents = {
   "polkadot.validators": PolkadotValidatorsField,


### PR DESCRIPTION
- (Polkadot): fix scrolling issue in device confirm fields


<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

![Screenshot_2021-11-25-12-40-46-099_com ledger live debug](https://user-images.githubusercontent.com/11752937/143435812-e5e20be2-3e5f-4f45-850b-6c98235ef61d.jpg)

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug Fix
### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
[LL-8271]
### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Sending a tx on polkadot should now show all fields correctly with some scroll

[LL-8271]: https://ledgerhq.atlassian.net/browse/LL-8271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ