### PR TITLE
remove requirement of latest FW version when swapping

### DIFF
--- a/src/screens/Swap/Confirmation.js
+++ b/src/screens/Swap/Confirmation.js
@@ -185,7 +185,6 @@ const Confirmation = ({
                   exchangeRate: rate,
                   transaction,
                   userId: providerKYC?.id,
-                  requireLatestFirmware: true,
                 }}
                 onResult={({ initSwapResult, initSwapError }) => {
                   if (initSwapError) {


### PR DESCRIPTION
Currently, users without an old firmware version are not able to do a swap because the swap requires the latest firmware version.
This creates problems:
- for every new FW version, swappers a forced to update their FW
- even if the stack is still operational, Live forces the user to upgrade FW despite having a stack that does work. 
- pushes down addressable swap userbase to 0 the moment there is a new FW version

This PR simply removes the requirement for swap by deleting the line that creates such constrain as per https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/3518464073/SWAP-FW-UPDATE+-+Problem+intro

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Feature

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/3518693389/SWAP-FW-UPDATE+-+New+firmware+drops+swappable+audience+to+0

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
- SWAP
- e2e test on latest firmware only. if possible outdated firmware n-1
