### PR TITLE
LL-8966 Plugin autoupdate feat

### DIFF
--- a/src/screens/SignTransaction/02-ConnectDevice.js
+++ b/src/screens/SignTransaction/02-ConnectDevice.js
@@ -60,6 +60,9 @@ function ConnectDevice({ route }: Props) {
     onSuccess,
   });
 
+  // Nb setting the mainAccount as a dependency will ensure latest versions of plugins.
+  const dependencies = [mainAccount];
+
   return transaction ? (
     <SafeAreaView style={[styles.root, { backgroundColor: colors.background }]}>
       <TrackScreen
@@ -75,6 +78,8 @@ function ConnectDevice({ route }: Props) {
           transaction,
           status,
           tokenCurrency,
+          dependencies,
+          requireLatestFirmware: true,
         }}
         device={route.params.device}
         onResult={handleTx}


### PR DESCRIPTION
Force the usage of latest plugin/app versions when interacting with live apps, also set up a firmware version wall, allowing only devices with the latest firmware version to sign transactions within the discover section. I still think this is a bad idea, for the record.
![image](https://user-images.githubusercontent.com/4631227/149496760-77e6f23d-b850-4072-850a-3547f3e9a652.png)

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-8966

### Parts of the app affected / Test plan

There's a test plan on Jira for this, just as it has for LLD.
