### PR TITLE
LL-8962 Drop jcenter to fix android builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,7 +13,6 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:4.2.1")
@@ -40,16 +39,20 @@ allprojects {
             // Android JSC is installed from npm
             url("$rootDir/../node_modules/jsc-android/dist")
         }
-
         google()
-        jcenter()
         maven { url 'https://jitpack.io' }
         maven {
             url "$rootDir/../node_modules/detox/Detox-android"
         }
-        jcenter()
-         maven {
+        maven {
             url "$rootDir/../node_modules/expo-camera/android/maven"
+        }
+    }
+    configurations.all {
+        resolutionStrategy {
+            dependencySubstitution {
+                substitute module("com.redmadrobot:input-mask-android:6.0.0") using module('com.github.RedMadRobot:input-mask-android:6.0.0')
+            }
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "react-native-easy-markdown": "^2.0.0",
     "react-native-extra-dimensions-android": "^1.2.5",
     "react-native-fast-image": "^8.5.11",
-    "react-native-fingerprint-scanner": "^6.0.0",
+    "react-native-fingerprint-scanner": "git+https://github.com/hieuvp/react-native-fingerprint-scanner.git#f1d136f605412d58e4de9e7e155d6f818ba24731",
     "react-native-gesture-handler": "^1.10.3",
     "react-native-keychain": "^7.0.0",
     "react-native-level-fs": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12490,10 +12490,9 @@ react-native-fast-image@^8.5.11:
   resolved "https://registry.yarnpkg.com/react-native-fast-image/-/react-native-fast-image-8.5.11.tgz#e3dc969d0e4e8df026646bf18194465aa55cbc2b"
   integrity sha512-cNW4bIJg3nvKaheG8vGMfqCt5LMWX9MS5+wMudgKIHbGO51spRr4sgnlhVgwHLcZ5aeNOVJ8CPRxDIWKRq/0QA==
 
-react-native-fingerprint-scanner@^6.0.0:
+"react-native-fingerprint-scanner@git+https://github.com/hieuvp/react-native-fingerprint-scanner.git#f1d136f605412d58e4de9e7e155d6f818ba24731":
   version "6.0.0"
-  resolved "https://registry.yarnpkg.com/react-native-fingerprint-scanner/-/react-native-fingerprint-scanner-6.0.0.tgz#ecb47ad0682d2a66a5e126d2b9e4d95e73c8dbf2"
-  integrity sha512-8VoKSA0Z0kWnIni96yABZfUUzfmWFXQEXcELwWr1CNLloPt3WoPptYb/6pGsBcH0YxSsW3X4+C8tl0clgyBsvA==
+  resolved "git+https://github.com/hieuvp/react-native-fingerprint-scanner.git#f1d136f605412d58e4de9e7e155d6f818ba24731"
 
 react-native-gesture-handler@^1.10.3:
   version "1.10.3"


### PR DESCRIPTION
When trying to build yesterday I noticed all  dependencies that were tried to be fetched from jcenter were failing, this proposes a workaround by following the alternatives each of the failing dependencies were proposing. In particular `com.redmadrobot:input-mask-android` which is used internally by our direct dependency `react-native-text-input-mask` needs to be resolved via a configuration change in the app.build, and the `react-native-fingerprint-scanner` we are pointing at a specific commit now since the library is no longer maintained and doesn't release.

We should drop these two dependencies if they don't solve the jcenter issue soon, but this is a solution in the meantime that shouldn't introduce any security vulnerabilities, the specific commit can't change, the rewrite points to their github, specific tagged version.

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-8962
