### PR TITLE
Of course it was KB

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1322,7 +1322,7 @@
   },
   "byteSize": {
     "bytes": "{{size}} bytes",
-    "kbUnit": "{{size}} kB",
+    "kbUnit": "{{size}} KB",
     "mbUnit": "{{size}} MB"
   },
   "numberCompactNotation": {


### PR DESCRIPTION
## 🦒 Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LIVE-1193

Product asked to change `Kb` to `kB` and now it's `KB`.
🙏🏼 