### PR TITLE
LL-6233 Fix analytics on LLM

### DIFF
--- a/src/analytics/TrackScreen.js
+++ b/src/analytics/TrackScreen.js
@@ -10,13 +10,15 @@ type Props = {
 
 export default function TrackScreen({ category, name, ...props }: Props) {
   const isFocused = useIsFocused();
-
-  const isFocusedRef = useRef(isFocused);
+  const isFocusedRef = useRef();
 
   useEffect(() => {
     if (isFocusedRef.current !== isFocused) {
       isFocusedRef.current = isFocused;
-      screen(category, name, props);
+
+      if (isFocusedRef.current) {
+        screen(category, name, props);
+      }
     }
   }, [category, name, props, isFocused]);
 

--- a/src/components/AnalyticsConsole.js
+++ b/src/components/AnalyticsConsole.js
@@ -1,5 +1,5 @@
 // @flow
-import React, { useReducer, useEffect } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { StyleSheet, View, Text } from "react-native";
 import { map } from "rxjs/operators";
 import useEnv from "@ledgerhq/live-common/lib/hooks/useEnv";
@@ -8,26 +8,45 @@ import { trackSubject } from "../analytics/segment";
 let id = 0;
 
 const AnalyticsConsole = () => {
-  const [items, addItem] = useReducer(
-    (items, item) => (items.length > 10 ? items.slice(1) : items).concat(item),
-    [],
-  );
+  const [items, setItems] = useState([]);
+  const filter = useCallback((curr, prev) => {
+    if (!prev || !curr.properties) return curr;
+    // We repeat a bunch of data over and over again, filter that out unless it changes.
+    // Will only work for flat props.
+    const keys = Object.keys(curr.properties).filter(
+      k => curr?.properties[k] !== prev?.properties[k],
+    );
+    const properties = keys.reduce(
+      (ret, key) => ({ ...ret, [key]: curr.properties[key] }),
+      {},
+    );
+    return { ...curr, properties };
+  }, []);
+
+  const addItem = useCallback(item => {
+    setItems(currentItems => [...currentItems.slice(0, 9), item]);
+  }, []);
 
   useEffect(() => {
     trackSubject.pipe(map(item => ({ ...item, id: ++id }))).subscribe(addItem);
-  }, []);
+  }, [addItem]);
   const render = useEnv("ANALYTICS_CONSOLE");
 
   return render ? (
     <View style={styles.root} pointerEvents="none">
-      {items.map(item => (
-        <View style={styles.item} key={item.id}>
-          <Text style={styles.eventName}>{item.event}</Text>
-          <Text>
-            {item.properties ? JSON.stringify(item.properties) : null}
-          </Text>
-        </View>
-      ))}
+      {items.map((item, index) => {
+        const filteredData = filter(item, items[index - 1]);
+        return (
+          <View style={styles.item} key={item.id}>
+            <Text style={styles.eventName}>{filteredData.event}</Text>
+            <Text>
+              {filteredData.properties
+                ? JSON.stringify(filteredData.properties)
+                : null}
+            </Text>
+          </View>
+        );
+      })}
     </View>
   ) : null;
 };
@@ -36,11 +55,13 @@ const styles = StyleSheet.create({
   root: {
     zIndex: 999,
     backgroundColor: "#fffc",
+    color: "#000",
     flex: 1,
     position: "absolute",
     opacity: 0.4,
     top: 0,
     left: 0,
+    flexDirection: "column-reverse",
   },
   item: {
     padding: 2,

--- a/src/components/AnalyticsConsole.js
+++ b/src/components/AnalyticsConsole.js
@@ -24,7 +24,7 @@ const AnalyticsConsole = () => {
   }, []);
 
   const addItem = useCallback(item => {
-    setItems(currentItems => [...currentItems.slice(0, 9), item]);
+    setItems(currentItems => [...currentItems.slice(-9), item]);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
https://user-images.githubusercontent.com/4631227/147925467-17d10e85-c952-4d08-a6a6-b96a6e426666.mov

https://user-images.githubusercontent.com/4631227/147925480-b03c1c8e-2eb8-416b-91cd-ba8a181eb0ef.mov

![image](https://user-images.githubusercontent.com/4631227/147925581-9940905d-f6ed-4c1f-935c-9ba1c17da7bf.png)

The logic for tracking a screen load seems to be wrong, resulting in only triggering the event after we unmount the screen, also creating duplicated events after we load the next screen and breaking the overall analytics flow. I also introduced an improvement requested by product on the analytics console to make it more readable and usable.


### Type

Bug Fix + Feature I guess

### Context

https://ledgerhq.atlassian.net/browse/LL-6233

### Parts of the app affected / Test plan

- Enable analytics on LLM (either by the env flag or in the debug menu)
- Navigate through the app and see if the events now make sense
- They didnt make sense before
