### PR TITLE
LL-9026 LL-8839 Fix NFT Send fractional quantity and set properties title to bold

### DIFF
--- a/src/components/Nft/NftViewer.js
+++ b/src/components/Nft/NftViewer.js
@@ -225,7 +225,7 @@ const NftViewer = ({ route }: Props) => {
         {properties && (
           <>
             <View style={styles.propertiesContainer}>
-              <LText style={styles.sectionTitle}>
+              <LText style={styles.sectionTitle} semiBold>
                 {t("nft.viewer.properties")}
               </LText>
             </View>

--- a/src/screens/SendFunds/03b-AmountNft.js
+++ b/src/screens/SendFunds/03b-AmountNft.js
@@ -131,7 +131,7 @@ export default function SendAmountNFT({ route }: Props) {
               editable={true}
               multiline={false}
               keyboardType="numeric"
-              value={quantity}
+              value={quantity?.toString()}
               onChangeText={onQuantityChange}
               placeholder="0"
             />


### PR DESCRIPTION
The user is not allowed anymore to use dots when choosing a quantity, the number is automatically converted to integer.
The properties section title is now bold.

https://user-images.githubusercontent.com/6013294/151174888-fff33928-525b-4d80-a82b-c509b4c11280.mp4


### Type
Bug Fix, UI Polish

### Context
[LL-9026] - Quantity Bug
[LL-8839] - Properties title
### Parts of the app affected / Test plan
NFT Viewer and NFT Send


[LL-9026]: https://ledgerhq.atlassian.net/browse/LL-9026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LL-8839]: https://ledgerhq.atlassian.net/browse/LL-8839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ