### PR TITLE
LL-8841 - Limit the number of lines for the NFT's name in the viewer

### DIFF
--- a/src/components/Nft/NftViewer.js
+++ b/src/components/Nft/NftViewer.js
@@ -184,7 +184,7 @@ const NftViewer = ({ route }: Props) => {
             style={[styles.nftName, styles.nftNameSkeleton]}
             loading={isLoading}
           >
-            <LText style={styles.nftName} semiBold>
+            <LText style={styles.nftName} numberOfLines={3} semiBold>
               {metadata?.nftName || "-"}
             </LText>
           </Skeleton>


### PR DESCRIPTION

![Screenshot_20220103_150350_com ledger live debug](https://user-images.githubusercontent.com/6013294/147940859-b5b3c22d-6e45-41da-aa4c-4ff321a942c8.jpg)


### Type
UI Polish

### Context
[LL-8841]

### Parts of the app affected / Test plan
NFT Viewer


[LL-8841]: https://ledgerhq.atlassian.net/browse/LL-8841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ