### PR TITLE
LL-5867 - Prompt user to activate bluetooth

### DIFF
--- a/android/app/src/main/java/com/ledger/live/BluetoothHelperModule.java
+++ b/android/app/src/main/java/com/ledger/live/BluetoothHelperModule.java
@@ -1,0 +1,40 @@
+package com.ledger.live;
+
+import android.bluetooth.BluetoothAdapter;
+import android.content.Intent;
+
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class BluetoothHelperModule extends ReactContextBaseJavaModule {
+  public BluetoothHelperModule(ReactApplicationContext context) {
+    super(context);
+  }
+
+  @Override
+  public String getName() {
+    return "BluetoothHelperModule";
+  }
+
+  /*
+   * Prompts the user to enable bluetooth if possible.
+   */
+  @ReactMethod
+  public void prompt() {
+    BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+    if (bluetoothAdapter != null && !bluetoothAdapter.isEnabled()) {
+      // Activity Action: Show a system activity that allows the user to turn on Bluetooth.
+      // This system activity will return once Bluetooth has completed turning on, or the user has decided not to turn Bluetooth on.
+      // See: https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#ACTION_REQUEST_ENABLE
+      Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
+      this.getCurrentActivity().startActivityForResult(enableBtIntent, 0);
+    }
+  }
+}

--- a/android/app/src/main/java/com/ledger/live/BluetoothHelperModule.java
+++ b/android/app/src/main/java/com/ledger/live/BluetoothHelperModule.java
@@ -2,6 +2,7 @@ package com.ledger.live;
 
 import android.bluetooth.BluetoothAdapter;
 import android.content.Intent;
+import android.app.Activity;
 
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.Promise;
@@ -9,13 +10,44 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ActivityEventListener;
+import com.facebook.react.bridge.BaseActivityEventListener;
 
 import java.util.Map;
 import java.util.HashMap;
 
 public class BluetoothHelperModule extends ReactContextBaseJavaModule {
+
+  private static final int REQUEST_ENABLE_BT = 0;
+
+  private static final String E_ACTIVITY_DOES_NOT_EXIST = "E_ACTIVITY_DOES_NOT_EXIST";
+  private static final String E_BLE_CANCELLED = "E_BLE_CANCELLED";
+
+  private Promise blePromise;
+
+  private final ActivityEventListener bleActivityEventListener = new BaseActivityEventListener() {
+
+  @Override
+  public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
+      if (requestCode == REQUEST_ENABLE_BT) {
+        if (blePromise != null) {
+          if (resultCode == Activity.RESULT_CANCELED) {
+            blePromise.reject(E_BLE_CANCELLED, "Ble activation was cancelled");
+          } else if (resultCode == Activity.RESULT_OK) {
+            blePromise.resolve(true);
+          }
+
+          blePromise = null;
+        }
+      }
+    }
+  };
+
   public BluetoothHelperModule(ReactApplicationContext context) {
     super(context);
+
+    // Add the listener for `onActivityResult`
+    context.addActivityEventListener(bleActivityEventListener);
   }
 
   @Override
@@ -23,18 +55,34 @@ public class BluetoothHelperModule extends ReactContextBaseJavaModule {
     return "BluetoothHelperModule";
   }
 
+  
+
+  /*
+   * check if bluetooth is available.
+   */
+  @ReactMethod
+  public boolean isBluetoothAvailable() {
+    BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+    return bluetoothAdapter != null && bluetoothAdapter.isEnabled();
+  }
+
   /*
    * Prompts the user to enable bluetooth if possible.
    */
   @ReactMethod
-  public void prompt() {
-    BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
-    if (bluetoothAdapter != null && !bluetoothAdapter.isEnabled()) {
+  public void prompt(Promise promise) {
+    boolean isBLEAvailable = this.isBluetoothAvailable();
+
+    if (!isBLEAvailable) {
       // Activity Action: Show a system activity that allows the user to turn on Bluetooth.
       // This system activity will return once Bluetooth has completed turning on, or the user has decided not to turn Bluetooth on.
       // See: https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#ACTION_REQUEST_ENABLE
       Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
-      this.getCurrentActivity().startActivityForResult(enableBtIntent, 0);
-    }
+      blePromise = promise;
+
+      this.getCurrentActivity().startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT);
+    } else {
+      promise.resolve(true);
+    }    
   }
 }

--- a/android/app/src/main/java/com/ledger/live/BluetoothHelperPackage.java
+++ b/android/app/src/main/java/com/ledger/live/BluetoothHelperPackage.java
@@ -1,0 +1,28 @@
+package com.ledger.live;
+
+
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class BluetoothHelperPackage implements ReactPackage {
+
+    @Override
+    public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<NativeModule> createNativeModules(
+            ReactApplicationContext reactContext) {
+        List<NativeModule> modules = new ArrayList<>();
+        modules.add(new BluetoothHelperModule(reactContext));
+        return modules;
+    }
+
+}

--- a/android/app/src/main/java/com/ledger/live/MainApplication.java
+++ b/android/app/src/main/java/com/ledger/live/MainApplication.java
@@ -38,6 +38,8 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
+          packages.add(new RNCameraPackage());
+          packages.add(new BluetoothHelperPackage());
           return packages;
         }
 

--- a/android/app/src/main/java/com/ledger/live/MainApplication.java
+++ b/android/app/src/main/java/com/ledger/live/MainApplication.java
@@ -38,7 +38,6 @@ public class MainApplication extends Application implements ReactApplication {
         protected List<ReactPackage> getPackages() {
           @SuppressWarnings("UnnecessaryLocalVariable")
           List<ReactPackage> packages = new PackageList(this).getPackages();
-          packages.add(new RNCameraPackage());
           packages.add(new BluetoothHelperPackage());
           return packages;
         }

--- a/ios/ledgerlivemobile.xcodeproj/project.pbxproj
+++ b/ios/ledgerlivemobile.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		13B07FBD1A68108700A75B9A /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB11A68108700A75B9A /* LaunchScreen.xib */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
+		17F58472269C64670070C475 /* RCTBluetoothHelperModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 17F58471269C64670070C475 /* RCTBluetoothHelperModule.m */; };
 		2372D3D5180104DBED4E22EE /* libPods-ledgerlivemobile.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 31C4672E151A9F9D4A18DB00 /* libPods-ledgerlivemobile.a */; };
 		2A2FAB56B85E5D2BFF574A32 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09BC9C5402323A57C5327727 /* ExpoModulesProvider.swift */; };
 		3407D5D9215D2AB800C9D40B /* NeededForBLE.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3407D5D8215D2AB800C9D40B /* NeededForBLE.swift */; };
@@ -56,6 +57,8 @@
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = ledgerlivemobile/main.m; sourceTree = "<group>"; };
 		13BEF41FFA9D4B06B1C8A8E1 /* libLottie.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libLottie.a; sourceTree = "<group>"; };
 		148B039A3EDE47A19A6BC6AE /* Feather.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Feather.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Feather.ttf"; sourceTree = "<group>"; };
+		17F58471269C64670070C475 /* RCTBluetoothHelperModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = RCTBluetoothHelperModule.m; path = ledgerlivemobile/RCTBluetoothHelperModule.m; sourceTree = "<group>"; };
+		17F58473269C64870070C475 /* RCTBluetoothHelperModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RCTBluetoothHelperModule.h; path = ledgerlivemobile/RCTBluetoothHelperModule.h; sourceTree = "<group>"; };
 		2402D074219C2E6600276138 /* ledgerlivemobile.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = ledgerlivemobile.entitlements; path = ledgerlivemobile/ledgerlivemobile.entitlements; sourceTree = "<group>"; };
 		2433F86A66DB455E803650A5 /* Octicons.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Octicons.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Octicons.ttf"; sourceTree = "<group>"; };
 		2B8A443FFF9942B295210CA2 /* Entypo.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = unknown; name = Entypo.ttf; path = "../node_modules/react-native-vector-icons/Fonts/Entypo.ttf"; sourceTree = "<group>"; };
@@ -162,6 +165,8 @@
 		13B07FAE1A68108700A75B9A /* ledgerlivemobile */ = {
 			isa = PBXGroup;
 			children = (
+				17F58473269C64870070C475 /* RCTBluetoothHelperModule.h */,
+				17F58471269C64670070C475 /* RCTBluetoothHelperModule.m */,
 				2402D074219C2E6600276138 /* ledgerlivemobile.entitlements */,
 				008F07F21AC5B25A0029DE68 /* main.jsbundle */,
 				3407D5D8215D2AB800C9D40B /* NeededForBLE.swift */,
@@ -618,6 +623,7 @@
 			files = (
 				3407D5D9215D2AB800C9D40B /* NeededForBLE.swift in Sources */,
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
+				17F58472269C64670070C475 /* RCTBluetoothHelperModule.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
 				2A2FAB56B85E5D2BFF574A32 /* ExpoModulesProvider.swift in Sources */,
 			);

--- a/ios/ledgerlivemobile/RCTBluetoothHelperModule.h
+++ b/ios/ledgerlivemobile/RCTBluetoothHelperModule.h
@@ -1,0 +1,18 @@
+//
+//  RCTBluetoothHelperModule.h
+//  ledgerlivemobile
+//
+//  Created by jelbaz on 12/07/2021.
+//  Copyright © 2021 Ledger SAS. All rights reserved.
+//
+
+#ifndef RCTBluetoothHelperModule_h
+#define RCTBluetoothHelperModule_h
+
+#import <React/RCTBridgeModule.h>
+#import <CoreBluetooth/CoreBluetooth.h>
+
+@interface RCTBluetoothHelperModule : NSObject <RCTBridgeModule>
+@end
+
+#endif /* RCTBluetoothHelperModule_h */

--- a/ios/ledgerlivemobile/RCTBluetoothHelperModule.h
+++ b/ios/ledgerlivemobile/RCTBluetoothHelperModule.h
@@ -12,7 +12,15 @@
 #import <React/RCTBridgeModule.h>
 #import <CoreBluetooth/CoreBluetooth.h>
 
+@interface Delegate : NSObject<CBCentralManagerDelegate>
+@property CBCentralManager *centralManager;
+@property RCTPromiseResolveBlock resolve;
+@property RCTPromiseRejectBlock reject;
+- (instancetype)initWithPromise: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
+@end
+
 @interface RCTBluetoothHelperModule : NSObject <RCTBridgeModule>
+@property(strong) Delegate * delegate;
 @end
 
 #endif /* RCTBluetoothHelperModule_h */

--- a/ios/ledgerlivemobile/RCTBluetoothHelperModule.m
+++ b/ios/ledgerlivemobile/RCTBluetoothHelperModule.m
@@ -1,0 +1,30 @@
+//
+//  RCTBluetoothHelperModule.m
+//  ledgerlivemobile
+//
+//  Created by jelbaz on 12/07/2021.
+//  Copyright © 2021 Ledger SAS. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "RCTBluetoothHelperModule.h"
+
+@implementation RCTBluetoothHelperModule
+
+// To export a module named BluetoothHelperModule
+// Without passing in a name this will export the native module name as the Objective-C class name with “RCT” removed
+RCT_EXPORT_MODULE();
+
+/*
+ * Prompts the user to enable bluetooth if possible.
+ */
+RCT_EXPORT_METHOD(prompt)
+{
+  CBCentralManager* manager = [CBCentralManager alloc];
+  // Calling init() is enough to show a prompt with a redirect to the bluetooth settings.
+  // (option "CBCentralManagerOptionShowPowerAlertKey" is true by default)
+  // See: https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/central_manager_initialization_options?language=objc
+  [manager init];
+}
+
+@end

--- a/ios/ledgerlivemobile/RCTBluetoothHelperModule.m
+++ b/ios/ledgerlivemobile/RCTBluetoothHelperModule.m
@@ -9,6 +9,58 @@
 #import <Foundation/Foundation.h>
 #import "RCTBluetoothHelperModule.h"
 
+@implementation Delegate
+- (instancetype)initWithPromise: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+  if(self = [super init]) {
+    // Calling initWithDelegate() is enough to show a prompt with a redirect to the bluetooth settings.
+    // (option "CBCentralManagerOptionShowPowerAlertKey" is true by default)
+    // See: https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/central_manager_initialization_options?language=objc
+    self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];
+    self.resolve = resolve;
+    self.reject = reject;
+  }
+  return self;
+}
+- (void)centralManagerDidUpdateState:(CBCentralManager *)central {
+  self.resolve(nil);
+  
+  // Keeping the following lines commented for reference, if we ever want to be more accurate.
+  
+  /*
+  if(!self.centralManager) {
+    return;
+  }
+  
+  switch ([central state])
+  {
+    case CBCentralManagerStatePoweredOn:
+      // Bluetooth LE is turned on and ready for communication.
+      self.resolve(nil);
+      break;
+    case CBCentralManagerStateUnsupported:
+      self.reject(@"bluetooth_unsupported", @"This device does not support Bluetooth Low Energy.", nil);
+      break;
+    case CBCentralManagerStateUnauthorized:
+      self.reject(@"bluetooth_unauthorized", @"This app is not authorized to use Bluetooth Low Energy.", nil);
+      break;
+    case CBCentralManagerStatePoweredOff:
+      self.reject(@"bluetooth_powered_off", @"Bluetooth on this device is currently powered off.", nil);
+      break;
+    case CBCentralManagerStateResetting:
+      self.reject(@"bluetooth_resetting", @"The BLE Manager is resetting; a state update is pending.", nil);
+      break;
+    case CBCentralManagerStateUnknown:
+      self.reject(@"bluetooth_unknown", @"The state of the BLE Manager is unknown.", nil);
+      break;
+    default:
+      self.reject(@"bluetooth_unknown", @"The state of the BLE Manager is unknown.", nil);
+  }
+   */
+  
+  self.centralManager = nil;
+}
+@end
+
 @implementation RCTBluetoothHelperModule
 
 // To export a module named BluetoothHelperModule
@@ -18,13 +70,9 @@ RCT_EXPORT_MODULE();
 /*
  * Prompts the user to enable bluetooth if possible.
  */
-RCT_EXPORT_METHOD(prompt)
+RCT_EXPORT_METHOD(prompt: (RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)
 {
-  CBCentralManager* manager = [CBCentralManager alloc];
-  // Calling init() is enough to show a prompt with a redirect to the bluetooth settings.
-  // (option "CBCentralManagerOptionShowPowerAlertKey" is true by default)
-  // See: https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/central_manager_initialization_options?language=objc
-  [manager init];
+  self.delegate = [[Delegate alloc] initWithPromise: resolve reject:reject];
 }
 
 @end

--- a/src/components/GenericErrorView.js
+++ b/src/components/GenericErrorView.js
@@ -34,7 +34,9 @@ function GenericErrorView({
 }: Props) {
   useEffect(() => {
     if (error instanceof BluetoothRequired) {
-      NativeModules.BluetoothHelperModule.prompt();
+      NativeModules.BluetoothHelperModule.prompt().catch(() => {
+        /* ignore */
+      });
     }
   }, [error]);
 

--- a/src/components/GenericErrorView.js
+++ b/src/components/GenericErrorView.js
@@ -1,22 +1,20 @@
 /* @flow */
-import React from "react";
-import { View, StyleSheet } from "react-native";
+import React, { memo, useEffect } from "react";
+import { View, StyleSheet, NativeModules } from "react-native";
+
 import { Trans } from "react-i18next";
-import useExportLogs from "./useExportLogs";
+
+import { BluetoothRequired } from "@ledgerhq/errors";
+
 import LText from "./LText";
 import ErrorIcon from "./ErrorIcon";
 import TranslatedError from "./TranslatedError";
 import SupportLinkError from "./SupportLinkError";
 import Button from "./Button";
 import DownloadFileIcon from "../icons/DownloadFile";
+import useExportLogs from "./useExportLogs";
 
-const GenericErrorView = ({
-  error,
-  outerError,
-  withDescription = true,
-  withIcon = true,
-  hasExportLogButton = true,
-}: {
+type Props = {
   error: Error,
   // sometimes we want to "hide" the technical error into a category
   // for instance, for Genuine check we want to express "Genuine check failed" because "<actual error>"
@@ -25,7 +23,21 @@ const GenericErrorView = ({
   withDescription?: boolean,
   withIcon?: boolean,
   hasExportLogButton?: boolean,
-}) => {
+};
+
+function GenericErrorView({
+  error,
+  outerError,
+  withDescription = true,
+  withIcon = true,
+  hasExportLogButton = true,
+}: Props) {
+  useEffect(() => {
+    if (error instanceof BluetoothRequired) {
+      NativeModules.BluetoothHelperModule.prompt();
+    }
+  }, [error]);
+
   const onExport = useExportLogs();
 
   const titleError = outerError || error;
@@ -79,7 +91,7 @@ const GenericErrorView = ({
       ) : null}
     </View>
   );
-};
+}
 
 const styles = StyleSheet.create({
   root: {
@@ -117,4 +129,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default GenericErrorView;
+export default memo<Props>(GenericErrorView);

--- a/src/components/RequiresBLE/BluetoothDisabled.js
+++ b/src/components/RequiresBLE/BluetoothDisabled.js
@@ -17,7 +17,7 @@ function BluetoothDisabled() {
   useEffect(() => {
     // Prompts the user to enable bluetooth using native api calls when the component gets initially rendered.
     NativeModules.BluetoothHelperModule.prompt();
-  });
+  }, []);
 
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.card }]}>

--- a/src/components/RequiresBLE/BluetoothDisabled.js
+++ b/src/components/RequiresBLE/BluetoothDisabled.js
@@ -1,7 +1,7 @@
 // @flow
 
-import React, { memo } from "react";
-import { View, StyleSheet, SafeAreaView } from "react-native";
+import React, { memo, useEffect } from "react";
+import { View, StyleSheet, SafeAreaView, NativeModules } from "react-native";
 import { Trans } from "react-i18next";
 import Icon from "react-native-vector-icons/dist/Feather";
 import { useTheme } from "@react-navigation/native";
@@ -13,6 +13,12 @@ import { deviceNames } from "../../wording";
 
 function BluetoothDisabled() {
   const { colors } = useTheme();
+
+  useEffect(() => {
+    // Prompts the user to enable bluetooth using native api calls when the component gets initially rendered.
+    NativeModules.BluetoothHelperModule.prompt();
+  });
+
   return (
     <SafeAreaView style={[styles.container, { backgroundColor: colors.card }]}>
       <InfoIcon

--- a/src/components/RequiresBLE/BluetoothDisabled.js
+++ b/src/components/RequiresBLE/BluetoothDisabled.js
@@ -16,7 +16,9 @@ function BluetoothDisabled() {
 
   useEffect(() => {
     // Prompts the user to enable bluetooth using native api calls when the component gets initially rendered.
-    NativeModules.BluetoothHelperModule.prompt();
+    NativeModules.BluetoothHelperModule.prompt().catch(() => {
+      /* ignore */
+    });
   }, []);
 
   return (

--- a/src/components/SelectDevice/index.js
+++ b/src/components/SelectDevice/index.js
@@ -1,6 +1,6 @@
 // @flow
 import React, { useCallback, useEffect, useState } from "react";
-import { StyleSheet, View, Platform } from "react-native";
+import { StyleSheet, View, Platform, NativeModules } from "react-native";
 import Config from "react-native-config";
 import { useSelector, useDispatch } from "react-redux";
 import { Trans } from "react-i18next";
@@ -63,9 +63,11 @@ export default function SelectDevice({
   const [devices, setDevices] = useState([]);
 
   const onPairNewDevice = useCallback(() => {
-    navigation.navigate(ScreenName.PairDevices, {
-      onDone: autoSelectOnAdd ? handleOnSelect : null,
-    });
+    NativeModules.BluetoothHelperModule.prompt().then(() =>
+      navigation.navigate(ScreenName.PairDevices, {
+        onDone: autoSelectOnAdd ? handleOnSelect : null,
+      }),
+    );
   }, [autoSelectOnAdd, navigation, handleOnSelect]);
 
   const renderItem = useCallback(

--- a/src/components/SelectDevice/index.js
+++ b/src/components/SelectDevice/index.js
@@ -63,11 +63,15 @@ export default function SelectDevice({
   const [devices, setDevices] = useState([]);
 
   const onPairNewDevice = useCallback(() => {
-    NativeModules.BluetoothHelperModule.prompt().then(() =>
-      navigation.navigate(ScreenName.PairDevices, {
-        onDone: autoSelectOnAdd ? handleOnSelect : null,
-      }),
-    );
+    NativeModules.BluetoothHelperModule.prompt()
+      .then(() =>
+        navigation.navigate(ScreenName.PairDevices, {
+          onDone: autoSelectOnAdd ? handleOnSelect : null,
+        }),
+      )
+      .catch(() => {
+        /* ignore */
+      });
   }, [autoSelectOnAdd, navigation, handleOnSelect]);
 
   const renderItem = useCallback(


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

copy of #1819
**Should prompt the user to activate bluetooth when needed.**

In order to do that, this PR adds one native module arbitrarily named `BluetoothHelperModule` that leverages native api calls both on Android and IOS but with a slightly different behaviour:

-  On IOS, prompts the user to go to their settings panel to activate/allow connections using [CBCentralManager](https://developer.apple.com/documentation/corebluetooth/cbcentralmanager/central_manager_initialization_options?language=objc).
- On Android, prompts the user to enable blutooth on-site using [BluetoothAdapter](https://developer.android.com/reference/android/bluetooth/BluetoothAdapter#ACTION_REQUEST_ENABLE).

Below some recordings: 🎥 

<details>
  <summary>Android</summary>
  <image src="https://user-images.githubusercontent.com/86958797/125453317-1f2d3bfb-3922-4200-9dd2-17486157f2a2.gif" alt="android_gif" width=300/>
</details>

<details>
  <summary>Iphone</summary>
  
![ios_bluetooth_prompt](https://user-images.githubusercontent.com/86958797/125453667-1ad1ed5d-68d7-4ef7-b18d-93c2a2bc8a28.gif)

</details>

### Type

Feature

### Context

[LL-5867]

### Parts of the app affected / Test plan

Go to Manager -> Try to set up / connect a new device with bluetooth disabled


[LL-5867]: https://ledgerhq.atlassian.net/browse/LL-5867