### PR TITLE
add cjs resolver to metro config

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -5,6 +5,8 @@
  * @format
  */
 
+const defaultSourceExts = require('metro-config/src/defaults/defaults').sourceExts
+
 module.exports = {
   transformer: {
     getTransformOptions: async () => ({
@@ -14,4 +16,7 @@ module.exports = {
       },
     }),
   },
+  resolver: {
+    sourceExts: [...defaultSourceExts, 'cjs'],
+  }
 };


### PR DESCRIPTION
Add `cjs` resolver to metro config as some node packages use `.cjs` modules.

### Type

Infra

### Context

As part of Solana integration

