### PR TITLE
LL-9186 Only display quantity in summary for ERC1155 NFTs

### DIFF
--- a/src/screens/SendFunds/SummaryNft.js
+++ b/src/screens/SendFunds/SummaryNft.js
@@ -40,9 +40,11 @@ const SummaryNft = ({ transaction }: Props) => {
           </LText>
         </View>
       </SummaryRow>
-      <SummaryRow title={t("send.summary.quantity")}>
-        <LText semiBold>{quantity?.toFixed()}</LText>
-      </SummaryRow>
+      {transaction?.mode === "erc1155.transfer" && (
+        <SummaryRow title={t("send.summary.quantity")}>
+          <LText semiBold>{quantity?.toFixed()}</LText>
+        </SummaryRow>
+      )}
     </>
   );
 };


### PR DESCRIPTION
When sending an NFT, we used to display the quantity sent in the summary for both ERC721 and ERC1155 NFTs. Now we're displaying it only for ERC1155 NFTs

https://user-images.githubusercontent.com/6013294/152381327-3170c030-d630-4ff2-83e7-0f84444d5fc5.mp4

### Type
UI Polish

### Context
[LL-9186]

### Parts of the app affected / Test plan
Display an NFT and click to send it, get up to the summary section of the flow.
Do the same for both ERC1155 and ERC721 NFTs, in the summary there should be a Quantity displayed for the ERC1155 NFT but not for the ERC721 NFT.


[LL-9186]: https://ledgerhq.atlassian.net/browse/LL-9186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ