### PR TITLE
LL-9168 Unmount portfolio page on blur

### DIFF
--- a/src/components/RootNavigator/MainNavigator.js
+++ b/src/components/RootNavigator/MainNavigator.js
@@ -42,6 +42,7 @@ export default function MainNavigator({
         name={ScreenName.Portfolio}
         component={Portfolio}
         options={{
+          unmountOnBlur: true,
           tabBarIcon: (props: any) => <PortfolioTabIcon {...props} />,
         }}
       />


### PR DESCRIPTION
This PR adds a configuration for React Navigator on the portfolio page that makes it unmount the page component when we navigate to another page.

During investigations it was seen that the Portfolio page was being rerender at each sync even when it was not the current page. This was impacting the performance everywhere in the app. This PR prevents this behavior since the page gets unmounted.

Further investigations are needed to check if we can prevent the page from rerendering when it isn't necessary **even** if it's the current page.

### Type
Perfomance improvement

### Context
[LL-9168]

### Parts of the app affected / Test plan
Navigation between pages (from and to Portfolio page)


[LL-9168]: https://ledgerhq.atlassian.net/browse/LL-9168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ