### PR TITLE
LIVE-1601 Use FastImage component for all platforms

### DIFF
--- a/src/components/Nft/NftImage.js
+++ b/src/components/Nft/NftImage.js
@@ -20,24 +20,15 @@ const ImageComponent = ({
   resizeMode: string,
   onLoadEnd: () => *,
   onLoad: () => *,
-}) =>
-  Platform.OS === "android" ? (
-    <Image
-      style={style}
-      resizeMode={resizeMode}
-      source={source}
-      onLoad={onLoad}
-      onLoadEnd={onLoadEnd}
-    />
-  ) : (
-    <FastImage
-      style={style}
-      resizeMode={FastImage.resizeMode[resizeMode]}
-      source={source}
-      onLoad={onLoad}
-      onLoadEnd={onLoadEnd}
-    />
-  );
+}) => (
+  <FastImage
+    style={style}
+    resizeMode={FastImage.resizeMode[resizeMode]}
+    source={source}
+    onLoad={onLoad}
+    onLoadEnd={onLoadEnd}
+  />
+);
 
 const NotFound = ({
   colors,
@@ -70,7 +61,6 @@ type Props = {
   style?: Object,
   status: string,
   src: string,
-  hackWidth?: number,
   colors: any,
 };
 
@@ -79,10 +69,6 @@ type State = {
 };
 
 class NftImage extends React.PureComponent<Props, State> {
-  static defaultProps = {
-    hackWidth: 90,
-  };
-
   state = {
     loadError: false,
   };
@@ -98,15 +84,8 @@ class NftImage extends React.PureComponent<Props, State> {
   };
 
   render() {
-    const { style, status, src, hackWidth, colors } = this.props;
+    const { style, status, src, colors } = this.props;
     const { loadError } = this.state;
-
-    const hackSrc = (() => {
-      const isPreProcessedSrc = /^https:\/\/lh3.googleusercontent.com\/.*/g;
-      return isPreProcessedSrc.test(src) && hackWidth
-        ? `${src}=s${hackWidth}`
-        : src;
-    })();
 
     return (
       <View style={[style, styles.root]}>
@@ -134,7 +113,7 @@ class NftImage extends React.PureComponent<Props, State> {
               ]}
               resizeMode="cover"
               source={{
-                uri: hackSrc,
+                uri: src,
               }}
               onLoad={({ nativeEvent }: Image.ImageLoadEvent) => {
                 if (!nativeEvent) {

--- a/src/components/Nft/NftImage.js
+++ b/src/components/Nft/NftImage.js
@@ -3,7 +3,7 @@
 import React, { useState } from "react";
 
 import FastImage from "react-native-fast-image";
-import { Image, View, StyleSheet, Animated, Platform } from "react-native";
+import { Image, View, StyleSheet, Animated } from "react-native";
 import ImageNotFoundIcon from "../../icons/ImageNotFound";
 import { withTheme } from "../../colors";
 import Skeleton from "../Skeleton";

--- a/src/components/Nft/NftViewer.js
+++ b/src/components/Nft/NftViewer.js
@@ -196,7 +196,6 @@ const NftViewer = ({ route }: Props) => {
               style={styles.image}
               src={metadata?.media}
               status={status}
-              hackWidth={300}
             />
           </View>
 


### PR DESCRIPTION
Currently we’re using different components for displaying NFT Images on iOS and Android. The component being used on Android has worse performance, this is due to an inability to handle certain types of images on that platform. However, with the new image processing service, all images are being converted to a supported format, this fixes this problem and we can use the fast component for both Android and iOS.

### Type
UX Improvement (performance)

### Context
[LIVE-1601]

### Parts of the app affected / Test plan
All NFT pages (Gallery and NFT viewer) should be working seamlessly.

[LIVE-1601]: https://ledgerhq.atlassian.net/browse/LIVE-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ