### PR TITLE
LIVE-992 LIVE-967 Fix languages discoverability

### DIFF
--- a/src/components/CheckLanguageAvailability.js
+++ b/src/components/CheckLanguageAvailability.js
@@ -42,7 +42,11 @@ export default function CheckLanguageAvailability() {
   }, [dispatch, defaultLanguage, answer, onRequestClose]);
 
   const toShow =
-    modalOpened && !hasAnswered && currAppLanguage !== defaultLanguage;
+    modalOpened &&
+    !hasAnswered &&
+    currAppLanguage !== defaultLanguage &&
+    currAppLanguage === "en";
+
   if (!toShow) {
     return null;
   }

--- a/src/components/CheckLanguageAvailability.js
+++ b/src/components/CheckLanguageAvailability.js
@@ -11,7 +11,7 @@ import Button from "./Button";
 import Circle from "./Circle";
 import ModalBottomAction from "./ModalBottomAction";
 import LanguageIcon from "../icons/Language";
-import { languageSelector } from "../reducers/settings";
+import { languageSelector, languageIsSetByUserSelector } from "../reducers/settings";
 import { setLanguage } from "../actions/settings";
 import { getDefaultLanguageLocale } from "../languages";
 import { useLanguageAvailableChecked } from "../context/Locale";
@@ -25,6 +25,7 @@ export default function CheckLanguageAvailability() {
   const defaultLanguage = getDefaultLanguageLocale();
   const currAppLanguage = useSelector(languageSelector);
   const [hasAnswered, answer] = useLanguageAvailableChecked();
+  const isLanguageSetByUser = useSelector(languageIsSetByUserSelector);
 
   const onRequestClose = useCallback(() => {
     setModalOpened(false);
@@ -43,6 +44,7 @@ export default function CheckLanguageAvailability() {
 
   const toShow =
     modalOpened &&
+    !isLanguageSetByUser &&
     !hasAnswered &&
     currAppLanguage !== defaultLanguage &&
     currAppLanguage === "en";

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -85,6 +85,7 @@ export type SettingsState = {
   carouselVisibility: number,
   discreetMode: boolean,
   language: string,
+  languageIsSetByUser: boolean,
   locale: ?string,
   swap: {
     hasAcceptedIPSharing: false,
@@ -120,6 +121,7 @@ export const INITIAL_STATE: SettingsState = {
   carouselVisibility: 0,
   discreetMode: false,
   language: getDefaultLanguageLocale(),
+  languageIsSetByUser: false,
   locale: null,
   swap: {
     hasAcceptedIPSharing: false,
@@ -306,6 +308,7 @@ const handlers: Object = {
   SETTINGS_SET_LANGUAGE: (state: SettingsState, { payload }) => ({
     ...state,
     language: payload,
+    languageIsSetByUser: true,
   }),
   SETTINGS_SET_LOCALE: (state: SettingsState, { payload }) => ({
     ...state,
@@ -513,6 +516,9 @@ export const osThemeSelector = (state: State) => state.settings.osTheme;
 
 export const languageSelector = (state: State) =>
   state.settings.language || getDefaultLanguageLocale();
+
+export const languageIsSetByUserSelector = (state: State) =>
+  state.settings.languageIsSetByUser;
 
 export const localeSelector = (state: State) =>
   state.settings.locale || getDefaultLocale();


### PR DESCRIPTION
### Type

Bug fix

### Context

This PR solves this two issues regarding the language discoverability modal, a dialog that shows up for **existing users** who have their app in english informing them that their OS language (for now French or Russian) is available:

- [LIVE-992] **The language discoverability modal should always be in english. This is solved by making sure that the language discoverability drawer only appears if the current app language is English.** The reason is that this discoverability drawer is meant for _existing_ users who are using the app in english (the app's default language) and might not now that the app is available in their language (with a limitation to Russian and French for now)

- [LIVE-967] **The language discoverability drawer should not appear after switching manually the app's language.**
This one is solved by introducing a new key in the settings (`languageIsSetByUser`) that will be set to true whenever the user changes the app's language. It's `false` by default as it's impossible to retrieve this information otherwise, but worst case scenario is that as a consequence it just makes the discoverability modal appear _once_ for users that have never seen it (e.g. a user that has manually set his app language to English — before installing the new version — even though his system is in french).


### Parts of the app affected / Test plan

[LIVE-992]
- Case A: Existing user, existing app in English, system in French/Russian.
   1. Uninstall LL
   2. Switch OS language to english
   3. Install LL, launch it, go through onboarding
   4. Quit LL, switch OS language to French or Russian.
   5. Launch LL
   6. LL should prompt a dialogue asking the user to switch the language to the OS language. **The dialog should be in english**.

- Case B: system in English, existing app in any language other than English/Russian/French.
   1. Uninstall LL
   2. Switch OS language to english
   3. Install LL, go through onboarding and set it in any language other than English/Russian/French.
   4. Quit LL, switch OS language to English.
   5. Launch LL
   6. LL should not show the discoverability modal. (This is the expected behavior, before this PR the actual behavior is that it would show the discoverability modal in English)


[LIVE-967]
> **Steps to Reproduce:**
> 1.  system Language in FR
> 2.  LL in FR
> 3.  update to new version
> 4.  Switch manually to LL EN
>
> **Expected behavior:**
> Nothing happens
>
> **Actual behavior:**
> Discoverability modals pops out


[LIVE-992]: https://ledgerhq.atlassian.net/browse/LIVE-992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-967]: https://ledgerhq.atlassian.net/browse/LIVE-967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-992]: https://ledgerhq.atlassian.net/browse/LIVE-992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ