### PR TITLE
LL-8648 - fix(send): remove digits when select custom fees

### DIFF
--- a/src/families/bitcoin/ScreenEditCustomFees.js
+++ b/src/families/bitcoin/ScreenEditCustomFees.js
@@ -43,7 +43,9 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
   invariant(transaction.family === "bitcoin", "not bitcoin family");
   invariant(account, "no account found");
 
-  const [ownSatPerByte, setOwnSatPerByte] = useState(null);
+  const [ownSatPerByte, setOwnSatPerByte] = useState(
+    satPerByte ? satPerByte.toString() : "",
+  );
 
   const onChange = text => {
     setOwnSatPerByte(text.replace(/\D/g, ""));
@@ -83,12 +85,12 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
             <TextInput
               autoFocus
               style={[styles.textInputAS, { color: colors.darkBlue }]}
-              defaultValue={satPerByte ? satPerByte.toString() : ""}
-              keyboardType="numeric"
+              keyboardType="number-pad"
               returnKeyType="done"
               maxLength={10}
               onChangeText={onChange}
               onSubmitEditing={onValidateText}
+              value={ownSatPerByte}
             />
             <LText style={[styles.currency, { color: colors.grey }]}>
               <Trans i18nKey="common.satPerByte" />


### PR DESCRIPTION
Until now it was possible to set decimal numbers in the fee field when selecting how much sat/bytes we want to consume when sending BTC.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

[LL-8648]

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LL-8648]: https://ledgerhq.atlassian.net/browse/LL-8648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ