### PR TITLE
Bugfix/LIVE-971 - Fix colors in ValidateMessageOnDevice device action (WalletConnect)

### DIFF
--- a/src/components/ValidateMessageOnDevice.js
+++ b/src/components/ValidateMessageOnDevice.js
@@ -2,6 +2,7 @@
 import React from "react";
 import { View, StyleSheet, ScrollView } from "react-native";
 import { useTranslation } from "react-i18next";
+import { useTheme } from "@react-navigation/native";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import type { TypedMessageData } from "@ledgerhq/live-common/lib/families/ethereum/types";
 import type { MessageData } from "@ledgerhq/live-common/lib/hw/signMessage/types";
@@ -18,6 +19,13 @@ type Props = {
 
 export default function ValidateOnDevice({ device, message, account }: Props) {
   const { t } = useTranslation();
+  const { colors } = useTheme();
+
+  const messageContainerStyle = [
+    styles.messageContainer,
+    { backgroundColor: colors.background },
+  ];
+  const messageTextStyle = [styles.property, { color: colors.text }];
 
   return (
     <View style={styles.root}>
@@ -32,15 +40,15 @@ export default function ValidateOnDevice({ device, message, account }: Props) {
         <LText style={styles.action}>
           {t("walletconnect.stepVerification.action")}
         </LText>
-        <View style={styles.messageContainer}>
-          <LText style={styles.property}>
+        <View style={messageContainerStyle}>
+          <LText style={messageTextStyle}>
             {t("walletconnect.stepVerification.accountName")}
           </LText>
           <LText semiBold>{account && account.name ? account.name : ""}</LText>
         </View>
         {message && message.hashes && message.hashes.domainHash ? (
-          <View style={styles.messageContainer}>
-            <LText style={styles.property}>
+          <View style={messageContainerStyle}>
+            <LText style={messageTextStyle}>
               {t("walletconnect.domainHash")}
             </LText>
             <LText semiBold>
@@ -51,8 +59,8 @@ export default function ValidateOnDevice({ device, message, account }: Props) {
           </View>
         ) : null}
         {message && message.hashes && message.hashes.messageHash ? (
-          <View style={styles.messageContainer}>
-            <LText style={styles.property}>
+          <View style={messageContainerStyle}>
+            <LText style={messageTextStyle}>
               {t("walletconnect.messageHash")}
             </LText>
             <LText semiBold>
@@ -63,8 +71,8 @@ export default function ValidateOnDevice({ device, message, account }: Props) {
           </View>
         ) : null}
         {message && message.hashes && message.hashes.stringHash ? (
-          <View style={styles.messageContainer}>
-            <LText style={styles.property}>
+          <View style={messageContainerStyle}>
+            <LText style={messageTextStyle}>
               {t("walletconnect.stringHash")}
             </LText>
             <LText semiBold>
@@ -74,8 +82,8 @@ export default function ValidateOnDevice({ device, message, account }: Props) {
             </LText>
           </View>
         ) : null}
-        <View style={styles.messageContainer}>
-          <LText style={styles.property}>{t("walletconnect.message")}</LText>
+        <View style={messageContainerStyle}>
+          <LText style={messageTextStyle}>{t("walletconnect.message")}</LText>
           <LText semiBold>
             {message.message.domain
               ? JSON.stringify(message.message)
@@ -103,7 +111,6 @@ const styles = StyleSheet.create({
   },
   messageContainer: {
     padding: 12,
-    backgroundColor: "#F5F5F5",
     borderRadius: 4,
     marginTop: 2,
   },


### PR DESCRIPTION
Fixing a color issue when signing a message on WalletConnect in dark mode.

**Steps to reproduce:**

1. Have LLM ready with an Ethereum account and the Nano for that account
2. On LLM Open the page for the Ethereum account and in the actions press WalletConnect.
3. Go to OpenSea or any dapp that uses WalletConnect
4. In the DApp, choose to login with Wallet connect (you'll need to scan the QR code displayed in your browser & validate in LLM)
5. Perform an action on the DApp that requests a signature (for instance hide or unhide an NFT in your collection)
6. You'll get to the desired screen.


**Before:**
![Image from iOS (1) (1)](https://user-images.githubusercontent.com/91890529/154731445-00fc07bd-b466-45a2-ae72-e38adf35cbba.png)

**After:**
(The background of these boxes is hardly visible but this was hardcoded previously and I can't find a design so it'll be like that, at least everything is readable in all themes now and that's the main point).
![adb-screencap(9)](https://user-images.githubusercontent.com/91890529/154731462-8ee1af69-6a66-4dde-9373-b15e30a85e9a.png)
![adb-screencap(11)](https://user-images.githubusercontent.com/91890529/154731467-4ddd33a7-1092-46a5-9726-cbac49939c56.png)


### Type

Bug fix

### Context

[LIVE-971]

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LIVE-971]: https://ledgerhq.atlassian.net/browse/LIVE-971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ