### PR TITLE
LIVE-955 (Android): dark mode forceDarkAllowed to false

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -10,5 +10,6 @@
         <item name="android:statusBarColor">@color/primary_dark</item>
         <item name="android:windowFullscreen">true</item>
         <item name="windowActionBar">false</item>
+        <item name="android:forceDarkAllowed">false</item>
     </style>
 </resources>


### PR DESCRIPTION
fixes issue on system dark mode forcing svg icons colors to black

### Type

Bug Fix

### Context

[LIVE-955]
<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LIVE-955]: https://ledgerhq.atlassian.net/browse/LIVE-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ