### PR TITLE
LL-8253 Re-adding Elrond that was removed for 2.35 release

### DIFF
--- a/src/live-common-setup.js
+++ b/src/live-common-setup.js
@@ -51,6 +51,7 @@ setSupportedCurrencies([
   "bitcoin_testnet",
   "ethereum_ropsten",
   "cosmos_testnet",
+  "elrond",
 ]);
 
 if (Config.VERBOSE) {


### PR DESCRIPTION
Just re-adding elrond

### Type

Feature activation

### Context

[LL-8253](https://ledgerhq.atlassian.net/browse/LL-8253)

### Parts of the app affected / Test plan

Elrond is now available in LLM globally
