### PR TITLE
LIVE-926 Disable closing modals while inline install is happening

### DIFF
--- a/src/actions/appstate.js
+++ b/src/actions/appstate.js
@@ -18,3 +18,6 @@ export const syncIsConnected = (isConnected: boolean | null) => (
 export const setHasConnectedDevice = (hasConnectedDevice: boolean) => (
   dispatch: *,
 ) => dispatch({ type: "HAS_CONNECTED_DEVICE", hasConnectedDevice });
+
+export const setModalLock = (modalLock: boolean) => (dispatch: *) =>
+  dispatch({ type: "SET_MODAL_LOCK", modalLock });

--- a/src/components/BottomModal.js
+++ b/src/components/BottomModal.js
@@ -2,10 +2,12 @@
 
 import React, { useEffect, useState } from "react";
 import { View, StyleSheet, Platform } from "react-native";
+import { useSelector } from "react-redux";
 import ReactNativeModal from "react-native-modal";
 import type { ViewStyleProp } from "react-native/Libraries/StyleSheet/StyleSheet";
 import { useTheme } from "@react-navigation/native";
 import TrackScreen from "../analytics/TrackScreen";
+import { isModalLockedSelector } from "../reducers/appstate";
 import StyledStatusBar from "./StyledStatusBar";
 import ButtonUseTouchable from "../context/ButtonUseTouchable";
 import getWindowDimensions from "../logic/getWindowDimensions";
@@ -46,14 +48,15 @@ const BottomModal = ({
 }: Props) => {
   const { colors } = useTheme();
   const [open, setIsOpen] = useState(false);
+  const isModalLocked = useSelector(isModalLockedSelector);
   const backDropProps = preventBackdropClick
     ? {}
     : {
-        onBackdropPress: onClose,
-        onBackButtonPress: onClose,
+        onBackdropPress: !isModalLocked ? onClose : undefined,
+        onBackButtonPress: !isModalLocked ? onClose : undefined,
       };
 
-  // workarround to make sure no double modal can be opened at same time
+  // workaround to make sure no double modal can be opened at same time
   useEffect(
     () => () => {
       isModalOpenedref = false;

--- a/src/components/DeviceAction/rendering.js
+++ b/src/components/DeviceAction/rendering.js
@@ -1,11 +1,13 @@
 // @flow
 import React, { useEffect } from "react";
 import { View, StyleSheet } from "react-native";
+import { useDispatch } from "react-redux";
 import Icon from "react-native-vector-icons/dist/Feather";
 import { WrongDeviceForAccount, UnexpectedBootloader } from "@ledgerhq/errors";
 import type { TokenCurrency } from "@ledgerhq/live-common/lib/types";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import type { AppRequest } from "@ledgerhq/live-common/lib/hw/actions/app";
+import { setModalLock } from "../../actions/appstate";
 import { urls } from "../../config/urls";
 import LText from "../LText";
 import Alert from "../Alert";
@@ -452,6 +454,17 @@ export function LoadingAppInstall({
   description?: string,
   request?: AppRequest,
 }) {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    // Nb Blocks closing the modal while the install is happening.
+    // releases the block on onmount.
+    dispatch(setModalLock(true));
+    return () => {
+      dispatch(setModalLock(false));
+    };
+  }, [dispatch]);
+
   const currency = request?.currency || request?.account?.currency;
   const appName = request?.appName || currency?.managerAppName;
   useEffect(() => {

--- a/src/components/DeviceActionModal.js
+++ b/src/components/DeviceActionModal.js
@@ -1,10 +1,12 @@
 // @flow
 import React from "react";
 import { View, StyleSheet } from "react-native";
+import { useSelector } from "react-redux";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/lib/bridge/react";
 import { useTheme } from "@react-navigation/native";
 import { useTranslation } from "react-i18next";
+import { isModalLockedSelector } from "../reducers/appstate";
 import DeviceAction from "./DeviceAction";
 import BottomModal from "./BottomModal";
 import ModalBottomAction from "./ModalBottomAction";
@@ -72,16 +74,24 @@ export default function DeviceActionModal({
         />
       )}
       {device && <SyncSkipUnderPriority priority={100} />}
-      <Touchable
-        event="DeviceActionModalClose"
-        style={styles.close}
-        onPress={onClose}
-      >
-        <Close color={colors.fog} size={20} />
-      </Touchable>
+      <ModalLockAwareClose>
+        <Touchable
+          event="DeviceActionModalClose"
+          style={styles.close}
+          onPress={onClose}
+        >
+          <Close color={colors.fog} size={20} />
+        </Touchable>
+      </ModalLockAwareClose>
     </BottomModal>
   );
 }
+
+const ModalLockAwareClose = ({ children }) => {
+  const modalLock = useSelector(isModalLockedSelector);
+  if (modalLock) return null;
+  return children;
+};
 
 const styles = StyleSheet.create({
   footerContainer: {

--- a/src/reducers/appstate.js
+++ b/src/reducers/appstate.js
@@ -12,11 +12,13 @@ export type AsyncState = {
 export type AppState = {
   isConnected: boolean | null,
   hasConnectedDevice: boolean,
+  modalLock: boolean,
 };
 
 const initialState: AppState = {
   isConnected: true,
   hasConnectedDevice: false, // NB for this current session, have we done a device action with a device.
+  modalLock: false,
 };
 
 const handlers: Object = {
@@ -31,11 +33,16 @@ const handlers: Object = {
     state: AppState,
     { hasConnectedDevice }: { hasConnectedDevice: boolean },
   ) => ({ ...state, hasConnectedDevice }),
+  SET_MODAL_LOCK: (state: AppState, { modalLock }: { modalLock: boolean }) => ({
+    ...state,
+    modalLock,
+  }),
 };
 
 // Selectors
 
 export const isConnectedSelector = (state: State) => state.appstate.isConnected;
+export const isModalLockedSelector = (state: State) => state.appstate.modalLock;
 export const hasConnectedDeviceSelector = (state: State) =>
   state.appstate.hasConnectedDevice;
 


### PR DESCRIPTION
Since the introduction of the feature [back in April 2021](https://github.com/LedgerHQ/ledger-live-mobile/pull/1679#pullrequestreview-646260570) @aulric-ledger noticed that the inline installation could be stopped midway by either closing the modal or tapping outside of it. At the time we couldn't think of an easy solution to prevent this but I see no reason why this wouldn't work. 



https://user-images.githubusercontent.com/4631227/153897273-5afa0dc7-c6d1-4bef-a649-0df265b24358.mov



### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LIVE-926

### Parts of the app affected / Test plan

- Enter a device action flow without the appropriate application
- Notice that the bottom modal can be closed at any given time
- During inline installation the X that closes the modal should not be present
- Clicking on the backdrop should not close the modal
- Clicking _back_ on the device (Android) should not close the modal

Completing the installation or failing (device disconnection for instance) should also unlock the modal and allow closing it. In other words, it should only remain locked during the inline installation and any other step that was locked before.