### PR TITLE
[Celo integation] Add Account Balance Summary with available balance

### DIFF
--- a/src/families/celo/AccountBalanceSummaryFooter.js
+++ b/src/families/celo/AccountBalanceSummaryFooter.js
@@ -1,0 +1,103 @@
+// @flow
+
+import React, { useCallback, useState } from "react";
+import { ScrollView, StyleSheet } from "react-native";
+import { useTranslation } from "react-i18next";
+import { getCryptoCurrencyById } from "@ledgerhq/live-common/lib/currencies";
+import { getAccountUnit } from "@ledgerhq/live-common/lib/account/helpers";
+import { getCryptoCurrencyIcon } from "@ledgerhq/live-common/lib/reactNative";
+
+import type { Account } from "@ledgerhq/live-common/lib/types";
+
+import invariant from "invariant";
+import { useTheme } from "@react-navigation/native";
+import InfoModal from "../../modals/Info";
+import type { ModalInfo } from "../../modals/Info";
+import CurrencyUnitValue from "../../components/CurrencyUnitValue";
+import InfoItem from "../../components/BalanceSummaryInfoItem";
+
+type Props = {
+  account: Account,
+};
+
+type InfoName = "available";
+
+function AccountBalanceSummaryFooter({ account }: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const [infoName, setInfoName] = useState<InfoName | typeof undefined>();
+  const info = useInfo();
+
+  const { spendableBalance } = account;
+
+  const unit = getAccountUnit(account);
+
+  const onCloseModal = useCallback(() => {
+    setInfoName(undefined);
+  }, []);
+
+  const onPressInfoCreator = useCallback(
+    (infoName: InfoName) => () => setInfoName(infoName),
+    [],
+  );
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      style={[styles.root, { borderTopColor: colors.lightFog }]}
+    >
+      <InfoModal
+        isOpened={!!infoName}
+        onClose={onCloseModal}
+        data={infoName ? info[infoName] : []}
+      />
+
+      <InfoItem
+        title={t("account.availableBalance")}
+        onPress={onPressInfoCreator("available")}
+        value={
+          <CurrencyUnitValue
+            unit={unit}
+            value={spendableBalance}
+            disableRounding
+          />
+        }
+      />
+    </ScrollView>
+  );
+}
+
+export default function AccountBalanceFooter({ account }: Props) {
+  if (account.balance.lte(0)) return null;
+
+  return <AccountBalanceSummaryFooter account={account} />;
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    flexDirection: "row",
+    borderTopWidth: 1,
+
+    paddingTop: 16,
+    overflow: "visible",
+  },
+});
+
+function useInfo(): { [key: InfoName]: ModalInfo[] } {
+  const { t } = useTranslation();
+  const currency = getCryptoCurrencyById("celo");
+  const CeloIcon = getCryptoCurrencyIcon(currency);
+  invariant(CeloIcon, "Icon is expected");
+
+  return {
+    available: [
+      {
+        Icon: () => <CeloIcon color={currency.color} size={18} />,
+        title: t("celo.info.available.title"),
+        description: t("celo.info.available.description"),
+      },
+    ],
+  };
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -2975,6 +2975,14 @@
       }
     }
   },
+  "celo": {
+    "info": {
+      "available": {
+        "title": "CELO available",
+        "description": "This amount is disposable."
+      }
+    }
+  },
   "cosmos": {
     "info": {
       "available": {


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
This PR adds `Available balance` to account footer in Celo integration.

![Screenshot_20220203-102022](https://user-images.githubusercontent.com/1530318/152314783-142339a6-ec6c-47a2-b477-c3151e60dbd9.jpg)
![Screenshot_20220203-102027](https://user-images.githubusercontent.com/1530318/152314787-94b36eae-a336-482b-91e5-0352c1f79cf5.jpg)


### Type

Feature

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

Related PRs: 
https://github.com/LedgerHQ/ledger-live-common/pull/1536
https://github.com/LedgerHQ/ledger-live-desktop/pull/4513

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

To test:
1. Add a Celo account with some Celo on it
2. Navigate to Celo account details
3. Check that `Available balance` footer is there and that you can click on it. When clicked, it opens a modal

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
