### PR TITLE
LL-6987 Use localname for ble devices when available

### DIFF
--- a/src/screens/PairDevices/Scanning.js
+++ b/src/screens/PairDevices/Scanning.js
@@ -34,7 +34,7 @@ export default function Scanning({ onTimeout, onError, onSelect }: Props) {
       const knownDevice = knownDevices.find(d => d.id === item.id);
       const deviceMeta = {
         deviceId: item.id,
-        deviceName: item.name,
+        deviceName: item.localName ?? item.name,
         wired: false,
         modelId: "nanoX",
       };


### PR DESCRIPTION
When pairing a BLE device on LLM we were relying solely on the device name and ignoring the fact that they might have renamed it already. We were only updating this app state level name when renaming the device so if we wanted to pair a 
forgotten device again, or pair a renamed device it would show (and keep) the old name and not the new one. 

Pretty low prio edge case, but quick win.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LL-6987

### Parts of the app affected / Test plan

- Pair a device, ie "Nano E123"
- Rename this device to "newname"
- Forget the device
- Scan for the device
- It is expected that the device shows up as "newname" and not "Nano E123"
