### PR TITLE
Revert "LIVE-1413 - Hide tab bar when keyboard focus on market page"

### DIFF
--- a/src/components/RootNavigator/MainNavigator.js
+++ b/src/components/RootNavigator/MainNavigator.js
@@ -39,7 +39,6 @@ export default function MainNavigator({
         tabBarShowLabel: false,
         tabBarActiveTintColor: colors.live,
         headerShown: false,
-        tabBarHideOnKeyboard: true,
       }}
     >
       <Tab.Screen


### PR DESCRIPTION
Reverts LedgerHQ/ledger-live-mobile#2269

Issue was found where this removes tab bar at all times