### PR TITLE
fix - animated header bottom padding

### DIFF
--- a/src/components/AnimatedHeader.js
+++ b/src/components/AnimatedHeader.js
@@ -221,8 +221,6 @@ const styles = StyleSheet.create({
   scrollArea: {
     paddingHorizontal: 24,
     paddingTop: 50,
-    paddingBottom: 24,
+    paddingBottom: 116,
   },
-  spacerTop: { marginTop: 60 },
-  spacerBottom: { marginTop: 24 },
 });


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
missing padding at bottom of animated scroll zone 

<details>
<summary>
before
</summary>

![Screenshot_2022-02-18-14-08-50-162_com ledger live debug](https://user-images.githubusercontent.com/11752937/154689010-761dfd39-53da-425d-9c04-a321e0dbbf02.jpg)

![Screenshot_2022-02-18-14-08-39-963_com ledger live debug](https://user-images.githubusercontent.com/11752937/154689026-a977ae38-af18-4f02-a6f2-cd8fa123eb90.jpg)


</details>

<details>
<summary>
after
</summary>

![Screenshot_2022-02-18-14-09-15-039_com ledger live debug](https://user-images.githubusercontent.com/11752937/154689198-4d669cc3-1891-40b7-9912-6419b940d05e.jpg)

![Screenshot_2022-02-18-14-08-25-557_com ledger live debug](https://user-images.githubusercontent.com/11752937/154689204-8bd8cf19-4f5a-45af-9590-d55217a317d7.jpg)


</details>

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
