### PR TITLE
LL-8974 bypass import.meta from polkadot new bump

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -6,6 +6,7 @@
  */
 
 const defaultSourceExts = require('metro-config/src/defaults/defaults').sourceExts
+const resolve = require("metro-resolver").resolve
 
 module.exports = {
   transformer: {
@@ -18,5 +19,28 @@ module.exports = {
   },
   resolver: {
     sourceExts: [...defaultSourceExts, 'cjs'],
+    resolveRequest: (context, realModuleName, platform, moduleName) => {
+      const { resolveRequest: removed, ...restContext} = context;
+
+      let module = realModuleName;
+      // When resolveRequest exist, ripple-lib doesn't seems to be able to find ws.
+      if (moduleName === 'ws') {
+        return {
+          type: 'sourceFile',
+          filePath: `${__dirname}/node_modules/ws/browser.js`
+        }
+      }
+
+      // Patch for polkadot, because inside of packageInfo.js they used
+      // import.meta that is still not avaible
+      if (
+        context.originModulePath.includes("@polkadot") &&
+        moduleName === "./packageInfo.js"
+      ) {
+        module = module.replace(".js", ".cjs");
+      }
+
+      return resolve(restContext, module, platform);
+    },
   }
 };


### PR DESCRIPTION
### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-8974

related to :
https://github.com/LedgerHQ/ledger-live-common/pull/1635

### Parts of the app affected / Test plan

Polkadot implents experimental feature in his new bump.
A workaround from @jelbaz-ledger (Thank you !) was to resolve with the `.cjs` and not the `.js` which got the import, it's seems to work that way but I'm afraid that for the next bump we will need to patch something else again.

Warning :  one weird thing is that ripple-lib when the resolve request was defined was not able to resolve ws, even though it exist in `/node_modules`. I have no idea why

