### PR TITLE
[LL-7025] - Language discoverability fixes

### DIFF
--- a/src/components/CheckLanguageAvailability.js
+++ b/src/components/CheckLanguageAvailability.js
@@ -52,7 +52,7 @@ export default function CheckLanguageAvailability() {
       <Track
         onMount
         event={`Discoverability - Prompt - ${defaultLanguage}`}
-        eventProperties={defaultLanguage}
+        eventProperties={{ language: defaultLanguage }}
       />
       <BottomModal
         id="CheckLanguageAvailabilityModal"

--- a/src/components/CheckLanguageAvailability.js
+++ b/src/components/CheckLanguageAvailability.js
@@ -1,12 +1,10 @@
 // @flow
 
 import React, { useState, useCallback } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Trans, useTranslation } from "react-i18next";
 import { View } from "react-native";
-import Locale from "react-native-locale";
 import { useTheme } from "@react-navigation/native";
-import i18next from "i18next";
 
 import BottomModal from "./BottomModal";
 import Button from "./Button";
@@ -14,7 +12,8 @@ import Circle from "./Circle";
 import ModalBottomAction from "./ModalBottomAction";
 import LanguageIcon from "../icons/Language";
 import { languageSelector } from "../reducers/settings";
-import { pushedLanguages } from "../languages";
+import { setLanguage } from "../actions/settings";
+import { getDefaultLanguageLocale } from "../languages";
 import { useLanguageAvailableChecked } from "../context/Locale";
 import { Track } from "../analytics";
 
@@ -22,8 +21,8 @@ export default function CheckLanguageAvailability() {
   const { t } = useTranslation();
   const { colors } = useTheme();
   const [modalOpened, setModalOpened] = useState(true);
-  const { localeIdentifier } = Locale.constants();
-  const osLanguage = localeIdentifier.split("_")[0];
+  const dispatch = useDispatch();
+  const defaultLanguage = getDefaultLanguageLocale();
   const currAppLanguage = useSelector(languageSelector);
   const [hasAnswered, answer] = useLanguageAvailableChecked();
 
@@ -31,23 +30,19 @@ export default function CheckLanguageAvailability() {
     setModalOpened(false);
   }, [setModalOpened]);
 
-  const dontSwitchLanguage = useCallback(() => {
+  const handleDismissPressed = useCallback(() => {
     answer();
     onRequestClose();
   }, [answer, onRequestClose]);
 
-  const switchLanguage = useCallback(() => {
-    i18next.changeLanguage(osLanguage);
+  const handleChangeLanguagePressed = useCallback(() => {
+    dispatch(setLanguage(defaultLanguage));
     answer();
     onRequestClose();
-  }, [osLanguage, answer, onRequestClose]);
+  }, [dispatch, defaultLanguage, answer, onRequestClose]);
 
   const toShow =
-    modalOpened &&
-    !hasAnswered &&
-    currAppLanguage !== osLanguage &&
-    pushedLanguages.includes(osLanguage);
-
+    modalOpened && !hasAnswered && currAppLanguage !== defaultLanguage;
   if (!toShow) {
     return null;
   }
@@ -56,8 +51,8 @@ export default function CheckLanguageAvailability() {
     <>
       <Track
         onMount
-        event={`Discoverability - Prompt - ${osLanguage}`}
-        eventProperties={osLanguage}
+        event={`Discoverability - Prompt - ${defaultLanguage}`}
+        eventProperties={defaultLanguage}
       />
       <BottomModal
         id="CheckLanguageAvailabilityModal"
@@ -75,7 +70,9 @@ export default function CheckLanguageAvailability() {
             <Trans
               i18nKey="systemLanguageAvailable.description.newSupport"
               values={{
-                language: t(`systemLanguageAvailable.languages.${osLanguage}`),
+                language: t(
+                  `systemLanguageAvailable.languages.${defaultLanguage}`,
+                ),
               }}
             />
           }
@@ -83,29 +80,29 @@ export default function CheckLanguageAvailability() {
             <View>
               <Button
                 type="primary"
-                event={`Discoverability - Switch - ${osLanguage}`}
-                eventProperties={{ language: osLanguage }}
+                event={`Discoverability - Switch - ${defaultLanguage}`}
+                eventProperties={{ language: defaultLanguage }}
                 title={
                   <>
                     <Trans
                       i18nKey="systemLanguageAvailable.switchButton"
                       values={{
                         language: t(
-                          `systemLanguageAvailable.languages.${osLanguage}`,
+                          `systemLanguageAvailable.languages.${defaultLanguage}`,
                         ),
                       }}
                     />
                   </>
                 }
-                onPress={switchLanguage}
+                onPress={handleChangeLanguagePressed}
               />
               <Button
                 type="secondary"
                 outline={false}
-                event={`Discoverability - Denied - ${osLanguage}`}
-                eventProperties={{ language: osLanguage }}
+                event={`Discoverability - Denied - ${defaultLanguage}`}
+                eventProperties={{ language: defaultLanguage }}
                 title={<Trans i18nKey="systemLanguageAvailable.no" />}
-                onPress={dontSwitchLanguage}
+                onPress={handleDismissPressed}
               />
             </View>
           }

--- a/src/languages.js
+++ b/src/languages.js
@@ -28,10 +28,25 @@ export const languages = {
 export const DEFAULT_LANGUAGE_LOCALE = "en";
 
 export const localeIds: string[] = Object.keys(allLocales);
-export const pushedLanguages = ["fr", "ru"];
+
+/**
+ * This is the list of languages that are supported in terms of in-app translations
+ * and it is meant to appear in the settings.
+ */
 export const supportedLocales = Config.LEDGER_DEBUG_ALL_LANGS
   ? localeIds
   : ["en", "fr", "es", "ru", "zh", "de", "tr", "ja", "ko"];
+
+/**
+ * This is the list of languages that are supported in terms of in-app translations
+ * (so it is a subset of `supportedLocales`)
+ * AND supported in terms of external resources (i.e. customer support, articles etc.)
+ * These languages will be used by default for new users if it's their system language
+ * or in the case of existing users, they will be prompted once to change their
+ * Ledger Live language.
+ */
+export const fullySupportedLocales = ["en", "fr", "ru"];
+
 export const locales = supportedLocales.reduce((obj, key) => {
   obj[key] = allLocales[key]; // eslint-disable-line no-param-reassign
   return obj;
@@ -46,7 +61,7 @@ export const getDefaultLanguageLocale = (
   const matches = locale.match(/([a-z]{2,4}[-_]([A-Z]{2,4}|[0-9]{3}))/);
   const lang = (matches && matches[1].replace("_", "-")) || "en-US";
   return (
-    Object.keys(locales).find(locale => lang.startsWith(locale)) ||
+    fullySupportedLocales.find(locale => lang.startsWith(locale)) ||
     fallbackLocale
   );
 };

--- a/src/screens/Portfolio/index.js
+++ b/src/screens/Portfolio/index.js
@@ -184,8 +184,8 @@ export default function PortfolioScreen({ navigation }: Props) {
           />
         ) : null}
 
-      <RequireTerms />
-      <CheckLanguageAvailability />
+        <RequireTerms />
+        <CheckLanguageAvailability />
 
         <TrackScreen category="Portfolio" accountsLength={accounts.length} />
 


### PR DESCRIPTION
- Fix "discoverability for new users" -> the list of languages that can be applied by default (depending on the language of the OS) is **now restricted to English, Russian and French**, as opposed to "all supported languages". This was a blurry part of the spec, now clarified w/ @ahadwan-ledger. The reason is a dependency on available languages in external resources (articles, customer support etc.)
- Fix "discoverability for existing users" -> if the user selected the language, **the language was applied but not saved** for later runs of the app. This bug was due to a change in the logic for setting the app's language. I missed this part in my previous PR on this topic.

### Context

[LL-7025]

### Parts of the app affected / Test plan

- Discoverability for new users (fully supported languages):
    1. Uninstall LL
    2. Switch OS language to french or russian (fully supported languages)
    3. Install LL, launch it
    4. LL should be in the system's language
- Discoverability for new users (not fully supported languages):
    1. Uninstall LL
    2. Switch OS language to a language not fully supported (german for instance)
    3. Install LL, launch it
    4. LL should still be in the english

- Discoverability for existing users
   1. Uninstall LL
   2. Switch OS language to english
   3. Install LL, launch it, go through onboarding
   4. Quit LL, switch OS language to french or russian (resp. a not fully supported language like German)
   5. Launch LL
   6. LL should prompt a dialogue asking the user to switch the language to the OS language (resp. if OS language is not a fully supported language, nothing should happen)





[LL-7025]: https://ledgerhq.atlassian.net/browse/LL-7025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ