### PR TITLE
LIVE-954 LIVE-978 LIVE-991 Fix "swap" & "buy" CTA navigation in MarketDetail

### DIFF
--- a/src/components/DiscreetModeButton.js
+++ b/src/components/DiscreetModeButton.js
@@ -19,9 +19,9 @@ export default function DiscreetModeButton() {
   return (
     <TouchableOpacity onPress={onPress} style={styles.root}>
       {discreetMode ? (
-        <EyeCrossed size={16} color={colors.grey} />
+        <EyeCrossed size={24} color={colors.grey} />
       ) : (
-        <Eye size={16} color={colors.grey} />
+        <Eye size={24} color={colors.grey} />
       )}
     </TouchableOpacity>
   );

--- a/src/components/RootNavigator/MainNavigator.js
+++ b/src/components/RootNavigator/MainNavigator.js
@@ -4,14 +4,12 @@ import { Platform } from "react-native";
 import { useTheme } from "@react-navigation/native";
 import { Icons } from "@ledgerhq/native-ui";
 import { ScreenName, NavigatorName } from "../../const";
-import Portfolio, { PortfolioTabIcon } from "../../screens/Portfolio";
+import Portfolio from "../../screens/Portfolio";
 import Transfer, { TransferTabIcon } from "../../screens/Transfer";
 import AccountsNavigator from "./AccountsNavigator";
 import ManagerNavigator, { ManagerTabIcon } from "./ManagerNavigator";
 import PlatformNavigator from "./PlatformNavigator";
 import TabIcon from "../TabIcon";
-import AccountsIcon from "../../icons/Accounts";
-import AppsIcon from "../../icons/Apps";
 import MarketNavigator from "./MarketNavigator";
 import Tab from "./CustomBlockRouterNavigator";
 
@@ -45,7 +43,13 @@ export default function MainNavigator({
         component={Portfolio}
         options={{
           unmountOnBlur: true,
-          tabBarIcon: (props: any) => <PortfolioTabIcon {...props} />,
+          tabBarIcon: (props: any) => (
+            <TabIcon
+              Icon={Icons.HouseMedium}
+              i18nKey="tabs.portfolio"
+              {...props}
+            />
+          ),
         }}
       />
       <Tab.Screen
@@ -57,7 +61,11 @@ export default function MainNavigator({
         options={{
           unmountOnBlur: true,
           tabBarIcon: (props: any) => (
-            <TabIcon Icon={AccountsIcon} i18nKey="tabs.accounts" {...props} />
+            <TabIcon
+              Icon={Icons.WalletMedium}
+              i18nKey="tabs.accounts"
+              {...props}
+            />
           ),
           tabBarTestID: "TabBarAccounts",
         }}
@@ -78,7 +86,11 @@ export default function MainNavigator({
             headerShown: false,
             unmountOnBlur: true,
             tabBarIcon: (props: any) => (
-              <TabIcon Icon={AppsIcon} i18nKey="tabs.platform" {...props} />
+              <TabIcon
+                Icon={Icons.ManagerMedium}
+                i18nKey="tabs.platform"
+                {...props}
+              />
             ),
           }}
         />

--- a/src/components/RootNavigator/ManagerNavigator.js
+++ b/src/components/RootNavigator/ManagerNavigator.js
@@ -13,8 +13,8 @@ import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import styles from "../../navigation/styles";
 import ReadOnlyTab from "../ReadOnlyTab";
 import ManagerIcon from "../../icons/Manager";
-import NanoXIcon from "../../icons/TabNanoX";
 import { useIsNavLocked } from "./CustomBlockRouterNavigator";
+import { Icons } from "@ledgerhq/native-ui";
 
 const ManagerIconWithUpate = ({
   color,
@@ -26,7 +26,7 @@ const ManagerIconWithUpate = ({
   const { colors } = useTheme();
   return (
     <View style={stylesLocal.iconWrapper}>
-      <ManagerIcon size={size} color={color} />
+      <Icons.NanoFoldedMedium size={size} color={color} />
       <View style={[stylesLocal.blueDot, { backgroundColor: colors.live }]} />
     </View>
   );
@@ -75,9 +75,11 @@ export function ManagerTabIcon(props: any) {
 
   const content = (
     <ReadOnlyTab
-      OnIcon={NanoXIcon}
+      OnIcon={Icons.NanoFoldedMedium}
       oni18nKey="tabs.nanoX"
-      OffIcon={hasAvailableUpdate ? ManagerIconWithUpate : ManagerIcon}
+      OffIcon={
+        hasAvailableUpdate ? ManagerIconWithUpate : Icons.NanoFoldedMedium
+      }
       offi18nKey="tabs.manager"
       {...props}
     />

--- a/src/components/TabIcon.js
+++ b/src/components/TabIcon.js
@@ -15,7 +15,7 @@ export default function TabIcon({ Icon, i18nKey, color, focused }: Props) {
   const { t } = useTranslation();
   return (
     <View style={styles.root}>
-      <Icon size={20} color={color} />
+      <Icon size={24} color={color} />
       <LText
         numberOfLines={1}
         semiBold={!focused}

--- a/src/screens/Market/MarketDetail/index.tsx
+++ b/src/screens/Market/MarketDetail/index.tsx
@@ -4,15 +4,9 @@
 /* eslint-disable import/no-unresolved */
 import React, { useMemo, useCallback, useState, useEffect } from "react";
 import { useTheme } from "styled-components/native";
-import {
-  Flex,
-  Text,
-  ScrollContainerHeader,
-  Icons,
-  Icon,
-} from "@ledgerhq/native-ui";
+import { Flex, Text, ScrollContainerHeader, Icons } from "@ledgerhq/native-ui";
 import { useDispatch, useSelector } from "react-redux";
-import { useTranslation, TFunction } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import {
   useMarketData,
   useSingleCoinMarketData,
@@ -185,19 +179,14 @@ export default function MarketDetail({
   */
 
   const navigateToSwap = useCallback(() => {
-    if (allAccounts && allAccounts.length === 1) {
-      navigation.navigate(NavigatorName.Swap, {
-        screen: ScreenName.Swap,
-      });
-    } else {
-      navigation.navigate(NavigatorName.AddAccounts, {
-        screen: ScreenName.AddAccountsSelectDevice,
-        params: {
-          currency: internalCurrency,
-        },
-      });
-    }
-  }, [navigation, internalCurrency, allAccounts]);
+    navigation.navigate(NavigatorName.Swap, {
+      screen: ScreenName.Swap,
+      params: {
+        defaultAccount:
+          allAccounts && allAccounts.length > 0 ? allAccounts[0] : undefined,
+      },
+    });
+  }, [navigation, allAccounts]);
 
   useEffect(() => {
     if (name) {

--- a/src/screens/Market/MarketDetail/index.tsx
+++ b/src/screens/Market/MarketDetail/index.tsx
@@ -183,7 +183,7 @@ export default function MarketDetail({
       screen: ScreenName.Swap,
       params: {
         defaultAccount:
-          allAccounts && allAccounts.length > 0 ? allAccounts[0] : undefined,
+          allAccounts?.length > 0 ? allAccounts[0] : undefined,
       },
     });
   }, [navigation, allAccounts]);

--- a/src/screens/Market/MarketDetail/index.tsx
+++ b/src/screens/Market/MarketDetail/index.tsx
@@ -182,8 +182,7 @@ export default function MarketDetail({
     navigation.navigate(NavigatorName.Swap, {
       screen: ScreenName.Swap,
       params: {
-        defaultAccount:
-          allAccounts?.length > 0 ? allAccounts[0] : undefined,
+        defaultAccount: allAccounts?.length > 0 ? allAccounts[0] : undefined,
       },
     });
   }, [navigation, allAccounts]);

--- a/src/screens/Market/MarketDetail/index.tsx
+++ b/src/screens/Market/MarketDetail/index.tsx
@@ -123,7 +123,9 @@ export default function MarketDetail({
     swapSelectableCurrenciesSelector(state),
   );
   const availableOnSwap =
-    internalCurrency && swapCurrencies.includes(internalCurrency.id);
+    internalCurrency &&
+    allAccounts?.length > 0 &&
+    swapCurrencies.includes(internalCurrency.id);
 
   const toggleStar = useCallback(() => {
     const action = isStarred ? removeStarredMarketCoins : addStarredMarketCoins;

--- a/src/screens/Market/MarketDetail/index.tsx
+++ b/src/screens/Market/MarketDetail/index.tsx
@@ -216,6 +216,7 @@ export default function MarketDetail({
                 size={32}
                 currency={internalCurrency}
                 color={undefined}
+                sizeRatio={0.9}
               />
             ) : (
               image && (

--- a/src/screens/Market/MarketDetail/index.tsx
+++ b/src/screens/Market/MarketDetail/index.tsx
@@ -145,25 +145,13 @@ export default function MarketDetail({
   >();
 
   const navigateToBuy = useCallback(() => {
-    if (allAccounts && allAccounts.length === 1) {
-      navigation.navigate(NavigatorName.ExchangeBuyFlow, {
-        screen: ScreenName.ExchangeConnectDevice,
-        params: {
-          mode: "buy",
-          currency: internalCurrency,
-          account: allAccounts[0],
-        },
-      });
-    } else {
-      navigation.navigate(NavigatorName.ExchangeBuyFlow, {
-        screen: ScreenName.ExchangeSelectAccount,
-        params: {
-          mode: "buy",
-          currency: internalCurrency,
-        },
-      });
-    }
-  }, [navigation, internalCurrency, allAccounts]);
+    navigation.navigate(NavigatorName.Exchange, {
+      screen: ScreenName.ExchangeBuy,
+      params: {
+        mode: "buy",
+      },
+    });
+  }, [navigation]);
 
   /** Disabled for now on demand of PO
   const renderAccountItem = useCallback(

--- a/src/screens/Portfolio/Header.js
+++ b/src/screens/Portfolio/Header.js
@@ -5,14 +5,12 @@ import { useSelector } from "react-redux";
 import { useNavigation, useTheme } from "@react-navigation/native";
 import { useGlobalSyncState } from "@ledgerhq/live-common/lib/bridge/react";
 import { useAnnouncements } from "@ledgerhq/live-common/lib/notifications/AnnouncementProvider";
+import { Icons } from "@ledgerhq/native-ui";
 import { isUpToDateSelector } from "../../reducers/accounts";
 import { networkErrorSelector } from "../../reducers/appstate";
 import HeaderErrorTitle from "../../components/HeaderErrorTitle";
 import HeaderSynchronizing from "../../components/HeaderSynchronizing";
 import Touchable from "../../components/Touchable";
-import BellIcon from "../../icons/Bell";
-import SettingsIcon from "../../icons/Settings";
-import DeviceIcon from "../../icons/NanoS";
 import { NavigatorName } from "../../const";
 import { scrollToTop } from "../../navigation/utils";
 import LText from "../../components/LText";
@@ -77,17 +75,17 @@ export default function PortfolioHeader() {
               </LText>
             </View>
           )}
-          <BellIcon size={18} color={colors.grey} />
+          <Icons.NotificationsMedium size={24} color={colors.grey} />
         </Touchable>
       </View>
       <View style={[styles.distributionButton, styles.marginLeft]}>
         <Touchable onPress={onSettingsButtonPress}>
-          <SettingsIcon size={18} color={colors.grey} />
+          <Icons.SettingsMedium size={24} color={colors.grey} />
         </Touchable>
       </View>
       <View style={[styles.distributionButton, styles.marginLeft]}>
         <Touchable onPress={onDeviceButtonPress}>
-          <DeviceIcon size={18} color={colors.grey} />
+          <Icons.NanoFoldedMedium size={24} color={colors.grey} />
         </Touchable>
       </View>
     </View>
@@ -112,7 +110,7 @@ const styles = StyleSheet.create({
     borderRadius: 32,
     alignSelf: "center",
   },
-  marginLeft: { marginLeft: 8 },
+  marginLeft: { marginLeft: 24 },
   badge: {
     width: 16,
     height: 16,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15449,16 +15449,7 @@ string-width@^1.0.1:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^2.0.0, string-width@^2.1.1:
+"string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
@@ -15474,6 +15465,15 @@ string-width@^3.0.0, string-width@^3.1.0:
     emoji-regex "^7.0.1"
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string.prototype.matchall@^4.0.6:
   version "4.0.6"


### PR DESCRIPTION
[LIVE-991] [LIVE-954] [LIVE-978]
___

**Swap CTA:**
The Swap CTA is now only visible when there is an account for the given asset.
Pressing the swap CTA in the MarketDetail screen will now always navigate to the swap form and the "from" field will be pre-filled with the first account found.


https://user-images.githubusercontent.com/91890529/153385195-bfdd689e-a511-4972-9d7c-41c560ac10fa.mp4



**Buy CTA:**
Pressing the Buy CTA in the MarketDetail screen will now redirect to the multi-buy screen. No field is pre-filled as this is currently not implemented for the multi-buy.


https://user-images.githubusercontent.com/91890529/153385270-2b425431-0d17-4b8d-bd0b-c1b5661f4f4d.mp4



### Type

Bug fix

### Context

#### Bug 1 (buy CTA) [LIVE-978]:

> **Steps to Reproduce:**
> 
> Go to the Market page, click Bitcoin, click Buy.
>
> **Expected behavior:**
> 
> Multi buy screen is opened.
> 
> **Actual behavior:**
> 
> User is redirected to the Coinify Buy screen.


#### Bug 2 (swap CTA) [LIVE-954]:

> **Steps to Reproduce:**
> 
> Have to 2 accounts on the same coin (Bitcoin native segwit + taproot for example)
> 
> Click Market / Bitcoin / Swap
> 
> **Expected behavior:**
> 
> Swap form is ready for the user to input a quantity
> 
> **Actual behavior:**
> 
> LLM is asking for the Nano and then adding new account 

### Parts of the app affected / Test plan


[LIVE-954]: https://ledgerhq.atlassian.net/browse/LIVE-954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-978]: https://ledgerhq.atlassian.net/browse/LIVE-978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LIVE-991]: https://ledgerhq.atlassian.net/browse/LIVE-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ