### PR TITLE
LL-9182: reduce data store in dbs (proposal)

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -355,7 +355,7 @@ PODS:
   - RNAnalytics (1.5.0):
     - Analytics
     - React-Core
-  - RNCAsyncStorage (1.12.1):
+  - RNCAsyncStorage (1.15.17):
     - React-Core
   - RNCClipboard (1.5.1):
     - React-Core
@@ -494,7 +494,7 @@ DEPENDENCIES:
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - "ReactNativeART (from `../node_modules/@react-native-community/art`)"
   - "RNAnalytics (from `../node_modules/@segment/analytics-react-native`)"
-  - "RNCAsyncStorage (from `../node_modules/@react-native-community/async-storage`)"
+  - "RNCAsyncStorage (from `../node_modules/@react-native-async-storage/async-storage`)"
   - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
   - "RNCMaskedView (from `../node_modules/@react-native-community/masked-view`)"
   - RNFastImage (from `../node_modules/react-native-fast-image`)
@@ -643,7 +643,7 @@ EXTERNAL SOURCES:
   RNAnalytics:
     :path: "../node_modules/@segment/analytics-react-native"
   RNCAsyncStorage:
-    :path: "../node_modules/@react-native-community/async-storage"
+    :path: "../node_modules/@react-native-async-storage/async-storage"
   RNCClipboard:
     :path: "../node_modules/@react-native-community/clipboard"
   RNCMaskedView:
@@ -741,7 +741,7 @@ SPEC CHECKSUMS:
   ReactCommon: eafed38eec7b591c31751bfa7494801618460459
   ReactNativeART: 78edc68dd4a1e675338cd0cd113319cf3a65f2ab
   RNAnalytics: a6dc48511d5d99b1ecaaf7157d8b5c618d15337e
-  RNCAsyncStorage: b03032fdbdb725bea0bd9e5ec5a7272865ae7398
+  RNCAsyncStorage: 6bd5a7ba3dde1c3facba418aa273f449bdc5437a
   RNCClipboard: 41d8d918092ae8e676f18adada19104fa3e68495
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNFastImage: 1f2cab428712a4baaf78d6169eaec7f622556dd7

--- a/package.json
+++ b/package.json
@@ -182,8 +182,7 @@
     "tty-browserify": "0.0.1",
     "url": "^0.11.0",
     "uuid": "^8.3.2",
-    "vm-browserify": "1.1.2",
-    "zipson": "^0.2.12"
+    "vm-browserify": "1.1.2"
   },
   "devDependencies": {
     "@actions/core": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -73,8 +73,8 @@
     "@ledgerhq/react-native-ledger-core": "4.19.1",
     "@ledgerhq/react-native-passcode-auth": "^2.1.0",
     "@polkadot/reactnative-identicon": "0.87.5",
+    "@react-native-async-storage/async-storage": "^1.15.17",
     "@react-native-community/art": "^1.2.0",
-    "@react-native-community/async-storage": "^1.12.1",
     "@react-native-community/clipboard": "^1.5.1",
     "@react-native-community/masked-view": "^0.1.11",
     "@react-native-community/netinfo": "^6.0.1",
@@ -155,7 +155,6 @@
     "react-native-safe-area-view": "^1.1.1",
     "react-native-screens": "^3.9.0",
     "react-native-share": "^6.2.0",
-    "react-native-simple-store": "^2.0.2",
     "react-native-slider": "^0.11.0",
     "react-native-splash-screen": "3.2.0",
     "react-native-svg": "^12.1.1",
@@ -183,7 +182,8 @@
     "tty-browserify": "0.0.1",
     "url": "^0.11.0",
     "uuid": "^8.3.2",
-    "vm-browserify": "1.1.2"
+    "vm-browserify": "1.1.2",
+    "zipson": "^0.2.12"
   },
   "devDependencies": {
     "@actions/core": "^1.5.0",

--- a/src/bridge/cache.js
+++ b/src/bridge/cache.js
@@ -1,6 +1,6 @@
 // @flow
 
-import AsyncStorage from "@react-native-community/async-storage";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { makeBridgeCacheSystem } from "@ledgerhq/live-common/lib/bridge/cache";
 import { log } from "@ledgerhq/logs";
 import type { CryptoCurrency } from "@ledgerhq/live-common/lib/types";

--- a/src/context/Locale.js
+++ b/src/context/Locale.js
@@ -9,7 +9,7 @@ import React, {
 import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
 import type { TFunction } from "react-i18next";
-import AsyncStorage from "@react-native-community/async-storage";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useSelector } from "react-redux";
 import {
   DEFAULT_LANGUAGE_LOCALE,

--- a/src/db.js
+++ b/src/db.js
@@ -1,9 +1,9 @@
 // @flow
 import { log } from "@ledgerhq/logs";
-import store from "./logic/storeWrapper";
 import { atomicQueue } from "@ledgerhq/live-common/lib/promise";
 import type { AccountRaw } from "@ledgerhq/live-common/lib/types";
 import type { CounterValuesStateRaw } from "@ledgerhq/live-common/lib/countervalues/types";
+import store from "./logic/storeWrapper";
 
 const ACCOUNTS_KEY = "accounts";
 const ACCOUNTS_KEY_SORT = "accounts.sort";
@@ -84,18 +84,15 @@ async function unsafeSaveCountervalues(
 ): Promise<void> {
   if (!changed) return;
 
-
   const deletedKeys = (await getKeys(COUNTERVALUES_DB_PREFIX)).filter(
     k =>
       ![...pairIds, "status"].includes(k.replace(COUNTERVALUES_DB_PREFIX, "")),
   );
 
-
   const data = Object.entries(state).map(([key, val]) => [
     `${COUNTERVALUES_DB_PREFIX}${key}`,
     val,
   ]);
-  
 
   await store.save(data);
 
@@ -125,9 +122,8 @@ async function unsafeGetAccounts(): Promise<{ active: AccountRaw[] }> {
   await migrateAccountsIfNecessary();
 
   const keys = await store.keys();
-  // await store.delete(keys); 
+  // await store.delete(keys);
   const accountKeys = onlyAccountsKeys(keys);
-
 
   // if some account keys, we retrieve them and return
   if (accountKeys && accountKeys.length > 0) {

--- a/src/db.js
+++ b/src/db.js
@@ -122,7 +122,6 @@ async function unsafeGetAccounts(): Promise<{ active: AccountRaw[] }> {
   await migrateAccountsIfNecessary();
 
   const keys = await store.keys();
-  // await store.delete(keys);
   const accountKeys = onlyAccountsKeys(keys);
 
   // if some account keys, we retrieve them and return

--- a/src/db.js
+++ b/src/db.js
@@ -1,6 +1,6 @@
 // @flow
 import { log } from "@ledgerhq/logs";
-import store from "react-native-simple-store";
+import store from "./logic/storeWrapper";
 import { atomicQueue } from "@ledgerhq/live-common/lib/promise";
 import type { AccountRaw } from "@ledgerhq/live-common/lib/types";
 import type { CounterValuesStateRaw } from "@ledgerhq/live-common/lib/countervalues/types";
@@ -84,15 +84,18 @@ async function unsafeSaveCountervalues(
 ): Promise<void> {
   if (!changed) return;
 
+
   const deletedKeys = (await getKeys(COUNTERVALUES_DB_PREFIX)).filter(
     k =>
       ![...pairIds, "status"].includes(k.replace(COUNTERVALUES_DB_PREFIX, "")),
   );
 
+
   const data = Object.entries(state).map(([key, val]) => [
     `${COUNTERVALUES_DB_PREFIX}${key}`,
     val,
   ]);
+  
 
   await store.save(data);
 
@@ -122,7 +125,9 @@ async function unsafeGetAccounts(): Promise<{ active: AccountRaw[] }> {
   await migrateAccountsIfNecessary();
 
   const keys = await store.keys();
+  // await store.delete(keys); 
   const accountKeys = onlyAccountsKeys(keys);
+
 
   // if some account keys, we retrieve them and return
   if (accountKeys && accountKeys.length > 0) {

--- a/src/experimental.js
+++ b/src/experimental.js
@@ -1,7 +1,7 @@
 // @flow
 import { useState, useEffect } from "react";
 import Config from "react-native-config";
-import AsyncStorage from "@react-native-community/async-storage";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { concatMap } from "rxjs/operators";
 import {
   setEnvUnsafe,

--- a/src/logic/storeWrapper.js
+++ b/src/logic/storeWrapper.js
@@ -2,154 +2,151 @@
  * @overview A minimalistic wrapper around React Native's AsyncStorage.
  * @license MIT
  */
- import AsyncStorage from '@react-native-async-storage/async-storage';
- import { stringify, parse } from "zipson"
- import { merge } from 'lodash';
- 
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { stringify, parse } from "zipson";
+import { merge } from "lodash";
+
 const COMPRESSED_KEY = "_-_COMPRESSED";
 const CHUNK_SIZE = 1000000;
 
 const getChunks = (str, size) => {
-    const strLength = str.length;
-    const numChunks = Math.ceil(strLength / size);
-    const chunks = new Array(numChunks);
-  
-    let i = 0;
-    let o = 0;
-  
-    for (; i < numChunks; ++i, o += size) {
-      chunks[i] = str.substr(o, size);
+  const strLength = str.length;
+  const numChunks = Math.ceil(strLength / size);
+  const chunks = new Array(numChunks);
+
+  let i = 0;
+  let o = 0;
+
+  for (; i < numChunks; ++i, o += size) {
+    chunks[i] = str.substr(o, size);
+  }
+
+  return chunks;
+};
+
+const stringifyPairs = pairs =>
+  pairs.reduce((acc, current) => {
+    const key = current[0];
+    const data = JSON.stringify(current[1]);
+
+    if (data.length > CHUNK_SIZE) {
+      const chunks = getChunks(stringify(current[1]), CHUNK_SIZE);
+      const numberOfChunks = chunks.length;
+      return [
+        ...acc,
+        [current[0], COMPRESSED_KEY + numberOfChunks],
+        ...chunks.map((chunk, index) => [key + COMPRESSED_KEY + index, chunk]),
+      ];
     }
-  
-    return chunks;
-  }
-
-const stringifyPairs = (pairs) => {
-    return pairs.reduce((acc, current) => {
-        const key = current[0];
-        const data = JSON.stringify(current[1]);
-
-        if (data.length > CHUNK_SIZE) {
-            const chunks = getChunks(stringify(current[1]), CHUNK_SIZE);
-            const numberOfChunks = chunks.length;
-            return [...acc, [current[0], COMPRESSED_KEY + numberOfChunks], ...chunks.map((chunk, index) => [key + COMPRESSED_KEY + index, chunk])]
-        } else {
-            return [...acc, [key, data]]
-        }  
-    }, [])
-  }
+    return [...acc, [key, data]];
+  }, []);
 
 const getCompressedValue = async (key, value) => {
-      console.log({key});
-      if (value && value.includes(COMPRESSED_KEY)) {
-        const numberOfChunk = Number(value.replace(COMPRESSED_KEY, ""))
-        const keys = []
-        for (let i = 0; i < numberOfChunk; i++) {
-            keys.push(key + COMPRESSED_KEY + i)
-        }
-        const values = await AsyncStorage.multiGet(keys);
-        const concatString = values.reduce((acc, current) => {
-            return acc + current[1]
-        }, "")
-        return parse(concatString)
-      }
-      return JSON.parse(value)
+  if (value && value.includes(COMPRESSED_KEY)) {
+    const numberOfChunk = Number(value.replace(COMPRESSED_KEY, ""));
+    const keys = [];
+    for (let i = 0; i < numberOfChunk; i++) {
+      keys.push(key + COMPRESSED_KEY + i);
+    }
+    const values = await AsyncStorage.multiGet(keys);
+    const concatString = values.reduce((acc, current) => acc + current[1], "");
+    return parse(concatString);
   }
+  return JSON.parse(value);
+};
 
+const deviceStorage = {
+  /**
+   * Get a one or more value for a key or array of keys from AsyncStorage
+   * @param {String|Array} key A key or array of keys
+   * @return {Promise}
+   */
+  async get(key) {
+    if (!Array.isArray(key)) {
+      const value = await AsyncStorage.getItem(key);
+      return await getCompressedValue(key, value);
+    }
+    const values = await AsyncStorage.multiGet(key);
+    const data = values.map(value => getCompressedValue(value[0], value[1]));
+    return Promise.all(data);
+  },
 
- const deviceStorage = {
-     /**
-      * Get a one or more value for a key or array of keys from AsyncStorage
-      * @param {String|Array} key A key or array of keys
-      * @return {Promise}
-      */
-     async get(key) {
-         if(!Array.isArray(key)) {
-             const value = await AsyncStorage.getItem(key);
-             return await getCompressedValue(key, value);
-         } else {
-             const values = await AsyncStorage.multiGet(key);
-             const data = values.map(value => {
-                return getCompressedValue(value[0], value[1]);
-            });
-            return Promise.all(data);
-         }
-     },
- 
-     /**
-      * Save a key value pair or a series of key value pairs to AsyncStorage.
-      * @param  {String|Array} key The key or an array of key/value pairs
-      * @param  {Any} value The value to save
-      * @return {Promise}
-      */
-     save(key, value) {
-         let pairs = [];
-         if(!Array.isArray(key)) {
-             pairs.push([key, value]);
-         } else {
-            pairs = key.map(function(pair) {
-                 return [pair[0], pair[1]];
-             });
-         }
+  /**
+   * Save a key value pair or a series of key value pairs to AsyncStorage.
+   * @param  {String|Array} key The key or an array of key/value pairs
+   * @param  {Any} value The value to save
+   * @return {Promise}
+   */
+  save(key, value) {
+    let pairs = [];
+    if (!Array.isArray(key)) {
+      pairs.push([key, value]);
+    } else {
+      pairs = key.map(pair => [pair[0], pair[1]]);
+    }
 
-         console.log({pairs});
-         console.log(stringifyPairs(pairs))
+    return AsyncStorage.multiSet(stringifyPairs(pairs));
+  },
 
-         return AsyncStorage.multiSet(stringifyPairs(pairs));
-     },
- 
-     /**
-      * Updates the value in the store for a given key in AsyncStorage. If the value is a string it will be replaced. If the value is an object it will be deep merged.
-      * @param  {String} key The key
-      * @param  {Value} value The value to update with
-      * @return {Promise}
-      */
-     update(key, value) {
-         return deviceStorage.get(key).then(item => {
-             value = typeof value === 'string' ? value : merge({}, item, value);
-             return deviceStorage.save(key, value);
-         });
-     },
- 
-     /**
-      * Delete the value for a given key in AsyncStorage.
-      * @param  {String|Array} key The key or an array of keys to be deleted
-      * @return {Promise}
-      */
-     delete(key) {
-         if (Array.isArray(key)) {
-             return AsyncStorage.multiRemove(key);
-         } else {
-             return AsyncStorage.removeItem(key);
-         }
-     },
- 
-     /**
-      * Get all keys in AsyncStorage.
-      * @return {Promise} A promise which when it resolves gets passed the saved keys in AsyncStorage.
-      */
-     keys() {
-         return AsyncStorage.getAllKeys().then((keys) => keys.filter(key => !key.includes(COMPRESSED_KEY)));
-     },
- 
-     /**
-      * Push a value onto an array stored in AsyncStorage by key or create a new array in AsyncStorage for a key if it's not yet defined.
-      * @param {String} key They key
-      * @param {Any} value The value to push onto the array
-      * @return {Promise}
-      */
-     push(key, value) {
-         return deviceStorage.get(key).then((currentValue) => {
-             if (currentValue === null) {
-                 // if there is no current value populate it with the new value
-                 return deviceStorage.save(key, [value]);
-             }
-             if (Array.isArray(currentValue)) {
-                 return deviceStorage.save(key, [...currentValue, value]);
-             }
-             throw new Error(`Existing value for key "${key}" must be of type null or Array, received ${typeof currentValue}.`);
-         });
-     },
- };
- 
- module.exports = deviceStorage;
+  /**
+   * Updates the value in the store for a given key in AsyncStorage. If the value is a string it will be replaced. If the value is an object it will be deep merged.
+   * @param  {String} key The key
+   * @param  {Value} value The value to update with
+   * @return {Promise}
+   */
+  update(key, value) {
+    return deviceStorage
+      .get(key)
+      .then(item =>
+        deviceStorage.save(
+          key,
+          typeof value === "string" ? value : merge({}, item, value),
+        ),
+      );
+  },
+
+  /**
+   * Delete the value for a given key in AsyncStorage.
+   * @param  {String|Array} key The key or an array of keys to be deleted
+   * @return {Promise}
+   */
+  delete(key) {
+    if (Array.isArray(key)) {
+      return AsyncStorage.multiRemove(key);
+    }
+    return AsyncStorage.removeItem(key);
+  },
+
+  /**
+   * Get all keys in AsyncStorage.
+   * @return {Promise} A promise which when it resolves gets passed the saved keys in AsyncStorage.
+   */
+  keys() {
+    return AsyncStorage.getAllKeys().then(keys =>
+      keys.filter(key => !key.includes(COMPRESSED_KEY)),
+    );
+  },
+
+  /**
+   * Push a value onto an array stored in AsyncStorage by key or create a new array in AsyncStorage for a key if it's not yet defined.
+   * @param {String} key They key
+   * @param {Any} value The value to push onto the array
+   * @return {Promise}
+   */
+  push(key, value) {
+    return deviceStorage.get(key).then(currentValue => {
+      if (currentValue === null) {
+        // if there is no current value populate it with the new value
+        return deviceStorage.save(key, [value]);
+      }
+      if (Array.isArray(currentValue)) {
+        return deviceStorage.save(key, [...currentValue, value]);
+      }
+      throw new Error(
+        `Existing value for key "${key}" must be of type null or Array, received ${typeof currentValue}.`,
+      );
+    });
+  },
+};
+
+module.exports = deviceStorage;

--- a/src/logic/storeWrapper.js
+++ b/src/logic/storeWrapper.js
@@ -1,0 +1,155 @@
+/**
+ * @overview A minimalistic wrapper around React Native's AsyncStorage.
+ * @license MIT
+ */
+ import merge from 'lodash.merge';
+ import AsyncStorage from '@react-native-async-storage/async-storage';
+ import { stringify, parse } from "zipson"
+ 
+const COMPRESSED_KEY = "_-_COMPRESSED";
+const CHUNK_SIZE = 1000000;
+
+getChunks = (str, size) => {
+    const strLength = str.length;
+    const numChunks = Math.ceil(strLength / size);
+    const chunks = new Array(numChunks);
+  
+    let i = 0;
+    let o = 0;
+  
+    for (; i < numChunks; ++i, o += size) {
+      chunks[i] = str.substr(o, size);
+    }
+  
+    return chunks;
+  }
+
+stringifyPairs = (pairs) => {
+    return pairs.reduce((acc, current) => {
+        const key = current[0];
+        const data = JSON.stringify(current[1]);
+
+        if (data.length > CHUNK_SIZE) {
+            const chunks = getChunks(stringify(current[1]), CHUNK_SIZE);
+            const numberOfChunks = chunks.length;
+            return [...acc, [current[0], COMPRESSED_KEY + numberOfChunks], ...chunks.map((chunk, index) => [key + COMPRESSED_KEY + index, chunk])]
+        } else {
+            return [...acc, [key, data]]
+        }  
+    }, [])
+  }
+
+  getCompressedValue = async (key, value) => {
+      console.log({key});
+      if (value && value.includes(COMPRESSED_KEY)) {
+        const numberOfChunk = Number(value.replace(COMPRESSED_KEY, ""))
+        const keys = []
+        for (let i = 0; i < numberOfChunk; i++) {
+            keys.push(key + COMPRESSED_KEY + i)
+        }
+        const values = await AsyncStorage.multiGet(keys);
+        const concatString = values.reduce((acc, current) => {
+            return acc + current[1]
+        }, "")
+        return parse(concatString)
+      }
+      return JSON.parse(value)
+  }
+
+
+ const deviceStorage = {
+     /**
+      * Get a one or more value for a key or array of keys from AsyncStorage
+      * @param {String|Array} key A key or array of keys
+      * @return {Promise}
+      */
+     async get(key) {
+         if(!Array.isArray(key)) {
+             const value = await AsyncStorage.getItem(key);
+             return await getCompressedValue(key, value);
+         } else {
+             const values = await AsyncStorage.multiGet(key);
+             const data = values.map(value => {
+                return getCompressedValue(value[0], value[1]);
+            });
+            return Promise.all(data);
+         }
+     },
+ 
+     /**
+      * Save a key value pair or a series of key value pairs to AsyncStorage.
+      * @param  {String|Array} key The key or an array of key/value pairs
+      * @param  {Any} value The value to save
+      * @return {Promise}
+      */
+     save(key, value) {
+         let pairs = [];
+         if(!Array.isArray(key)) {
+             pairs.push([key, value]);
+         } else {
+            pairs = key.map(function(pair) {
+                 return [pair[0], pair[1]];
+             });
+         }
+
+         console.log({pairs});
+         console.log(stringifyPairs(pairs))
+
+         return AsyncStorage.multiSet(stringifyPairs(pairs));
+     },
+ 
+     /**
+      * Updates the value in the store for a given key in AsyncStorage. If the value is a string it will be replaced. If the value is an object it will be deep merged.
+      * @param  {String} key The key
+      * @param  {Value} value The value to update with
+      * @return {Promise}
+      */
+     update(key, value) {
+         return deviceStorage.get(key).then(item => {
+             value = typeof value === 'string' ? value : merge({}, item, value);
+             return deviceStorage.save(key, value);
+         });
+     },
+ 
+     /**
+      * Delete the value for a given key in AsyncStorage.
+      * @param  {String|Array} key The key or an array of keys to be deleted
+      * @return {Promise}
+      */
+     delete(key) {
+         if (Array.isArray(key)) {
+             return AsyncStorage.multiRemove(key);
+         } else {
+             return AsyncStorage.removeItem(key);
+         }
+     },
+ 
+     /**
+      * Get all keys in AsyncStorage.
+      * @return {Promise} A promise which when it resolves gets passed the saved keys in AsyncStorage.
+      */
+     keys() {
+         return AsyncStorage.getAllKeys().then((keys) => keys.filter(key => !key.includes(COMPRESSED_KEY)));
+     },
+ 
+     /**
+      * Push a value onto an array stored in AsyncStorage by key or create a new array in AsyncStorage for a key if it's not yet defined.
+      * @param {String} key They key
+      * @param {Any} value The value to push onto the array
+      * @return {Promise}
+      */
+     push(key, value) {
+         return deviceStorage.get(key).then((currentValue) => {
+             if (currentValue === null) {
+                 // if there is no current value populate it with the new value
+                 return deviceStorage.save(key, [value]);
+             }
+             if (Array.isArray(currentValue)) {
+                 return deviceStorage.save(key, [...currentValue, value]);
+             }
+             throw new Error(`Existing value for key "${key}" must be of type null or Array, received ${typeof currentValue}.`);
+         });
+     },
+ };
+ 
+ module.exports = deviceStorage;

--- a/src/logic/storeWrapper.js
+++ b/src/logic/storeWrapper.js
@@ -2,14 +2,14 @@
  * @overview A minimalistic wrapper around React Native's AsyncStorage.
  * @license MIT
  */
- import merge from 'lodash.merge';
  import AsyncStorage from '@react-native-async-storage/async-storage';
  import { stringify, parse } from "zipson"
+ import { merge } from 'lodash';
  
 const COMPRESSED_KEY = "_-_COMPRESSED";
 const CHUNK_SIZE = 1000000;
 
-getChunks = (str, size) => {
+const getChunks = (str, size) => {
     const strLength = str.length;
     const numChunks = Math.ceil(strLength / size);
     const chunks = new Array(numChunks);
@@ -24,7 +24,7 @@ getChunks = (str, size) => {
     return chunks;
   }
 
-stringifyPairs = (pairs) => {
+const stringifyPairs = (pairs) => {
     return pairs.reduce((acc, current) => {
         const key = current[0];
         const data = JSON.stringify(current[1]);
@@ -39,7 +39,7 @@ stringifyPairs = (pairs) => {
     }, [])
   }
 
-  getCompressedValue = async (key, value) => {
+const getCompressedValue = async (key, value) => {
       console.log({key});
       if (value && value.includes(COMPRESSED_KEY)) {
         const numberOfChunk = Number(value.replace(COMPRESSED_KEY, ""))

--- a/src/logic/storeWrapper.js
+++ b/src/logic/storeWrapper.js
@@ -64,7 +64,7 @@ const deviceStorage = {
   async get(key) {
     if (!Array.isArray(key)) {
       const value = await AsyncStorage.getItem(key);
-      return await getCompressedValue(key, value);
+      return getCompressedValue(key, value);
     }
     const values = await AsyncStorage.multiGet(key);
     const data = values.map(value => getCompressedValue(value[0], value[1]));

--- a/src/logic/storeWrapper.js
+++ b/src/logic/storeWrapper.js
@@ -31,7 +31,7 @@ const stringifyPairs = pairs =>
     const data = JSON.stringify(current[1]);
 
     if (data.length > CHUNK_SIZE) {
-      const chunks = getChunks(JSON.stringify(current[1]), CHUNK_SIZE);
+      const chunks = getChunks(data, CHUNK_SIZE);
       const numberOfChunks = chunks.length;
       return [
         ...acc,

--- a/src/logic/terms.js
+++ b/src/logic/terms.js
@@ -1,6 +1,6 @@
 // @flow
 import { useEffect, useState, useCallback } from "react";
-import AsyncStorage from "@react-native-community/async-storage";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export const url =
   "https://github.com/LedgerHQ/ledger-live-mobile/blob/master/TERMS.md";

--- a/yarn.lock
+++ b/yarn.lock
@@ -15340,8 +15340,3 @@ zcash-bitcore-lib@^0.13.20-rc3:
     elliptic "=3.0.3"
     inherits "=2.0.1"
     lodash "=3.10.1"
-
-zipson@^0.2.12:
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/zipson/-/zipson-0.2.12.tgz#501f92e93f1c602ff908ad2c1c602e72746ecebb"
-  integrity sha512-+u+fyZQXJUJDTf4NGCChW+LoWGqCrhwHAfvtCtcmE0e40KmQt4YSP4l3TOay1WjRNv+VfODgBD/vNwaSSGnDwA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2623,6 +2623,13 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@react-native-async-storage/async-storage@^1.15.17":
+  version "1.15.17"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.15.17.tgz#0dae263a52e476ffce871086f1fef5b8e44708eb"
+  integrity sha512-NQCFs47aFEch9kya/bqwdpvSdZaVRtzU7YB02L8VrmLSLpKgQH/1VwzFUBPcc1/JI1s3GU4yOLVrEbwxq+Fqcw==
+  dependencies:
+    merge-options "^3.0.4"
+
 "@react-native-community/art@^1.1.2", "@react-native-community/art@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/art/-/art-1.2.0.tgz#386d95393f6042d9006f9d4bc6063fb898794460"
@@ -2631,18 +2638,6 @@
     art "^0.10.3"
     invariant "^2.2.4"
     prop-types "^15.7.2"
-
-"@react-native-community/async-storage@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.3.3.tgz#fbcd09c68be0f91362c1bc5696802d8e281cf67d"
-  integrity sha512-mypRivxWCO3apTDWpbvc7owcz5gZH0mI60JWPJDW/Pibr3vk9T7TQPA44b8m43qc/o5cnSEJFZk6l/1T4QEM/Q==
-
-"@react-native-community/async-storage@^1.12.1":
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/async-storage/-/async-storage-1.12.1.tgz#25f821b4f6b13abe005ad67e47c6f1cee9f27b24"
-  integrity sha512-70WGaH3PKYASi4BThuEEKMkyAgE9k7VytBqmgPRx3MzJx9/MkspwqJGmn3QLCgHLIFUgF1pit2mWICbRJ3T3lg==
-  dependencies:
-    deep-assign "^3.0.0"
 
 "@react-native-community/cli-debugger-ui@^6.0.0-rc.0":
   version "6.0.0-rc.0"
@@ -5979,13 +5974,6 @@ dedent@^0.7.0:
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
   integrity sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=
 
-deep-assign@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/deep-assign/-/deep-assign-3.0.0.tgz#c8e4c4d401cba25550a2f0f486a2e75bc5f219a2"
-  integrity sha512-YX2i9XjJ7h5q/aQ/IM9PEwEnDqETAIYbggmdDB3HLTlSgo1CxPsj6pvhPG68rq6SVE0+p+6Ywsm5fTYNrYtBWw==
-  dependencies:
-    is-obj "^1.0.0"
-
 deep-equal@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -8503,11 +8491,6 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
-  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
-
 is-object@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.2.tgz#a56552e1c665c9e950b4a025461da87e72f86fcf"
@@ -9952,7 +9935,7 @@ lodash.isstring@^4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
   integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
-lodash.merge@4.6.2, lodash.merge@^4.6.2:
+lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
@@ -10339,6 +10322,13 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -12395,14 +12385,6 @@ react-native-share@^6.2.0:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-6.5.0.tgz#6e2ce73d03168fcade7b89cc1f9c4318089c2325"
   integrity sha512-T46Mn+ALx2Fg+2/ksWFtzxSYNl34Xe/PH8eabx6DsLuCTDxatyaUblmpzDBjTO4rIMuVuTGMtR4mzwKKZcB5ZA==
-
-react-native-simple-store@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/react-native-simple-store/-/react-native-simple-store-2.0.2.tgz#5ee6e07d1869f6a5dd32d092e9c522e6c28aa826"
-  integrity sha512-2+EOxAGb5mMAQ3PKNUoE/X+i4fbHF7kV7BdJE9EQ42zbWty+rVH/3J6eJCijDXuGxvEvcQxkOU7P/VeY6wPvig==
-  dependencies:
-    "@react-native-community/async-storage" "1.3.3"
-    lodash.merge "4.6.2"
 
 react-native-slider@^0.11.0:
   version "0.11.0"
@@ -15358,3 +15340,8 @@ zcash-bitcore-lib@^0.13.20-rc3:
     elliptic "=3.0.3"
     inherits "=2.0.1"
     lodash "=3.10.1"
+
+zipson@^0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/zipson/-/zipson-0.2.12.tgz#501f92e93f1c602ff908ad2c1c602e72746ecebb"
+  integrity sha512-+u+fyZQXJUJDTf4NGCChW+LoWGqCrhwHAfvtCtcmE0e40KmQt4YSP4l3TOay1WjRNv+VfODgBD/vNwaSSGnDwA==


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

BugFix + Improvement (probably)

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
https://ledgerhq.atlassian.net/browse/LL-9182

With the new BTC JS implementation we encounter a very large amount of data for a single account.
In Android we are not able to store more than 2 Mo per row dues to SQLite limitation.

> AsyncStorage for Android uses SQLite for storage backend. While it has its own size limits, Android system also have two known limits: total storage size and per-entry size limit.
Total storage size is capped at 6 MB by default. You can increase this size by specifying a new size using feature flag.
Per-entry is limited by a size of a WindowCursor, a buffer used to read data from SQLite. Currently it's size is around 2 MB. This means that the single item read at one time cannot be larger than 2 MB. There's no supported workaround from AsyncStorage. We suggest keeping your data lower than that, by chopping it down into many entries, instead of one massive entry. This is where multiGet and multiSet APIs can shine

https://react-native-async-storage.github.io/async-storage/docs/limits

So as they recommended I tried to compress JSON of large data and then split them into multiple part, not the sexiest way to fix it tho.
I'm up for any recommandation :)

EDIT: We remove compression because it cost a lot of time, we store bigger data raw.

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
Part that rely on device storage. A lot of part in the app :(

test to install this new version other another app having btc accounts with lots of tx
on a 2.36.x version probably
check if the app boots with no issue and the data is migrated correctly
after a sync of the accounts stop the app and relaunch it
the app should reboot correctly without issue

this should cover all cases of old phones having to migrate data, phones with already migrated accounts but not big enough to kill the db and the rest.
