### PR TITLE
LL-8459 Hide quantity for non-ERC-1155 NFTs

### DIFF
--- a/src/components/Nft/NftViewer.js
+++ b/src/components/Nft/NftViewer.js
@@ -245,14 +245,17 @@ const NftViewer = ({ route }: Props) => {
 
           <Section title={t("nft.viewer.tokenId")} value={nft.tokenId} />
 
-          <View style={styles.hr} />
-
-          <TouchableOpacity onPress={closeModal}>
-            <Section
-              title={t("nft.viewer.quantity")}
-              value={nft.amount.toFixed()}
-            />
-          </TouchableOpacity>
+          {collection.standard === "ERC1155" && (
+            <>
+              <View style={styles.hr} />
+              <TouchableOpacity onPress={closeModal}>
+                <Section
+                  title={t("nft.viewer.quantity")}
+                  value={nft.amount.toFixed()}
+                />
+              </TouchableOpacity>
+            </>
+          )}
         </View>
       </ScrollView>
       <NftLinksPanel

--- a/src/screens/OperationDetails/Content.js
+++ b/src/screens/OperationDetails/Content.js
@@ -300,10 +300,12 @@ export default function Content({
             title={t("operationDetails.tokenId")}
             value={operation.tokenId}
           />
-          <Section
-            title={t("operationDetails.quantity")}
-            value={operation.value.toFixed()}
-          />
+          {operation.standard === "ERC1155" && (
+            <Section
+              title={t("operationDetails.quantity")}
+              value={operation.value.toFixed()}
+            />
+          )}
         </>
       ) : null}
 


### PR DESCRIPTION

![Screenshot_20211223_160646_com ledger live debug](https://user-images.githubusercontent.com/6013294/147262380-f282ea91-4954-4e7b-a607-e14df59195b1.jpg)
![Screenshot_20211223_160720_com ledger live debug](https://user-images.githubusercontent.com/6013294/147262381-b87b52d6-760e-4376-a6d9-789a35c1e40d.jpg)


### Type
UI Improvement

### Context
[LL-8459]

### Parts of the app affected / Test plan
NFT Viewer and NFT Transaction. Non ERC-1155 NFTs should not display any quantity anymore.

[LL-8459]: https://ledgerhq.atlassian.net/browse/LL-8459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ