### PR TITLE
LIVE-1392 Show NanoSP by default

### DIFF
--- a/src/screens/Onboarding/steps/deviceSelection.js
+++ b/src/screens/Onboarding/steps/deviceSelection.js
@@ -2,7 +2,6 @@
 
 import React, { useMemo, useCallback } from "react";
 import { StyleSheet, Image, View } from "react-native";
-import Config from "react-native-config";
 import { Trans } from "react-i18next";
 import { useTheme } from "@react-navigation/native";
 import { TrackScreen } from "../../../analytics";
@@ -26,9 +25,7 @@ function OnboardingStepDeviceSelection({ navigation }: *) {
   const deviceIds = useMemo(
     () => ({
       nanoS: { dark: nanoSLight, light: nanoSDark },
-      ...(Config.SHOW_NANOSP
-        ? { nanoSP: { dark: nanoSPLight, light: nanoSPDark } }
-        : {}),
+      nanoSP: { dark: nanoSPLight, light: nanoSPDark },
       nanoX: { dark: nanoXLight, light: nanoXDark },
     }),
     [],


### PR DESCRIPTION
Enable the Ledger Nano S Plus by default on the application, without requiring the `SHOW_NANOSP` flag like we needed up until now. This means the device should be available during onboarding and detected when plugged in (this last part was already the case).

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LIVE-1392

### Parts of the app affected / Test plan

- Make sure the app shows the device without needing the flag. All other functionality was tested in the specific PRs.