### PR TITLE
LIVE-1470 Guide users to onboarding if possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@ledgerhq/errors": "6.10.0",
     "@ledgerhq/hw-transport": "6.24.1",
     "@ledgerhq/hw-transport-http": "6.24.1",
-    "@ledgerhq/live-common": "^21.33.0",
+    "@ledgerhq/live-common": "https://github.com/ledgerhq/ledger-live-common.git#b4817f71f0d60d859c643a376122f5e5c7795cba",
     "@ledgerhq/logs": "6.10.0",
     "@ledgerhq/native-ui": "^0.7.0",
     "@ledgerhq/react-native-hid": "6.24.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@ledgerhq/errors": "6.10.0",
     "@ledgerhq/hw-transport": "6.24.1",
     "@ledgerhq/hw-transport-http": "6.24.1",
-    "@ledgerhq/live-common": "https://github.com/ledgerhq/ledger-live-common.git#b4817f71f0d60d859c643a376122f5e5c7795cba",
+    "@ledgerhq/live-common": "21.34.0",
     "@ledgerhq/logs": "6.10.0",
     "@ledgerhq/native-ui": "^0.7.0",
     "@ledgerhq/react-native-hid": "6.24.1",

--- a/src/components/DeviceAction/index.js
+++ b/src/components/DeviceAction/index.js
@@ -5,6 +5,8 @@ import type {
   Action,
   Device,
 } from "@ledgerhq/live-common/lib/hw/actions/types";
+import { DeviceNotOnboarded } from "@ledgerhq/live-common/lib/errors";
+import { TransportStatusError } from "@ledgerhq/errors";
 import { useTranslation } from "react-i18next";
 import { useNavigation, useTheme } from "@react-navigation/native";
 import { setLastSeenDeviceInfo } from "../../actions/settings";
@@ -204,6 +206,24 @@ export default function DeviceAction<R, H, P>({
 
   if (!isLoading && error) {
     onError && onError(error);
+
+    // NB Until we find a better way, remap the error if it's 6d06 and we haven't fallen
+    // into another handled case.
+    if (
+      error instanceof DeviceNotOnboarded ||
+      (error instanceof TransportStatusError &&
+        error.message.includes("0x6d06"))
+    ) {
+      return renderError({
+        t,
+        navigation,
+        error: new DeviceNotOnboarded(),
+        withOnboardingCTA: true,
+        colors,
+        theme,
+      });
+    }
+
     return renderError({
       t,
       navigation,

--- a/src/components/DeviceAction/rendering.js
+++ b/src/components/DeviceAction/rendering.js
@@ -327,12 +327,14 @@ export function renderError({
   onRetry,
   managerAppName,
   navigation,
+  withOnboardingCTA,
 }: {
   ...RawProps,
   navigation?: any,
   error: Error,
   onRetry?: () => void,
   managerAppName?: string,
+  withOnboardingCTA?: boolean,
 }) {
   const onPress = () => {
     if (managerAppName && navigation) {
@@ -343,6 +345,16 @@ export function renderError({
           updateModalOpened: true,
         },
       });
+    } else if (withOnboardingCTA && navigation) {
+      navigation.navigate(NavigatorName.BaseOnboarding, {
+        screen: NavigatorName.Onboarding,
+        params: {
+          screen: ScreenName.OnboardingUseCase,
+          params: {
+            deviceModelId: "nanoSP",
+          },
+        },
+      });
     } else if (onRetry) {
       onRetry();
     }
@@ -350,7 +362,7 @@ export function renderError({
   return (
     <View style={styles.wrapper}>
       <GenericErrorView error={error} withDescription withIcon />
-      {onRetry || managerAppName ? (
+      {onRetry || managerAppName || withOnboardingCTA ? (
         <View style={styles.actionContainer}>
           <Button
             event="DeviceActionErrorRetry"
@@ -358,6 +370,8 @@ export function renderError({
             title={
               managerAppName
                 ? t("DeviceAction.button.openManager")
+                : withOnboardingCTA
+                ? t("DeviceAction.button.openOnboarding")
                 : t("common.retry")
             }
             onPress={onPress}

--- a/src/components/ErrorIcon.js
+++ b/src/components/ErrorIcon.js
@@ -8,11 +8,15 @@ import {
   PairingFailed,
   UserRefusedAllowManager,
 } from "@ledgerhq/errors";
-import { SwapGenericAPIError } from "@ledgerhq/live-common/lib/errors";
+import {
+  SwapGenericAPIError,
+  DeviceNotOnboarded,
+} from "@ledgerhq/live-common/lib/errors";
 import { useTheme } from "@react-navigation/native";
 import Rounded from "./Rounded";
 import IconNanoX from "../icons/NanoX";
 import Close from "../icons/Close";
+import Info from "../icons/Info";
 import ErrorBadge from "./ErrorBadge";
 import Circle from "./Circle";
 import { rgba } from "../colors";
@@ -65,6 +69,14 @@ export default function ErrorIcon({ error }: Props) {
           name="clockcircleo"
           color={rgba(colors.darkBlue, 0.5)}
         />
+      </Circle>
+    );
+  }
+
+  if (error instanceof DeviceNotOnboarded) {
+    return (
+      <Circle size={80} bg={rgba(colors.live, 0.15)}>
+        <Info size={40} color={colors.live} />
       </Circle>
     );
   }

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -238,6 +238,10 @@
       "title": "Device not on Dashboard",
       "description": "Please return to the Dashboard on your device."
     },
+    "DeviceNotOnboarded": {
+      "title": "Your device is not ready to use yet",
+      "description": "Set up your device before using it with Ledger Live."
+    },
     "DeviceSocketFail": {
       "title": "Sorry, connection failed",
       "description": "Please try again."
@@ -2610,7 +2614,8 @@
       "alert": "Verify the Sell details on your device before sending it. The addresses are exchanged securely so you don’t have to verify them."
     },
     "button": {
-      "openManager": "Open Manager"
+      "openManager": "Open Manager",
+      "openOnboarding": "Setup device"
     },
     "installApp": "{{appName}} App installation {{percentage}}",
     "installAppDescription": "Please wait until the installation is finished",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,9 +2479,10 @@
     bignumber.js "^9.0.1"
     json-rpc-2.0 "^0.2.16"
 
-"@ledgerhq/live-common@https://github.com/ledgerhq/ledger-live-common.git#b4817f71f0d60d859c643a376122f5e5c7795cba":
-  version "21.33.0"
-  resolved "https://github.com/ledgerhq/ledger-live-common.git#b4817f71f0d60d859c643a376122f5e5c7795cba"
+"@ledgerhq/live-common@21.34.0":
+  version "21.34.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-21.34.0.tgz#2bd86b286b22cc31cfb788b8758195e91855f1f9"
+  integrity sha512-m7wlqEVLqlqwvB/y3D5aeadY55yUQ/qI1npjtUv74SK0fQd9/Yw9RsfDcoGlXEiXN5Pr5Xt60YJw7OPy6fNEKw==
   dependencies:
     "@celo/contractkit" "^1.5.1"
     "@celo/wallet-base" "^1.5.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,10 +2479,9 @@
     bignumber.js "^9.0.1"
     json-rpc-2.0 "^0.2.16"
 
-"@ledgerhq/live-common@^21.33.0":
+"@ledgerhq/live-common@https://github.com/ledgerhq/ledger-live-common.git#b4817f71f0d60d859c643a376122f5e5c7795cba":
   version "21.33.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-21.33.0.tgz#4b709dcbccdcb5010fd19b6829effe2a18587cc3"
-  integrity sha512-CpMiASJjLOYCz59EqjGEe3p7JxoF062RpbVuaF2AIBje09kxu9kVeqBeOQpk2bx+jLH2t3yWvmqVh9E1sm9FyA==
+  resolved "https://github.com/ledgerhq/ledger-live-common.git#b4817f71f0d60d859c643a376122f5e5c7795cba"
   dependencies:
     "@celo/contractkit" "^1.5.1"
     "@celo/wallet-base" "^1.5.1"


### PR DESCRIPTION
Same as https://github.com/LedgerHQ/ledger-live-desktop/pull/4786 but for mobile, the pr is pointing to a live-common commit instead of a release because the last release doesn't include the necessary logic. This is only affecting USB OTG users with a Nano S Plus that is not onboarded.

![image](https://user-images.githubusercontent.com/4631227/156218197-e3ed81d3-a6ce-424f-b3ac-bed38f41e5b7.png)


### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LIVE-1470

### Parts of the app affected / Test plan

- Connect a device that's no onboarded via USB OTG
- Try to access the manager
- It's expected you see that error if it's a nano s plus, you wouldn't be able to select the device otherwise 
