### PR TITLE
Rebranding - Fix color palette

### DIFF
--- a/src/StyleProvider.tsx
+++ b/src/StyleProvider.tsx
@@ -20,8 +20,8 @@ export default function StyleProvider({
     () => ({
       ...theme,
       colors: {
-        ...theme.colors,
         ...defaultTheme.colors,
+        ...palettes[selectedPalette],
         palette: palettes[selectedPalette],
       },
       theme: selectedPalette,


### PR DESCRIPTION
Old color palette was erasing new palette, reversed this. Also new color palette doesn't use only light theme anymore.

This fix the bug related to null backgroundColor prop crash.
### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
