### PR TITLE
Debug env v2

### DIFF
--- a/src/screens/DebugEnv.js
+++ b/src/screens/DebugEnv.js
@@ -3,6 +3,7 @@
 import React, { useState, useCallback } from "react";
 import { View, Text } from "react-native";
 import Config from "react-native-config";
+import { setEnvUnsafe } from "@ledgerhq/live-common/lib/env";
 import NavigationScrollView from "../components/NavigationScrollView";
 import Button from "../components/Button";
 import TextInput from "../components/TextInput";
@@ -24,6 +25,7 @@ export default function DebugEnv() {
     } else {
       setStatus(`Set value '${match[2]}' for '${match[1]}'`);
       Config[match[1]] = match[2];
+      setEnvUnsafe(match[1], match[2]);
     }
   }, [value]);
 

--- a/src/screens/DebugEnv.js
+++ b/src/screens/DebugEnv.js
@@ -21,6 +21,7 @@ export default function DebugEnv() {
       setStatus("Can't parse input");
     } else if (match[2] === "0") {
       setStatus(`Unsetting ${match[1]}`);
+      setEnvUnsafe(match[1], match[2]);
       delete Config[match[1]];
     } else {
       setStatus(`Set value '${match[2]}' for '${match[1]}'`);


### PR DESCRIPTION
In order to support more env variables in the Debug Env screen, allow the usage of `setEnvUnsafe` so that things like api changes, non broadcast flags, etc also propagate the env for code relying on the `setEnv` `getEnv` paradigm instead of `Config`.

### Type

QA tooling improvement

### Context

I don't have a task for this specifically

### Parts of the app affected / Test plan
Try setting an env such as `DISABLE_TRANSACTION_BROADCAST=1` and check if your funds get sent or not :trollface: 