### PR TITLE
LL-9214 remove metro.config.js

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -19,29 +19,6 @@ module.exports = {
     }),
   },
   resolver: {
-    sourceExts: [...defaultSourceExts, 'cjs'],
-    resolveRequest: (context, realModuleName, platform, moduleName) => {
-      const { resolveRequest: removed, ...restContext} = context;
-
-      let module = realModuleName;
-      // When resolveRequest exist, ripple-lib doesn't seems to be able to find ws.
-      if (moduleName === 'ws') {
-        return {
-          type: 'sourceFile',
-          filePath: `${__dirname}/node_modules/ws/browser.js`
-        }
-      }
-
-      // Patch for polkadot, because inside of packageInfo.js they used
-      // import.meta that is still not avaible
-      if (
-        context.originModulePath.includes("@polkadot") &&
-        moduleName === "./packageInfo.js"
-      ) {
-        module = module.replace(".js", ".cjs");
-      }
-
-      return resolve(restContext, module, platform);
-    },
+    sourceExts: [...defaultSourceExts, 'cjs']
   }
 };


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

BugFix

### Context

https://ledgerhq.atlassian.net/browse/LL-9214

I really don't know why it wasn't needed anymore. Do we change thing on polyfill or smth ? 

### Parts of the app affected / Test plan

XRP and DOT
