### PR TITLE
LL-8639 Handle OS theme properly

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -25,7 +25,7 @@ type SetExchangePairs = (
   }>,
 ) => *;
 
-export type Theme = "light" | "dark";
+export type Theme = "system" | "light" | "dark";
 
 export const setExchangePairsAction: SetExchangePairs = pairs => ({
   type: "SETTINGS_SET_PAIRS",

--- a/src/index.js
+++ b/src/index.js
@@ -379,13 +379,9 @@ const DeepLinkingNavigator = ({ children }: { children: React$Node }) => {
   const compareOsTheme = useCallback(() => {
     const currentOsTheme = Appearance.getColorScheme();
     if (currentOsTheme && osTheme !== currentOsTheme) {
-      const isDark = themes[theme].dark;
-      const newTheme =
-        currentOsTheme === "dark" ? (isDark ? theme : "dark") : "light";
-      dispatch(setTheme(newTheme));
       dispatch(setOsTheme(currentOsTheme));
     }
-  }, [dispatch, osTheme, theme]);
+  }, [dispatch, osTheme]);
 
   useEffect(() => {
     compareOsTheme();
@@ -395,14 +391,20 @@ const DeepLinkingNavigator = ({ children }: { children: React$Node }) => {
     return () => AppState.removeEventListener("change", osThemeChangeHandler);
   }, [compareOsTheme]);
 
+  const resolvedTheme = useMemo(
+    () =>
+      ((theme === "system" && osTheme) || theme) === "light" ? "light" : "dark",
+    [theme, osTheme],
+  );
+
   if (!isReady) {
     return null;
   }
 
   return (
-    <StyleProvider selectedPalette={theme === "light" ? "light" : "dark"}>
+    <StyleProvider selectedPalette={resolvedTheme}>
       <NavigationContainer
-        theme={themes[theme]}
+        theme={themes[resolvedTheme]}
         linking={linking}
         ref={navigationRef}
         onReady={() => {

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ import { lightTheme, darkTheme } from "./colors";
 import NotificationsProvider from "./screens/NotificationCenter/NotificationsProvider";
 import SnackbarContainer from "./screens/NotificationCenter/Snackbar/SnackbarContainer";
 import NavBarColorHandler from "./components/NavBarColorHandler";
-import { setOsTheme, setTheme } from "./actions/settings";
+import { setOsTheme } from "./actions/settings";
 // $FlowFixMe
 import StyleProvider from "./StyleProvider";
 // $FlowFixMe

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1665,6 +1665,7 @@
       "theme": "Theme",
       "themeDesc": "Set the app UI theme",
       "themes": {
+        "system": "System",
         "dark": "Dark",
         "light": "Light"
       },

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint import/no-cycle: 0 */
 import { handleActions } from "redux-actions";
-import { Platform, Appearance } from "react-native";
+import { Platform } from "react-native";
 import merge from "lodash/merge";
 import {
   findCurrencyByTicker,
@@ -55,9 +55,7 @@ export type Privacy = {
   biometricsEnabled: boolean,
 };
 
-const colorScheme = Appearance.getColorScheme();
-
-export type Theme = "light" | "dark";
+export type Theme = "system" | "light" | "dark";
 
 export type SettingsState = {
   counterValue: string,
@@ -117,7 +115,7 @@ export const INITIAL_STATE: SettingsState = {
   blacklistedTokenIds: [],
   dismissedBanners: [],
   hasAvailableUpdate: false,
-  theme: colorScheme === "dark" ? "dark" : "light",
+  theme: "system",
   osTheme: undefined,
   carouselVisibility: 0,
   discreetMode: false,

--- a/src/screens/Settings/General/ThemeSettingsRow.js
+++ b/src/screens/Settings/General/ThemeSettingsRow.js
@@ -39,7 +39,7 @@ export default function ThemeSettingsRow() {
       </SettingsRow>
       <BottomModal isOpened={isOpen} onClose={onClose}>
         <View style={styles.modal}>
-          {["light", "dark"].map((theme, i) => (
+          {["system", "light", "dark"].map((theme, i) => (
             <Touchable
               event="ThemeSettingsRow"
               eventProperties={{ theme }}


### PR DESCRIPTION
Offer the user an option to follow the system theme instead of overriding their choice when the OS theme changes. Default to that instead of dark. Keep in mind that there are three values for the operating system theme. If you've never set it before it will be `null`, if I've set it to dark before it will be `dark` but if I disable dark it will be `light`.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

https://user-images.githubusercontent.com/4631227/153578351-b885e192-b121-44a8-8ae8-977a9c93f5b6.mov


### Type

Bug Fix

### Context
https://ledgerhq.atlassian.net/browse/LL-8639


### Parts of the app affected / Test plan

- When the app theme is "system" it should follow the OS selection
- When the app theme is "light" it should ignore the OS selection and be light.
- When the app theme is "dark" it should ignore the OS selection and be dark.
