### PR TITLE
LIVE-1605 Fix receive flow loop

### DIFF
--- a/src/screens/ReceiveFunds/03-Confirmation.js
+++ b/src/screens/ReceiveFunds/03-Confirmation.js
@@ -160,13 +160,13 @@ export default function ReceiveConfirmation({ navigation, route }: Props) {
   useEffect(() => {
     const device = route.params.device;
 
-    if (device) {
+    if (device && !verified) {
       setAllowNavigation(false);
       verifyOnDevice(device);
     } else {
       setAllowNavigation(true);
     }
-  }, [route.params, account, parentAccount, verifyOnDevice]);
+  }, [route.params, verified, verifyOnDevice]);
 
   if (!account) return null;
   const { width } = getWindowDimensions();


### PR DESCRIPTION
Bad hook dependencies on the `useEffect` that was triggering the address confirmation were causing a re-trigger whenever the affected account was updated in the background. Basically if you were in the confirmation screen long enough, your account would sync and in doing so it would re-trigger the hook logic. Removing the dependencies and adding the extra condition of not having completed the confirmation fixes this, since a retry basically navigates back.

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LIVE-1605

### Parts of the app affected / Test plan

- Go through a receive flow
- Confirm the address on your device
- Wait, if nothing happens, we're good :trollface: 