### PR TITLE
LL-8449 - Fix segment using last seed device selector

### DIFF
--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -17,6 +17,7 @@ import getOrCreateUser from "../user";
 import {
   analyticsEnabledSelector,
   languageSelector,
+  lastSeenDeviceSelector
 } from "../reducers/settings";
 import { knownDevicesSelector } from "../reducers/ble";
 import type { State } from "../reducers";
@@ -33,7 +34,8 @@ const extraProperties = store => {
   const { localeIdentifier, preferredLanguages } = Locale.constants();
   const language = languageSelector(state);
   const devices = knownDevicesSelector(state);
-  const lastDevice = devices[devices.length - 1];
+  
+  const lastDevice = lastSeenDeviceSelector(state) || devices[0];
   const deviceInfo = lastDevice
     ? {
         deviceVersion: lastDevice.deviceInfo?.version,
@@ -41,7 +43,7 @@ const extraProperties = store => {
         modelId: lastDevice.modelId,
       }
     : {};
-
+  
   return {
     appVersion,
     androidVersionCode: getAndroidVersionCode(VersionNumber.buildVersion),

--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -17,7 +17,7 @@ import getOrCreateUser from "../user";
 import {
   analyticsEnabledSelector,
   languageSelector,
-  lastSeenDeviceSelector
+  lastSeenDeviceSelector,
 } from "../reducers/settings";
 import { knownDevicesSelector } from "../reducers/ble";
 import type { State } from "../reducers";
@@ -34,7 +34,7 @@ const extraProperties = store => {
   const { localeIdentifier, preferredLanguages } = Locale.constants();
   const language = languageSelector(state);
   const devices = knownDevicesSelector(state);
-  
+
   const lastDevice = lastSeenDeviceSelector(state) || devices[0];
   const deviceInfo = lastDevice
     ? {
@@ -43,7 +43,7 @@ const extraProperties = store => {
         modelId: lastDevice.modelId,
       }
     : {};
-  
+
   return {
     appVersion,
     androidVersionCode: getAndroidVersionCode(VersionNumber.buildVersion),

--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -35,7 +35,8 @@ const extraProperties = store => {
   const language = languageSelector(state);
   const devices = knownDevicesSelector(state);
 
-  const lastDevice = lastSeenDeviceSelector(state) || devices[0];
+  const lastDevice =
+    lastSeenDeviceSelector(state) || devices[devices.length - 1];
   const deviceInfo = lastDevice
     ? {
         deviceVersion: lastDevice.deviceInfo?.version,


### PR DESCRIPTION
### Type

Bug Fix

### Context
https://ledgerhq.atlassian.net/browse/LL-8449

### Parts of the app affected / Test plan
Events sending device information miss the informations and so on, the app to track events get some undefined values caused by those empty values.

The case to test are :
- try seeing what is sent on the events deviceVersion and modelId if I never connect a device
- try seeing what is sent on the events deviceVersion and modelId if I pair a BLE device and skip genuine check
- try only accessing the manager with a plugged in device and check deviceVersion and modelId

It should be missing on develop branch and fixed here if you have a last seen device defined.

we are fixing by doing :
- BLE users that for whatever reason failed to pass the genuine check. We offer a “skip genuine” check, which will write to the known device list but without the device info. This user will continue to report undefined forever since we never update that value, even if accessing the manager.
- Users who have only users a device through USB OTG, we are currently not updating the device information from these connections either. Again, even if they access the manager, these users will continue to report undefined, forever, unless they connect a BLE device at some point and pass the genuine check.

![image](https://user-images.githubusercontent.com/90627435/149782381-60fdc8d4-a24c-4cce-9a34-5d298e0ff8d8.png)
