### PR TITLE
LL-7746 - Rebrand - Improve onboarding modals animations

### DIFF
--- a/src/components/NavigationHeader.tsx
+++ b/src/components/NavigationHeader.tsx
@@ -1,17 +1,13 @@
 import React from "react";
 import { useTranslation } from "react-i18next";
-import { Pressable, View } from "react-native";
+import { View } from "react-native";
 import { ArrowLeftMedium, CloseMedium } from "@ledgerhq/native-ui/assets/icons";
 import { Flex, Text, Link } from "@ledgerhq/native-ui";
 import { StackHeaderProps } from "@react-navigation/stack";
 import { getHeaderTitle } from "@react-navigation/elements";
 
-// Magic number
-const HEADER_HEIGHT = 52;
-
 function NavigationHeader({
   navigation,
-  layout,
   route,
   options,
   back,
@@ -20,36 +16,31 @@ function NavigationHeader({
   const title = t(getHeaderTitle(options, route.name));
 
   return (
-    <Flex height={layout.height / 10 + HEADER_HEIGHT} justifyContent="flex-end">
-      <Pressable
-        style={{ flex: 1 }}
+    <Flex
+      flexDirection="row"
+      justifyContent="space-between"
+      alignItems="center"
+      backgroundColor="palette.neutral.c00"
+      py={6}
+      mb={6}
+    >
+      {back ? (
+        <Link size="large" Icon={ArrowLeftMedium} onPress={navigation.goBack} />
+      ) : (
+        <View />
+      )}
+      <Text variant="large" fontWeight="semiBold">
+        {title}
+      </Text>
+      <Link
+        size="large"
+        Icon={CloseMedium}
         onPress={() => {
-          navigation.canGoBack() && navigation.goBack();
+          navigation.getParent()?.goBack();
         }}
       />
-      <Flex
-        flexDirection="row"
-        justifyContent="space-between"
-        alignItems="center"
-        backgroundColor="palette.neutral.c00"
-        p={6}
-      >
-        {back ? (
-          <Link
-            size="large"
-            Icon={ArrowLeftMedium}
-            onPress={navigation.goBack}
-          />
-        ) : (
-          <View />
-        )}
-        <Text variant="large" fontWeight="semiBold">
-          {title}
-        </Text>
-        <Link size="large" Icon={CloseMedium} onPress={navigation.popToTop} />
-      </Flex>
     </Flex>
   );
 }
 
-export default NavigationHeader;
+export default (props: StackHeaderProps) => <NavigationHeader {...props} />;

--- a/src/components/NavigationModalContainer.tsx
+++ b/src/components/NavigationModalContainer.tsx
@@ -1,9 +1,37 @@
+import React from "react";
+import { Pressable, SafeAreaView } from "react-native";
 import { Flex } from "@ledgerhq/native-ui";
+import { StackScreenProps } from "@react-navigation/stack";
 import styled from "styled-components/native";
 
-export default styled(Flex).attrs(p => ({
+export const MIN_MODAL_HEIGHT = 30;
+
+const ScreenContainer = styled(Flex).attrs(p => ({
+  edges: ["bottom"],
   flex: 1,
   backgroundColor: "palette.neutral.c00",
   p: p.p ?? 6,
-  mb: p.mb ?? 4,
 }))``;
+type Props = StackScreenProps<{}> & { children: React.ReactNode };
+
+export default function NavigationModalContainer({
+  navigation,
+  children,
+}: Props) {
+  return (
+    <Flex flex={1}>
+      <Flex height="8%" minHeight={MIN_MODAL_HEIGHT}>
+        <Pressable
+          style={{ flex: 1 }}
+          onPress={() => {
+            navigation.canGoBack() && navigation.goBack();
+          }}
+        />
+      </Flex>
+
+      <ScreenContainer>
+        <SafeAreaView style={{ flex: 1 }}>{children}</SafeAreaView>
+      </ScreenContainer>
+    </Flex>
+  );
+}

--- a/src/components/NavigationOverlay.tsx
+++ b/src/components/NavigationOverlay.tsx
@@ -12,7 +12,7 @@ export default function NavigationOverlay() {
     <Pressable
       style={[
         StyleSheet.absoluteFill,
-        { backgroundColor: rgba(theme.colors.palette.neutral.c100, 0.5) },
+        { backgroundColor: rgba(theme.colors.neutral.c100, 0.5) },
       ]}
       onPress={() => {
         navigation.canGoBack() && navigation.goBack();

--- a/src/components/RootNavigator/OnboardingNavigator.tsx
+++ b/src/components/RootNavigator/OnboardingNavigator.tsx
@@ -4,6 +4,7 @@ import {
   CardStyleInterpolators,
   TransitionPresets,
   StackNavigationOptions,
+  StackScreenProps,
 } from "@react-navigation/stack";
 import { ScreenName, NavigatorName } from "../../const";
 import PasswordAddFlowNavigator from "./PasswordAddFlowNavigator";
@@ -28,15 +29,46 @@ import OnboardingQuizFinal from "../../screens/Onboarding/OnboardingQuizFinal";
 import NavigationHeader from "../NavigationHeader";
 import NavigationOverlay from "../NavigationOverlay";
 
+import NavigationModalContainer from "../NavigationModalContainer";
+
 const Stack = createStackNavigator();
+const LanguageModalStack = createStackNavigator();
+
+function LanguageModalNavigator(props: StackScreenProps<{}>) {
+  const options: Partial<StackNavigationOptions> = {
+    headerMode: "float",
+    header: NavigationHeader,
+    headerStyle: { backgroundColor: "transparent" },
+  };
+
+  return (
+    <NavigationModalContainer {...props}>
+      <LanguageModalStack.Navigator>
+        <LanguageModalStack.Screen
+          name={ScreenName.OnboardingLanguage}
+          component={OnboardingLanguage}
+          options={{
+            title: "onboarding.stepLanguage.title",
+            ...options,
+          }}
+        />
+        <LanguageModalStack.Screen
+          name={ScreenName.OnboardingStepLanguageGetStarted}
+          component={OnboardingStepLanguageGetStarted}
+          options={{
+            title: "onboarding.stepLanguage.title",
+            ...options,
+          }}
+        />
+      </LanguageModalStack.Navigator>
+    </NavigationModalContainer>
+  );
+}
 
 const modalOptions: Partial<StackNavigationOptions> = {
   presentation: "transparentModal",
-  headerShown: true,
-  headerMode: "screen",
-  header: NavigationHeader,
   cardOverlayEnabled: true,
-  cardOverlay: props => <NavigationOverlay {...props} />,
+  cardOverlay: () => <NavigationOverlay />,
   ...TransitionPresets.ModalSlideFromBottomIOS,
 };
 
@@ -48,20 +80,10 @@ export default function OnboardingNavigator() {
         component={OnboardingWelcome}
       />
       <Stack.Screen
-        name={ScreenName.OnboardingLanguage}
-        component={OnboardingLanguage}
-        options={{
-          title: "onboarding.stepLanguage.title",
-          ...modalOptions,
-        }}
-      />
-      <Stack.Screen
-        name={ScreenName.OnboardingStepLanguageGetStarted}
-        component={OnboardingStepLanguageGetStarted}
-        options={{
-          title: "onboarding.stepLanguage.title",
-          ...modalOptions,
-        }}
+        // TODO : index the name
+        name={"OnboardingModal"}
+        component={LanguageModalNavigator}
+        options={modalOptions}
       />
       <Stack.Screen
         name={ScreenName.OnboardingTermsOfUse}

--- a/src/screens/Onboarding/steps/language.tsx
+++ b/src/screens/Onboarding/steps/language.tsx
@@ -14,7 +14,6 @@ import { useLocale } from "../../../context/Locale";
 import { supportedLocales } from "../../../languages";
 import Button from "../../../components/Button";
 import { ScreenName } from "../../../const";
-import NavigationModalContainer from "../../../components/NavigationModalContainer";
 
 const languages = {
   de: "Deutsch",
@@ -49,7 +48,7 @@ function OnboardingStepLanguage({ navigation }: StackScreenProps<{}>) {
   };
 
   return (
-    <NavigationModalContainer justifyContent="space-between">
+    <>
       <ScrollView>
         <Flex mb={4}>
           <SelectableList
@@ -71,7 +70,7 @@ function OnboardingStepLanguage({ navigation }: StackScreenProps<{}>) {
         outline={false}
         title={<Trans i18nKey="onboarding.stepLanguage.cta" />}
       />
-    </NavigationModalContainer>
+    </>
   );
 }
 
@@ -79,11 +78,11 @@ export function OnboardingStepLanguageGetStarted({
   navigation,
 }: StackScreenProps<{}>) {
   const next = () => {
-    navigation.navigate(ScreenName.OnboardingTermsOfUse);
+    navigation.getParent()?.replace(ScreenName.OnboardingTermsOfUse);
   };
 
   return (
-    <NavigationModalContainer justifyContent="space-between">
+    <>
       <Flex flex={1} px={4} justifyContent="center" alignItems="center">
         <Flex mb={8}>
           <IconBox Icon={Icons.WarningMedium} />
@@ -101,7 +100,7 @@ export function OnboardingStepLanguageGetStarted({
         outline={false}
         title={<Trans i18nKey="onboarding.stepLanguage.cta" />}
       />
-    </NavigationModalContainer>
+    </>
   );
 }
 

--- a/src/screens/Onboarding/steps/welcome.tsx
+++ b/src/screens/Onboarding/steps/welcome.tsx
@@ -20,13 +20,12 @@ const SafeFlex = styled(Flex).attrs({ as: SafeAreaView })``;
 function OnboardingStepWelcome({ navigation }: any) {
   const buy = useCallback(() => Linking.openURL(urls.buyNanoX), []);
 
-  const next = useCallback(
-    () => navigation.navigate(ScreenName.OnboardingTermsOfUse),
-    [navigation],
-  );
+  const next = useCallback(() => {
+    navigation.navigate(ScreenName.OnboardingTermsOfUse);
+  }, [navigation]);
 
   const onLanguageSelect = useCallback(
-    () => navigation.navigate(ScreenName.OnboardingLanguage),
+    () => navigation.navigate("OnboardingModal"),
     [navigation],
   );
 


### PR DESCRIPTION
#### As a follow up to #2006 

- improves navigation experience (pressing the previous button from the terms now goes back to the first welcome screen - not the modal)
- improves transitions - only the content is transitioned (not the header) and uses native animation style
- overall improvements to the modal container & header components

https://user-images.githubusercontent.com/86958797/144416158-3edc172d-3bcf-48d9-9822-45e567d1cb47.mp4

### Type

UI

### Context

[LL-7746]

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LL-7746]: https://ledgerhq.atlassian.net/browse/LL-7746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ