### PR TITLE
LL-8038 - Rebrand - Add TextInput Wrapper

### DIFF
--- a/src/components/TextInput.android.tsx
+++ b/src/components/TextInput.android.tsx
@@ -1,0 +1,4 @@
+// @ts-ignore
+import TextInput from "./TextInput.tsx";
+
+export default TextInput;

--- a/src/components/TextInput.ios.tsx
+++ b/src/components/TextInput.ios.tsx
@@ -1,0 +1,4 @@
+// @ts-ignore
+import TextInput from "./TextInput.tsx";
+
+export default TextInput;

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { Platform, TextInput as NativeTextInput } from "react-native";
+import { BaseInput } from "@ledgerhq/native-ui";
+import { InputProps } from "@ledgerhq/native-ui/components/Form/Input/BaseInput";
+
+export interface Props extends InputProps {
+  withSuggestions?: boolean;
+}
+
+function TextInput(
+  { withSuggestions, ...props }: Props,
+  ref: React.ForwardedRef<NativeTextInput>,
+) {
+  const flags: Partial<InputProps> = {};
+
+  if (!withSuggestions) {
+    flags.autoCorrect = false;
+    if (Platform.OS === "android") flags.keyboardType = "visible-password";
+  }
+
+  return <BaseInput ref={ref} {...flags} {...props} />;
+}
+
+export default React.forwardRef(TextInput);


### PR DESCRIPTION
### ~~⚠️ Relies on: https://github.com/LedgerHQ/ui/pull/111~~

#### Adds a wrapper for `<TextInput/>`.

<img src="https://user-images.githubusercontent.com/86958797/144256136-5ec86c48-eb8e-40c8-aaf1-ae6fc301fc0b.png" width="300" />

### Type

UI

### Context

[LL-8038]

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LL-8038]: https://ledgerhq.atlassian.net/browse/LL-8038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ