### PR TITLE
LIVE-1654 - Fix experimental countervalues toggle

### DIFF
--- a/src/experimental.js
+++ b/src/experimental.js
@@ -85,8 +85,8 @@ export const experimentalFeatures: Feature[] = [
     title: "Experimental countervalues API",
     description:
       "This may cause the countervalues displayed for your accounts to become incorrect.",
-    valueOn: "https://countervalues.live.ledger.com",
-    valueOff: "https://countervalues-experimental.live.ledger.com",
+    valueOn: "https://countervalues-experimental.live.ledger.com",
+    valueOff: "https://countervalues.live.ledger.com",
   },
   ...(__DEV__
     ? [

--- a/src/screens/Settings/Experimental/FeatureSwitch.js
+++ b/src/screens/Settings/Experimental/FeatureSwitch.js
@@ -21,14 +21,19 @@ export default class FeatureSwitch extends PureComponent<Props, State> {
     valueOn: true,
     valueOff: false,
   };
+  state = {
+    checked: this.props.checked || false,
+  };
 
   onChange = (evt: boolean) => {
     const { onChange, valueOn, valueOff, name } = this.props;
     onChange(name, evt ? valueOn : valueOff);
+    this.setState({ checked: evt });
   };
 
   render() {
-    const { checked = false, name, readOnly } = this.props;
+    const { name, readOnly } = this.props;
+    const { checked } = this.state;
     return (
       <>
         <Track

--- a/src/screens/Settings/Experimental/FeatureSwitch.js
+++ b/src/screens/Settings/Experimental/FeatureSwitch.js
@@ -21,19 +21,14 @@ export default class FeatureSwitch extends PureComponent<Props, State> {
     valueOn: true,
     valueOff: false,
   };
-  state = {
-    checked: this.props.checked || false,
-  };
 
   onChange = (evt: boolean) => {
     const { onChange, valueOn, valueOff, name } = this.props;
     onChange(name, evt ? valueOn : valueOff);
-    this.setState({ checked: evt });
   };
 
   render() {
-    const { name, readOnly } = this.props;
-    const { checked } = this.state;
+    const { checked = false, name, readOnly } = this.props;
     return (
       <>
         <Track


### PR DESCRIPTION
The experimental countervalues API toggle keep changing its status back to enabled when coming back to the settings, after being manually disabled.

Here's the reason of the issue:
For `LEDGER_COUNTERVALUES_API`, the values of `valueOn` and `valueOff` in `src/experimental.js` were reversed (`valueOff` should be matching the `default` value declared in LLC's `env.ts` and `valueOn` should be the experimental value). This mismatch between the `default` value and the `valueOff` was causing the experimental switch toggle to have no effect.
#### Before:


https://user-images.githubusercontent.com/91890529/157937898-06636c9d-1218-456b-9d1a-b4afd00cef55.mp4

#### After:

https://user-images.githubusercontent.com/91890529/157936522-38fc2bf4-4cbb-49b5-89ec-8bd08e26dfb6.mp4

### Type

Bug fix

### Context

[LIVE-1654]

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LIVE-1654]: https://ledgerhq.atlassian.net/browse/LIVE-1654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ