### PR TITLE
LL-8928 - Fix "Receive page is blank"

### DIFF
--- a/src/screens/ReceiveFunds/02-ConnectDevice.js
+++ b/src/screens/ReceiveFunds/02-ConnectDevice.js
@@ -151,7 +151,7 @@ export default function ConnectDevice({ navigation, route }: Props) {
         <SelectDevice
           onSelect={setDevice}
           onWithoutDevice={onSkipDevice}
-          withoutDevice={!!account}
+          withoutDevice
         />
       </NavigationScrollView>
       <DeviceActionModal

--- a/src/screens/ReceiveFunds/02-ConnectDevice.js
+++ b/src/screens/ReceiveFunds/02-ConnectDevice.js
@@ -94,8 +94,7 @@ export default function ConnectDevice({ navigation, route }: Props) {
   const onSkipDevice = useCallback(() => {
     if (!account) return;
     navigation.navigate(ScreenName.ReceiveConfirmation, {
-      accountId: account.id,
-      parentId: parentAccount && parentAccount.id,
+      ...route.params,
     });
   }, [account, navigation, parentAccount]);
 
@@ -152,7 +151,7 @@ export default function ConnectDevice({ navigation, route }: Props) {
         <SelectDevice
           onSelect={setDevice}
           onWithoutDevice={onSkipDevice}
-          withoutDevice
+          withoutDevice={!!account}
         />
       </NavigationScrollView>
       <DeviceActionModal


### PR DESCRIPTION
Before, the `account` param property was missing so in `ReceiveFunds/03-Confirmation` in the following statement, the value of `account` was `undefined`.

```
const { account, parentAccount } = useSelector(accountScreenSelector(route));
```

As it is already done like this in the `onResult` callback, I assume the expected way of routing to the ReceiveConfirmation screen is to pass down the existing params, i.e: passing `...route.params` as params to `navigate(ScreenName.ReceiveConfirmation)`.

https://user-images.githubusercontent.com/91890529/148942608-7a809788-2211-4154-bce3-7d4f8b79a042.mp4


### Type

Bug fix

### Context

[LL-8928]

### Parts of the app affected / Test plan

What is impacted is the "Continue without my device" receive flow.

[LL-8928]: https://ledgerhq.atlassian.net/browse/LL-8928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ