### PR TITLE
LIVE-891 [+ LL-7931]Hide 'Keep your Nano X nearby' if wired

### DIFF
--- a/src/components/DeviceActionModal.js
+++ b/src/components/DeviceActionModal.js
@@ -59,9 +59,11 @@ export default function DeviceActionModal({
                   analyticsPropertyFlow={analyticsPropertyFlow}
                 />
               </View>
-              <InfoBox forceColor={{ text: colors.live }}>
-                {t("DeviceAction.stayInTheAppPlz")}
-              </InfoBox>
+              {!device.wired ? (
+                <InfoBox forceColor={{ text: colors.live }}>
+                  {t("DeviceAction.stayInTheAppPlz")}
+                </InfoBox>
+              ) : null}
             </View>
           }
         />

--- a/src/screens/Manager/index.js
+++ b/src/screens/Manager/index.js
@@ -182,7 +182,7 @@ class ChooseDevice extends Component<
           onBluetoothDeviceAction={this.onShowMenu}
         />
         <DeviceActionModal
-          onClose={this.onSelectDevice}
+          onClose={() => this.onSelectDevice()}
           device={device}
           onResult={this.onSelect}
           onModalHide={this.onModalHide}


### PR DESCRIPTION
### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LIVE-891

https://ledgerhq.atlassian.net/browse/LL-7931
>By pure chance we found LL-7931 and fixed it in the process. It was setting the device to the synthetic event (the back click) and then crashing the device action when the device passed was not a device anymore.

### Parts of the app affected / Test plan

### Wired case
- Launch LLM.
- Plug in a device (Android).
- Attempt to access the manager with that device.
- It is expected that the bottom modal does **not** show the blue banner.

### Wireless case
- Launch LLM.
- Attempt to access the manager with a paired wireless device.
- Is is expected that the bottom modal **does** show.