### PR TITLE
LL-8927 - Fix crash when KeyboardView is used out of a navigator with a header

### DIFF
--- a/src/components/KeyboardView.js
+++ b/src/components/KeyboardView.js
@@ -6,7 +6,7 @@ import {
   NativeModules,
   StatusBar,
 } from "react-native";
-import { useHeaderHeight } from "@react-navigation/elements";
+import { HeaderHeightContext } from "@react-navigation/elements";
 import { HEIGHT as ExperimentalHeaderHeight } from "../screens/Settings/Experimental/ExperimentalHeader";
 import { useExperimental } from "../experimental";
 
@@ -20,7 +20,7 @@ type Props = {
 const KeyboardView = React.memo<Props>(
   ({ style = { flex: 1 }, children }: *) => {
     const isExperimental = useExperimental();
-    const headerHeight = useHeaderHeight();
+    const headerHeight = React.useContext(HeaderHeightContext) || 0;
 
     let behavior;
     let keyboardVerticalOffset = isExperimental ? ExperimentalHeaderHeight : 0;


### PR DESCRIPTION
By default `useHeaderHeight()` throws an error if it is used outside of a `HeaderHeightContext.Provider`. The fix is to do what `useHeaderHeight()` does under the hood but handle an `undefined` returned value by simply defaulting to `0`.

### Type

Bug fix

### Context

[LL-8927]

### Parts of the app affected / Test plan

[LL-8927]: https://ledgerhq.atlassian.net/browse/LL-8927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ