### PR TITLE
LL-8751 fix ble pairing timeDout rendering

### DIFF
--- a/src/screens/PairDevices/index.js
+++ b/src/screens/PairDevices/index.js
@@ -231,7 +231,7 @@ function PairDevicesInner({ navigation, route }: Props) {
           onTimeout={onTimeout}
         />
       );
-    case "timedout":
+    case "timeout":
       return <ScanningTimeout onRetry={onRetry} />;
     case "pairing":
       return <PendingPairing />;


### PR DESCRIPTION
We introduced a bug nearly a year ago that resulted on a blank screen when the scan for a device to pair returned no devices. This was due a typo in the status, during a rework it was changed from `timedout` to `timeout` without updating the switch expression that determined the `timedout` case, no case, no rendering.

![image](https://user-images.githubusercontent.com/4631227/148573601-281a8e13-210c-492f-8476-b06c0f7a79a9.png)


### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-8751

### Parts of the app affected / Test plan

- Go to the manager
- On the device selection screen click on "Add new Ledger Nano X"
- Wait for the timeout
- It is expected that we now have a rendering matching the screenshot