### PR TITLE
LL-8571 - Operations list v3 rebranding

### DIFF
--- a/src/components/OperationRow.tsx
+++ b/src/components/OperationRow.tsx
@@ -1,0 +1,236 @@
+import React, { useCallback } from "react";
+import { TouchableOpacity } from "react-native";
+import { Trans } from "react-i18next";
+import styled from "styled-components/native";
+import { useNavigation } from "@react-navigation/native";
+import { getOperationAmountNumber } from "@ledgerhq/live-common/lib/operation";
+import {
+  getMainAccount,
+  getAccountCurrency,
+  getAccountName,
+  getAccountUnit,
+} from "@ledgerhq/live-common/lib/account";
+
+import {
+  Account,
+  Operation,
+  AccountLike,
+} from "@ledgerhq/live-common/lib/types";
+
+import { Box, Flex, InfiniteLoader, Text } from "@ledgerhq/native-ui";
+
+import debounce from "lodash/debounce";
+import CurrencyUnitValue from "./CurrencyUnitValue";
+import CounterValue from "./CounterValue";
+
+import OperationIcon from "./OperationIcon";
+import { ScreenName } from "../const";
+import OperationRowDate from "./OperationRowDate";
+
+import perFamilyOperationDetails from "../generated/operationDetails";
+
+const ContainerTouchable = styled(Flex).attrs(p => ({
+  height: "64px",
+  flexDirection: "row",
+  alignItems: "center",
+  marginBottom: p.isLast && 7,
+  px: 0,
+  py: 6,
+}))<{ isLast?: boolean }>``;
+
+const Wrapper = styled(Flex).attrs(p => ({
+  flex: 1,
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "space-between",
+  marginLeft: 4,
+  marginRight: 0,
+  opacity: p.isOptimistic ? 0.5 : 1,
+}))<{ isOptimistic?: boolean }>``;
+
+const SpinnerContainer = styled(Box).attrs({
+  height: 14,
+  mr: 2,
+  justifyContent: "center",
+})``;
+
+const BodyLeftContainer = styled(Flex).attrs({
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  alignItems: "flex-start",
+  flex: 1,
+})``;
+
+const BodyRightContainer = styled(Flex).attrs({
+  flexDirection: "column",
+  justifyContent: "flex-start",
+  alignItems: "flex-end",
+  flexShrink: 0,
+  pl: 3,
+})``;
+
+type Props = {
+  operation: Operation;
+  parentAccount: Account | undefined | null;
+  account: AccountLike;
+  multipleAccounts?: boolean;
+  isLast: boolean;
+  isSubOperation?: boolean;
+};
+
+const placeholderProps = {
+  width: 40,
+  containerHeight: 20,
+};
+
+export default function OperationRow({
+  account,
+  parentAccount,
+  operation,
+  isSubOperation,
+  multipleAccounts,
+  isLast,
+}: Props) {
+  const navigation = useNavigation();
+
+  const goToOperationDetails = debounce(() => {
+    const params = [
+      ScreenName.OperationDetails,
+      {
+        accountId: account.id,
+        parentId: parentAccount && parentAccount.id,
+        operation, // FIXME we should pass a operationId instead because data can changes over time.
+        isSubOperation,
+        key: operation.id,
+      },
+    ];
+
+    /** if suboperation push to stack navigation else we simply navigate */
+    if (isSubOperation) navigation.push(...params);
+    else navigation.navigate(...params);
+  }, 300);
+
+  const renderAmountCellExtra = useCallback(() => {
+    const mainAccount = getMainAccount(account, parentAccount);
+    const currency = getAccountCurrency(account);
+    const unit = getAccountUnit(account);
+    const specific = mainAccount.currency.family
+      ? perFamilyOperationDetails[mainAccount.currency.family]
+      : null;
+
+    const SpecificAmountCell =
+      specific && specific.amountCell
+        ? specific.amountCell[operation.type]
+        : null;
+
+    return SpecificAmountCell ? (
+      <SpecificAmountCell
+        operation={operation}
+        unit={unit}
+        currency={currency}
+      />
+    ) : null;
+  }, [account, parentAccount, operation]);
+
+  const amount = getOperationAmountNumber(operation);
+  const valueColor = amount.isNegative() ? "neutral.c100" : "success.c100";
+  const currency = getAccountCurrency(account);
+  const unit = getAccountUnit(account);
+
+  const text = <Trans i18nKey={`operations.types.${operation.type}`} />;
+  const isOptimistic = operation.blockHeight === null;
+  const spinner = (
+    <SpinnerContainer>
+      <InfiniteLoader size={10} />
+    </SpinnerContainer>
+  );
+
+  return (
+    <ContainerTouchable
+      as={TouchableOpacity}
+      isLast={isLast}
+      onPress={goToOperationDetails}
+    >
+      <Box opacity={isOptimistic ? 0.5 : 1}>
+        <OperationIcon
+          size={40}
+          operation={operation}
+          account={account}
+          parentAccount={parentAccount}
+        />
+      </Box>
+      <Wrapper opacity={isOptimistic ? 0.5 : 1}>
+        <BodyLeftContainer>
+          <Text
+            variant="body"
+            fontWeight="semiBold"
+            color="neutral.c100"
+            numberOfLines={1}
+          >
+            {multipleAccounts ? getAccountName(account) : text}
+          </Text>
+
+          {isOptimistic ? (
+            <Flex flexDirection="row" alignItems="center">
+              {spinner}
+              <Text
+                numberOfLines={1}
+                variant="paragraph"
+                fontWeight="medium"
+                color="neutral.c70"
+              >
+                <Trans
+                  i18nKey={
+                    amount.isNegative()
+                      ? "operationDetails.sending"
+                      : "operationDetails.receiving"
+                  }
+                />
+              </Text>
+            </Flex>
+          ) : (
+            <Text
+              numberOfLines={1}
+              color="neutral.c70"
+              variant="paragraph"
+              fontWeight="medium"
+            >
+              {text} <OperationRowDate date={operation.date} />
+            </Text>
+          )}
+        </BodyLeftContainer>
+
+        <BodyRightContainer>{renderAmountCellExtra()}</BodyRightContainer>
+
+        {amount.isZero() ? null : (
+          <BodyRightContainer>
+            <Text
+              numberOfLines={1}
+              color={valueColor}
+              variant="body"
+              fontWeight="semiBold"
+            >
+              <CurrencyUnitValue
+                showCode
+                unit={unit}
+                value={amount}
+                alwaysShowSign
+              />
+            </Text>
+            <Text variant="paragraph" fontWeight="medium" color="neutral.c70">
+              <CounterValue
+                showCode
+                date={operation.date}
+                currency={currency}
+                value={amount}
+                alwaysShowSign
+                withPlaceholder
+                placeholderProps={placeholderProps}
+              />
+            </Text>
+          </BodyRightContainer>
+        )}
+      </Wrapper>
+    </ContainerTouchable>
+  );
+}

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import styled from "styled-components/native";
+import { Flex, Text } from "@ledgerhq/native-ui";
+import FormatDay from "./FormatDay";
+
+type Props = {
+  section: {
+    day: Date;
+  };
+  withoutMarginBottom?: boolean;
+};
+
+const Container = styled(Flex).attrs(p => ({
+  backgroundColor: "neutral.c30",
+  padding: 5,
+  borderRadius: 2,
+  marginBottom: !p.withoutMarginBottom && 3,
+}))``;
+
+export default function SectionHeader({
+  section,
+  withoutMarginBottom = false,
+}: Props) {
+  return (
+    <Container withoutMarginBottom={withoutMarginBottom}>
+      <Text
+        numberOfLines={1}
+        color="neutral.c80"
+        fontWeight="semiBold"
+        variant="subtitle"
+        uppercase
+      >
+        <FormatDay day={section.day} />
+      </Text>
+    </Container>
+  );
+}

--- a/src/icons/OperationStatusIcon/index.tsx
+++ b/src/icons/OperationStatusIcon/index.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { OperationType } from "@ledgerhq/live-common/lib/types";
+import { Icons, BoxedIcon } from "@ledgerhq/native-ui";
+import {
+  DEFAULT_BOX_SIZE,
+  DEFAULT_ICON_SIZE,
+  DEFAULT_BADGE_SIZE,
+} from "@ledgerhq/native-ui/components/Icon/BoxedIcon";
+
+const iconsComponent = {
+  OUT: Icons.ArrowTopMedium,
+  IN: Icons.ArrowBottomMedium,
+  DELEGATE: Icons.HandshakeMedium,
+  REDELEGATE: Icons.DelegateMedium,
+  UNDELEGATE: Icons.UndelegateMedium,
+  REVEAL: Icons.EyeMedium,
+  CREATE: Icons.PlusMedium,
+  NONE: Icons.ArrowFromBottomMedium,
+  FREEZE: Icons.FreezeMedium,
+  UNFREEZE: Icons.UnfreezeMedium,
+  VOTE: Icons.VoteMedium,
+  REWARD: Icons.StarMedium,
+  FEES: Icons.FeesMedium,
+  OPT_IN: Icons.PlusMedium,
+  OPT_OUT: Icons.TrashMedium,
+  CLOSE_ACCOUNT: Icons.TrashMedium,
+  REDEEM: Icons.MinusMedium,
+  SUPPLY: Icons.ArrowRightMedium,
+  APPROVE: Icons.PlusMedium,
+  BOND: Icons.LinkMedium,
+  UNBOND: Icons.LinkNoneMedium,
+  WITHDRAW_UNBONDED: Icons.CoinsMedium,
+  SLASH: Icons.TrashMedium,
+  NOMINATE: Icons.VoteMedium,
+  CHILL: Icons.VoteMedium,
+  REWARD_PAYOUT: Icons.ClaimRewardsMedium,
+  SET_CONTROLLER: Icons.ArrowFromBottomMedium,
+  NFT_IN: undefined, // TODO: get an icon from design team
+  NFT_OUT: undefined, // TODO: get an icon from design team
+};
+
+export default ({
+  type,
+  confirmed,
+  failed,
+  size = 24,
+}: {
+  size?: number;
+  type: OperationType;
+  confirmed?: boolean;
+  failed?: boolean;
+}) => {
+  const Icon = iconsComponent[type] || iconsComponent.NONE;
+  const BadgeIcon = failed
+    ? Icons.CircledCrossSolidMedium
+    : confirmed
+    ? undefined
+    : Icons.CircledCrossSolidMedium;
+  const borderColor = failed ? "error.c40" : "neutral.c40";
+  const iconColor = failed
+    ? "error.c100"
+    : confirmed
+    ? "neutral.c100"
+    : "neutral.c50";
+  const badgeColor = failed ? "error.c100" : "neutral.c70";
+  return (
+    <BoxedIcon
+      Icon={Icon}
+      Badge={BadgeIcon}
+      size={size}
+      iconSize={(size * DEFAULT_ICON_SIZE) / DEFAULT_BOX_SIZE}
+      badgeSize={(size * DEFAULT_BADGE_SIZE) / DEFAULT_BOX_SIZE}
+      borderColor={borderColor}
+      iconColor={iconColor}
+      badgeColor={badgeColor}
+    />
+  );
+};

--- a/src/screens/Account/index.tsx
+++ b/src/screens/Account/index.tsx
@@ -1,0 +1,317 @@
+import React, { useState, useRef, useCallback, useMemo } from "react";
+import { StyleSheet, View, SectionList, FlatList } from "react-native";
+import { SectionBase } from "react-native/Libraries/Lists/SectionList";
+import Animated, { Value, event } from "react-native-reanimated";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigation, useTheme } from "@react-navigation/native";
+import {
+  isAccountEmpty,
+  groupAccountOperationsByDay,
+  getAccountCurrency,
+} from "@ledgerhq/live-common/lib/account";
+import {
+  Account,
+  AccountLike,
+  TokenAccount,
+  Operation,
+} from "@ledgerhq/live-common/lib/types";
+import debounce from "lodash/debounce";
+import {
+  getAccountCapabilities,
+  makeCompoundSummaryForAccount,
+} from "@ledgerhq/live-common/lib/compound/logic";
+import { switchCountervalueFirst } from "../../actions/settings";
+import { useBalanceHistoryWithCountervalue } from "../../actions/portfolio";
+import {
+  selectedTimeRangeSelector,
+  counterValueCurrencySelector,
+  countervalueFirstSelector,
+} from "../../reducers/settings";
+import { accountScreenSelector } from "../../reducers/accounts";
+import { TrackScreen } from "../../analytics";
+import accountSyncRefreshControl from "../../components/accountSyncRefreshControl";
+import OperationRow from "../../components/OperationRow";
+import SectionHeader from "../../components/SectionHeader";
+import NoMoreOperationFooter from "../../components/NoMoreOperationFooter";
+import LoadingFooter from "../../components/LoadingFooter";
+import { ScreenName } from "../../const";
+import EmptyStateAccount from "./EmptyStateAccount";
+import NoOperationFooter from "../../components/NoOperationFooter";
+import { useScrollToTop } from "../../navigation/utils";
+
+import { getListHeaderComponents } from "./ListHeaderComponent";
+
+type Props = {
+  navigation: any;
+  route: { params: RouteParams };
+};
+
+type RouteParams = {
+  accountId: string;
+  parentId?: string;
+};
+
+const AnimatedSectionList = Animated.createAnimatedComponent(SectionList);
+const List = accountSyncRefreshControl(AnimatedSectionList);
+
+const AnimatedFlatListWithRefreshControl = Animated.createAnimatedComponent(
+  accountSyncRefreshControl(FlatList),
+);
+
+function renderSectionHeader({ section }: any) {
+  return <SectionHeader section={section} />;
+}
+
+function keyExtractor(item: Operation) {
+  return item.id;
+}
+
+const stickySectionHeight = 56;
+
+export default function AccountScreen({ route }: Props) {
+  const { account, parentAccount } = useSelector(accountScreenSelector(route));
+  if (!account) return null;
+  return <AccountScreenInner account={account} parentAccount={parentAccount} />;
+}
+
+function AccountScreenInner({
+  account,
+  parentAccount,
+}: {
+  account: AccountLike;
+  parentAccount: Account | undefined | null;
+}) {
+  const navigation = useNavigation();
+  const dispatch = useDispatch();
+  const range = useSelector(selectedTimeRangeSelector);
+  const {
+    countervalueAvailable,
+    countervalueChange,
+    cryptoChange,
+    history,
+  } = useBalanceHistoryWithCountervalue({ account, range });
+  const useCounterValue = useSelector(countervalueFirstSelector);
+  const counterValueCurrency = useSelector(counterValueCurrencySelector);
+
+  const [opCount, setOpCount] = useState(100);
+  const ref = useRef();
+  const scrollY = useRef(new Value(0)).current;
+
+  useScrollToTop(ref);
+
+  const { colors } = useTheme();
+
+  const onEndReached = useCallback(() => {
+    setOpCount(opCount + 50);
+  }, [setOpCount, opCount]);
+
+  const onSwitchAccountCurrency = useCallback(() => {
+    dispatch(switchCountervalueFirst());
+  }, [dispatch]);
+
+  const onAccountPress = debounce((tokenAccount: TokenAccount) => {
+    navigation.push(ScreenName.Account, {
+      parentId: account.id,
+      accountId: tokenAccount.id,
+    });
+  }, 300);
+
+  const ListEmptyComponent = useCallback(
+    () =>
+      isAccountEmpty(account) && (
+        <EmptyStateAccount
+          account={account}
+          parentAccount={parentAccount}
+          navigation={navigation}
+        />
+      ),
+    [account, parentAccount, navigation],
+  );
+
+  const renderItem = useCallback(
+    ({
+      item,
+      index,
+      section,
+    }: {
+      item: Operation;
+      index: number;
+      section: SectionBase<any>;
+    }) => {
+      if (!account) return null;
+
+      return (
+        <OperationRow
+          operation={item}
+          account={account}
+          parentAccount={parentAccount}
+          isFirst={index === 0}
+          isLast={section.data.length - 1 === index}
+        />
+      );
+    },
+    [account, parentAccount],
+  );
+
+  const currency = getAccountCurrency(account);
+
+  const analytics = (
+    <TrackScreen
+      category="Account"
+      currency={currency.id}
+      operationsSize={account.operations.length}
+    />
+  );
+
+  const { sections, completed } = groupAccountOperationsByDay(account, {
+    count: opCount,
+  });
+
+  const compoundCapabilities =
+    account.type === "TokenAccount" &&
+    !!account.compoundBalance &&
+    getAccountCapabilities(account);
+
+  const compoundSummary =
+    compoundCapabilities?.status && account.type === "TokenAccount"
+      ? makeCompoundSummaryForAccount(account, parentAccount)
+      : undefined;
+
+  const [isCollapsed, setIsCollapsed] = useState(true);
+
+  const { listHeaderComponents, stickyHeaderIndices } = useMemo(
+    () =>
+      getListHeaderComponents({
+        account,
+        parentAccount,
+        countervalueAvailable,
+        useCounterValue,
+        range,
+        history,
+        countervalueChange,
+        cryptoChange,
+        counterValueCurrency,
+        onAccountPress,
+        onSwitchAccountCurrency,
+        compoundSummary,
+        isCollapsed,
+        setIsCollapsed,
+      }),
+    [
+      account,
+      compoundSummary,
+      counterValueCurrency,
+      countervalueAvailable,
+      countervalueChange,
+      cryptoChange,
+      history,
+      isCollapsed,
+      onAccountPress,
+      onSwitchAccountCurrency,
+      parentAccount,
+      range,
+      useCounterValue,
+    ],
+  );
+
+  const data = [
+    ...listHeaderComponents,
+    <List
+      ref={ref}
+      sections={sections}
+      style={[styles.sectionList]}
+      contentContainerStyle={styles.contentContainer}
+      ListFooterComponent={
+        !completed ? (
+          <LoadingFooter />
+        ) : sections.length === 0 ? (
+          isAccountEmpty(account) ? null : (
+            <NoOperationFooter />
+          )
+        ) : (
+          <NoMoreOperationFooter />
+        )
+      }
+      ListEmptyComponent={ListEmptyComponent}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      renderSectionHeader={renderSectionHeader}
+      onEndReached={onEndReached}
+      onScroll={event(
+        [
+          {
+            nativeEvent: {
+              contentOffset: { y: scrollY },
+            },
+          },
+        ],
+        { useNativeDriver: true },
+      )}
+      showsVerticalScrollIndicator={false}
+      accountId={account.id}
+      stickySectionHeadersEnabled={false}
+    />,
+  ];
+
+  return (
+    <View style={[styles.root]}>
+      {analytics}
+      <AnimatedFlatListWithRefreshControl
+        style={{ flex: 1 }}
+        data={data}
+        renderItem={({ item }) => item}
+        keyExtractor={(item, index) => String(index)}
+        showsVerticalScrollIndicator={false}
+        stickyHeaderIndices={stickyHeaderIndices}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: "column",
+  },
+  sectionList: {
+    flex: 1,
+    paddingHorizontal: 16,
+  },
+  balanceContainer: {
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  balanceText: {
+    fontSize: 22,
+    paddingBottom: 4,
+  },
+  contentContainer: {
+    paddingBottom: 64,
+    flexGrow: 1,
+  },
+  accountFabActions: {
+    width: "100%",
+    height: 56,
+    position: "absolute",
+    bottom: 0,
+    left: 0,
+  },
+  stickyContainer: {
+    width: "100%",
+    height: stickySectionHeight,
+    paddingVertical: 8,
+    position: "absolute",
+    left: 0,
+    top: 0,
+    zIndex: -100,
+    opacity: 0,
+  },
+  stickyBg: {
+    width: "100%",
+    height: "100%",
+    position: "absolute",
+    zIndex: 0,
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3801,6 +3801,15 @@
     "@types/react" "*"
     csstype "^3.0.2"
 
+"@types/styled-components@^5.1.14":
+  version "5.1.18"
+  resolved "https://registry.yarnpkg.com/@types/styled-components/-/styled-components-5.1.18.tgz#1c361130f76a52f1cb4851c2a32aa328267e5b78"
+  integrity sha512-xPTYmWP7Mxk5TAD3pYsqjwA9G5fAI8e/S51QUJEl7EQD1siKCdiYXIWiH2lzoHRl+QqbQCJMcGv3YTF3OmyPdQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "*"
+    "@types/react" "*"
+    csstype "^3.0.2"
+
 "@types/styled-system@^5.1.13":
   version "5.1.13"
   resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.13.tgz#9ad667534d3bd75720dd7778c94c783449cb5c14"


### PR DESCRIPTION
### Type

v3 rebranding

### Context

[LL-8571]

- v3 restyling of the list of operations, i.e. the `OperationRow`, `OperationStatusIcon` and `SectionHeader` components + add horizontal padding to the list in the Account screen (the horizontal padding is not implemented in these elementary components so it should be added later in the screens that use them).

[Figma for reference](https://www.figma.com/file/7VtMZwUewpyYYhKTECGFKz/LLM-%2F-Account?node-id=1223%3A49849)

https://user-images.githubusercontent.com/91890529/146793390-f420cbb9-ca1a-41d1-8ea7-2b9dc5f47014.mp4

[LL-8571]: https://ledgerhq.atlassian.net/browse/LL-8571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ