### PR TITLE
LL-7745 keyboard now opens automatically on password confirmation

### DIFF
--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,0 +1,152 @@
+import React, { useEffect, useState, useCallback, useRef } from "react";
+import { View, StyleSheet, TextInput } from "react-native";
+import Icon from "react-native-vector-icons/dist/Feather";
+import Touchable from "./Touchable";
+import { getFontStyle } from "./LText";
+import { withTheme } from "../colors";
+
+type Props = {
+  secureTextEntry: boolean;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  toggleSecureTextEntry: () => void;
+  placeholder: string;
+  autoFocus?: boolean;
+  inline?: boolean;
+  onFocus?: any;
+  onBlur?: any;
+  error?: Error;
+  password?: string;
+  colors: any;
+};
+
+const PasswordInput = ({
+  autoFocus,
+  error,
+  secureTextEntry,
+  onChange,
+  onSubmit,
+  onFocus,
+  onBlur,
+  toggleSecureTextEntry,
+  placeholder,
+  inline,
+  password,
+  colors,
+}: Props) => {
+  const [isFocused, setIsFocused] = useState(false);
+  const ref = useRef();
+
+  useEffect(() => {
+    if (autoFocus && !isFocused) {
+      ref.current?.focus();
+    }
+  }, [autoFocus, isFocused]);
+
+  const wrappedOnFocus = useCallback(() => {
+    setIsFocused(true);
+    onFocus && onFocus();
+  }, [onFocus]);
+
+  const wrappedOnBlur = useCallback(() => {
+    setIsFocused(false);
+    onBlur && onBlur();
+  }, [onBlur]);
+
+  let borderColorOverride = {};
+  if (!inline && isFocused) {
+    if (error) {
+      borderColorOverride = { borderColor: colors.alert };
+    } else {
+      borderColorOverride = { borderColor: colors.live };
+    }
+  }
+
+  return (
+    <View
+      style={[
+        styles.container,
+        !inline && {
+          ...styles.nonInlineContainer,
+          backgroundColor: colors.card,
+          borderColor: colors.lightFog,
+        },
+        borderColorOverride,
+      ]}
+    >
+      <TextInput
+        allowFontScaling={false}
+        autoFocus={autoFocus}
+        ref={ref}
+        style={[
+          styles.input,
+          getFontStyle({ semiBold: true }),
+          inline && styles.inlineTextInput,
+          { color: colors.darkBlue },
+        ]}
+        placeholder={placeholder}
+        placeholderTextColor={error ? colors.alert : colors.fog}
+        returnKeyType="done"
+        blurOnSubmit={false}
+        onChangeText={onChange}
+        onSubmitEditing={onSubmit}
+        secureTextEntry={secureTextEntry}
+        textContentType="password"
+        autoCorrect={false}
+        onFocus={wrappedOnFocus}
+        onBlur={wrappedOnBlur}
+        value={password}
+      />
+      {secureTextEntry ? (
+        <Touchable
+          event="PasswordInputToggleUnsecure"
+          style={styles.iconInput}
+          onPress={toggleSecureTextEntry}
+        >
+          <Icon
+            name="eye"
+            size={16}
+            color={inline ? colors.grey : colors.fog}
+          />
+        </Touchable>
+      ) : (
+        <Touchable
+          event="PasswordInputToggleSecure"
+          style={styles.iconInput}
+          onPress={toggleSecureTextEntry}
+        >
+          <Icon
+            name="eye-off"
+            size={16}
+            color={inline ? colors.grey : colors.fog}
+          />
+        </Touchable>
+      )}
+    </View>
+  );
+};
+
+export default withTheme(PasswordInput);
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: "row",
+    borderRadius: 4,
+    marginBottom: 16,
+  },
+  nonInlineContainer: {
+    borderWidth: 1,
+  },
+  inlineTextInput: {
+    fontSize: 20,
+  },
+  input: {
+    fontSize: 16,
+    paddingHorizontal: 16,
+    height: 48,
+    flex: 1,
+  },
+  iconInput: {
+    justifyContent: "center",
+    marginRight: 16,
+  },
+});


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

[LL-4045]

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Bug Fix : Previously, the keyboard didn't opened correctly on some android phones when confirming password, it is now fixed

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->


### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
There actually wasn't a lot of changes in the code, I copied the js file in a tsx file (which is the reason so many changes appeared) but only the lines 41 to 43 changed (I added a check to not toggle the keyboard when already opened)


[LL-4045]: https://ledgerhq.atlassian.net/browse/LL-4045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ