### PR TITLE
LL-8891 switch to run CI on external contribs

### DIFF
--- a/.github/workflows/bundle-app.yml
+++ b/.github/workflows/bundle-app.yml
@@ -17,8 +17,18 @@ jobs:
         with:
           access_token: ${{ secrets.GITHUB_TOKEN }}
 
+  check-org-member:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: ledgerhq/actions/packages/is-org-member@main
+        with:
+          organisation: ledgerhq
+          username: ${{ github.actor }}
+          token: ${{ github.token }}
+
   start-runner:
-    needs: cancel-previous
+    needs: [check-org-member]
+    if: success()
     name: "start ec2 instance (Linux)"
     uses: ledgerhq/actions/.github/workflows/start-linux-runner.yml@main
     with:
@@ -28,7 +38,7 @@ jobs:
 
   stop-runner:
     name: "stop ec2 instance (Linux)"
-    needs: [start-runner, bundle-apk]
+    needs: [start-runner, bundle-apk-hosted]
     uses: ledgerhq/actions/.github/workflows/stop-linux-runner.yml@main
     if: ${{ always() }}
     with:
@@ -37,8 +47,8 @@ jobs:
     secrets:
       CI_BOT_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
-  bundle-apk:
-    needs: [cancel-previous, start-runner]
+  bundle-apk-hosted:
+    needs: [start-runner]
     runs-on: ${{ needs.start-runner.outputs.label }}
     steps:
       - name: prepare runner
@@ -80,6 +90,53 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+      - name: install dependencies
+        run: yarn --frozen-lockfile --network-timeout 100000
+      - uses: ledgerhq/actions/get-package-infos@v1.0.0
+        id: version
+      - name: set beta name
+        uses: ledgerhq/actions/packages/change-product-name@main
+        with:
+          path: ${{ github.workspace }}
+      - name: Get short SHA
+        id: slug
+        run: echo "::set-output name=sha8::$(git rev-parse HEAD)"
+      - name: make local version
+        run: yarn version --new-version=${{ steps.version.outputs.clean }}-sha.${{ steps.slug.outputs.sha8 }}
+      - name: build the app
+        env:
+          ANDROID_KEYSTORE_PASS: staging
+          ANDROID_KEY_ALIAS: staging
+          ANDROID_KEY_PASS: staging
+        run: ANDROID_KEYSTORE_FILE="$(pwd)/android/app/staging.kstr" yarn android:local:apk
+      - uses: ledgerhq/actions/get-package-infos@v1.0.0
+        id: post-version
+      - name: upload Android app
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ steps.post-version.outputs.version }}-release
+          path: android/app/build/outputs/apk/release
+
+  bundle-apk-guest:
+    needs: [check-org-member]
+    if: failure()
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+      - name: set git user
+        run: |
+          git config user.email "team-live@ledger.fr"
+          git config user.name "Team Live"
+      - uses: actions/setup-node@main
+        with:
+          node-version: 14.x
+          cache: yarn
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
       - name: install dependencies
         run: yarn --frozen-lockfile --network-timeout 100000
       - uses: ledgerhq/actions/get-package-infos@v1.0.0


### PR DESCRIPTION
Switch back to Github runners for external contributions

### Type

CI Update

### Context

[LL-8891]

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LL-8891]: https://ledgerhq.atlassian.net/browse/LL-8891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ