### PR TITLE
LIVE-993 - Region analytics fixes

### DIFF
--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -17,6 +17,7 @@ import getOrCreateUser from "../user";
 import {
   analyticsEnabledSelector,
   languageSelector,
+  localeSelector,
   lastSeenDeviceSelector,
 } from "../reducers/settings";
 import { knownDevicesSelector } from "../reducers/ble";
@@ -33,6 +34,7 @@ const extraProperties = store => {
   const state: State = store.getState();
   const { localeIdentifier, preferredLanguages } = Locale.constants();
   const language = languageSelector(state);
+  const region = localeSelector(state);
   const devices = knownDevicesSelector(state);
 
   const lastDevice =
@@ -53,6 +55,7 @@ const extraProperties = store => {
     localeIdentifier,
     preferredLanguage: preferredLanguages ? preferredLanguages[0] : null,
     language,
+    region: region?.split("-")[1] || region,
     platformOS: Platform.OS,
     platformVersion: Platform.Version,
     sessionId,

--- a/src/screens/Settings/General/Region.js
+++ b/src/screens/Settings/General/Region.js
@@ -33,7 +33,9 @@ const mapDispatchToProps = {
 
 const Screen = makeGenericSelectScreen({
   id: "RegionSettingsSelect",
-  itemEventProperties: item => ({ countervalue: item.value }),
+  itemEventProperties: item => ({
+    region: item.value?.split("-")[1] || item.value,
+  }),
   keyExtractor: item => item.value,
   formatItem: item => item.label,
   searchable: true,


### PR DESCRIPTION
- Fix tracking of when user selects a different region in their settings. Now the event is tracked with a property `region` and only the second part of the local (the region part, after the "-") is used as a value for this property. This is safe as our list of regions is hardcoded and all have the same format.
- Add `settings.region` to extraProperties (super properties that are added to all tracked events).

### Type

Analytics

### Context

[LIVE-993]
>update property key to be names as “region”
>update property value to include the second part of the local en-US
>**Make sure the region property is a global variable linked to all events in the app**

### Parts of the app affected / Test plan
- Region select screen, event linked to picking a region on that screen.
- Extra properties on all analytics events (there is now the `region` property)

I've tested everything locally, on both a "new user" and "existing user" setup.

[LIVE-993]: https://ledgerhq.atlassian.net/browse/LIVE-993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ