### PR TITLE
LIVE-1108: missing traslate for extra key in tezos

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1441,7 +1441,11 @@
       "withdrawUnbondedAmount": "Withdraw Unbonded Amount",
       "palletMethod": "Method",
       "transferAmount": "Transfer Amount",
-      "validatorsCount": "Validators ({{number}})"
+      "validatorsCount": "Validators ({{number}})",
+      "storageLimit": "Storage Limit",
+      "gasLimit": "Gas Limit",
+      "opbytes": "opBytes",
+      "id": "Id"
     },
     "multipleAddresses": "Why multiple addresses?",
     "tokenName": "Token Name",


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LIVE-1108

Missing translate for extra op in Tezos

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
