### PR TITLE
LL-9063 Replacing discover tab by settings tab on apple products

### DIFF
--- a/src/components/RootNavigator/MainNavigator.js
+++ b/src/components/RootNavigator/MainNavigator.js
@@ -1,5 +1,6 @@
 // @flow
 import React from "react";
+import { Platform } from "react-native";
 import { useTheme } from "@react-navigation/native";
 import { ScreenName, NavigatorName } from "../../const";
 import Portfolio, { PortfolioTabIcon } from "../../screens/Portfolio";
@@ -7,9 +8,11 @@ import Transfer, { TransferTabIcon } from "../../screens/Transfer";
 import AccountsNavigator from "./AccountsNavigator";
 import ManagerNavigator, { ManagerTabIcon } from "./ManagerNavigator";
 import PlatformNavigator from "./PlatformNavigator";
+import SettingsNavigator from "./SettingsNavigator";
 import TabIcon from "../TabIcon";
 import AccountsIcon from "../../icons/Accounts";
 import AppsIcon from "../../icons/Apps";
+import SettingsIcon from "../../icons/Settings";
 
 import Tab from "./CustomBlockRouterNavigator";
 
@@ -64,17 +67,19 @@ export default function MainNavigator({
           tabBarIcon: (props: any) => <TransferTabIcon {...props} />,
         }}
       />
-      <Tab.Screen
-        name={NavigatorName.Platform}
-        component={PlatformNavigator}
-        options={{
-          headerShown: false,
-          unmountOnBlur: true,
-          tabBarIcon: (props: any) => (
-            <TabIcon Icon={AppsIcon} i18nKey="tabs.platform" {...props} />
-          ),
-        }}
-      />
+      {Platform.OS === "android" ? (
+        <Tab.Screen
+          name={NavigatorName.Platform}
+          component={PlatformNavigator}
+          options={{
+            headerShown: false,
+            unmountOnBlur: true,
+            tabBarIcon: (props: any) => (
+              <TabIcon Icon={AppsIcon} i18nKey="tabs.platform" {...props} />
+            ),
+          }}
+        />
+      ) : null}
       <Tab.Screen
         name={NavigatorName.Manager}
         component={ManagerNavigator}
@@ -99,6 +104,19 @@ export default function MainNavigator({
           },
         })}
       />
+      {Platform.OS === "ios" ? (
+        <Tab.Screen
+          name={NavigatorName.Settings}
+          component={SettingsNavigator}
+          options={{
+            headerShown: false,
+            unmountOnBlur: true,
+            tabBarIcon: (props: any) => (
+              <TabIcon Icon={SettingsIcon} i18nKey="tabs.settings" {...props} />
+            ),
+          }}
+        />
+      ) : null}
     </Tab.Navigator>
   );
 }


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Hot fix

### Context

https://ledgerhq.atlassian.net/browse/LL-9063

### Parts of the app affected / Test plan

On IOS, navigation should now be:

PORTFOLIO - ACCOUNTS - TRANSFERS - MANAGER - SETTINGS

Android should stay as is:

PORTFOLIO - ACCOUNTS - TRANSFERS - DISCOVER - MANAGER

