### PR TITLE
LIVE-1621 - v3 - Device Actions cleanup

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,13 +11,13 @@ PODS:
     - ExpoModulesCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
-  - EXCamera (12.1.2):
+  - EXCamera (12.0.3):
     - ExpoModulesCore
-  - EXConstants (13.0.2):
+  - EXConstants (12.1.3):
     - ExpoModulesCore
   - EXErrorRecovery (3.0.5):
     - ExpoModulesCore
-  - EXFileSystem (13.1.4):
+  - EXFileSystem (13.0.3):
     - ExpoModulesCore
   - EXFont (10.0.5):
     - ExpoModulesCore
@@ -26,11 +26,10 @@ PODS:
     - React-Core
   - EXKeepAwake (10.0.2):
     - ExpoModulesCore
-  - Expo (44.0.6):
+  - Expo (43.0.5):
     - ExpoModulesCore
-  - ExpoModulesCore (0.6.5):
+  - ExpoModulesCore (0.4.10):
     - React-Core
-    - ReactCommon/turbomodule/core
   - FBLazyVector (0.67.3)
   - FBReactNativeSpec (0.67.3):
     - RCT-Folly (= 2021.06.28.00-v2)
@@ -860,15 +859,15 @@ SPEC CHECKSUMS:
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
   EXApplication: 54fe5bd6268d697771645e8f1aef8b806a65247a
   EXBarCodeScanner: e5ca0062d8ad1c4c1d2e386d6a308d5a32213020
-  EXCamera: 4a0d00d6d1e4703c31a75514d8bc804a2eab27bd
-  EXConstants: 88bf79622fbd9b476c96d8ec57fe97ca44fe8e3c
+  EXCamera: 03d69135ceb6f5f18f37b63eddb63d7643b65c42
+  EXConstants: 6d585d93723b18d7a8c283591a335609e3bc153e
   EXErrorRecovery: b0d7582714a2cc896e94a2308a356f94dbf14ef7
-  EXFileSystem: 08a3033ac372b6346becf07839e1ccef26fb1058
+  EXFileSystem: 99aac7962c11c680681819dd9cbca24e20e5b1e7
   EXFont: 2597c10ac85a69d348d44d7873eccf5a7576ef5e
   EXImageLoader: 347b72c2ec2df65120ccec40ea65a4c4f24317ff
   EXKeepAwake: bf48d7f740a5cd2befed6cf9a49911d385c6c47d
-  Expo: 534e51e607aba8229293297da5585f4b26f50fa1
-  ExpoModulesCore: 32c0ccb47f477d330ee93db72505380adf0de09a
+  Expo: d9588796cd19999da4d440d87bf7eb7ae4dbd608
+  ExpoModulesCore: c9438f6add0fb7b04b7c64eb97a833d2752a7834
   FBLazyVector: 808f741ddb0896a20e5b98cc665f5b3413b072e2
   FBReactNativeSpec: 94473205b8741b61402e8c51716dea34aa3f5b2f
   Firebase: 44dd9724c84df18b486639e874f31436eaa9a20c

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -24,10 +24,7 @@ type Props = {
   id?: string;
   type: AlertType;
   children: React.ReactNode;
-  left?: React.ReactNode;
-  bottom?: React.ReactNode;
   title?: string;
-  vertical?: boolean;
   noIcon?: boolean;
   onLearnMore?: () => any;
   learnMoreKey?: string;
@@ -70,12 +67,12 @@ function getAlertProps(type: AlertType) {
       icon: Icons.ShieldSecurityMedium,
     },
     danger: {
-      type: "warning",
+      type: "error",
       icon: Icons.ShieldSecurityMedium,
     },
     update: {
-      type: "",
-      icon: null,
+      type: "warning",
+      icon: Icons.WarningMedium,
     },
   }[type];
 }
@@ -86,7 +83,6 @@ export default function Alert(props: Props) {
     type = "secondary",
     children: description,
     title,
-    vertical,
     noIcon,
     onLearnMore,
     learnMoreUrl,
@@ -117,7 +113,6 @@ export default function Alert(props: Props) {
 
   const learnMore = hasLearnMore && (
     <Text onPress={handleLearnMore}>
-      {" "}
       <Text style={[styles.learnMore]} fontSize={3}>
         <Trans i18nKey={learnMoreKey || "common.learnMore"} />
       </Text>
@@ -135,29 +130,19 @@ export default function Alert(props: Props) {
     id,
   ]);
 
-  if (type === "update") return <OldAlert {...props} />;
-
   /** TODO:
    * - cleanup styles
    * - use latest version of lib UI with customizable icon
-   * - implement proper design for learnMore link https://www.figma.com/file/wGzwuUVo0rkCJ3sM8cpbDY/LLM-%2F-Library?node-id=5913%3A67123
+   * - implement proper design for learnMore link using UI lib https://www.figma.com/file/wGzwuUVo0rkCJ3sM8cpbDY/LLM-%2F-Library?node-id=5913%3A67123
    */
 
   return (
     !isDismissed && (
       <BaseAlert {...alertProps}>
         <View style={[styles.root]}>
-          <View style={[styles.container, vertical && styles.vertical]}>
-            <View style={vertical ? styles.verticalContent : styles.content}>
-              {title ? (
-                <Text style={[vertical && styles.textCentered]}>{title}</Text>
-              ) : null}
-              <Text style={[vertical && styles.textCentered]}>
-                <Text fontSize={3}>{description}</Text>
-                {learnMore}
-              </Text>
-            </View>
-          </View>
+          {title ? <Text>{title}</Text> : null}
+          <Text fontSize={3}>{description}</Text>
+          <Text>{learnMore}</Text>
         </View>
       </BaseAlert>
     )
@@ -168,25 +153,8 @@ const styles = StyleSheet.create({
   root: {
     width: "100%",
     flexDirection: "column",
-  },
-  container: {
-    flexDirection: "row",
-    alignItems: "center",
-  },
-  vertical: {
-    width: "100%",
-    flexDirection: "column",
-  },
-  content: {
     flex: 1,
     alignItems: "flex-start",
-  },
-  verticalContent: {
-    flex: 0,
-    alignItems: "center",
-  },
-  textCentered: {
-    textAlign: "center",
   },
   learnMore: {
     textDecorationLine: "underline",

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -176,34 +176,32 @@ export default function Alert(props: Props) {
     id,
   ]);
 
-  return (
-    !isDismissed ? (
-      <BaseAlert
-        {...alertProps}
-        renderContent={({ textColor }) => (
-          <Container>
-            {title && <StyledText color={textColor}>{title}</StyledText>}
-            {description && (
-              <StyledText
-                mt={title ? "6px" : undefined}
-                mb={hasLearnMore ? "6px" : undefined}
-                color={textColor}
-              >
-                {description}
-              </StyledText>
-            )}
-            {hasLearnMore && (
-              <LearnMoreLink
-                color={textColor}
-                onPress={handleLearnMore}
-                learnMoreKey={learnMoreKey}
-                learnMoreIsInternal={learnMoreIsInternal}
-                Icon={learnMoreIcon}
-              />
-            )}
-          </Container>
-        )}
-      />
-    ): null 
-  );
+  return !isDismissed ? (
+    <BaseAlert
+      {...alertProps}
+      renderContent={({ textColor }) => (
+        <Container>
+          {title && <StyledText color={textColor}>{title}</StyledText>}
+          {description && (
+            <StyledText
+              mt={title ? "6px" : undefined}
+              mb={hasLearnMore ? "6px" : undefined}
+              color={textColor}
+            >
+              {description}
+            </StyledText>
+          )}
+          {hasLearnMore && (
+            <LearnMoreLink
+              color={textColor}
+              onPress={handleLearnMore}
+              learnMoreKey={learnMoreKey}
+              learnMoreIsInternal={learnMoreIsInternal}
+              Icon={learnMoreIcon}
+            />
+          )}
+        </Container>
+      )}
+    />
+  ) : null;
 }

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -2,8 +2,9 @@ import React, { useCallback, useMemo } from "react";
 import { Trans } from "react-i18next";
 import { Linking, TouchableOpacity } from "react-native";
 import { useSelector } from "react-redux";
-import { Icons, Text, Alert as BaseAlert, Flex } from "@ledgerhq/native-ui";
 import styled from "styled-components/native";
+import { Icons, Text, Alert as BaseAlert, Flex } from "@ledgerhq/native-ui";
+import { AlertProps as BaseAlertProps } from "@ledgerhq/native-ui/components/message/Alert";
 import { dismissedBannersSelector } from "../reducers/settings";
 
 type AlertType =
@@ -18,6 +19,8 @@ type AlertType =
   | "danger"
   | "update";
 
+type IconType = React.ComponentType<{ size: number; color: string }>;
+
 type Props = {
   id?: string;
   type: AlertType;
@@ -31,52 +34,54 @@ type Props = {
   learnMoreIcon?: IconType;
 };
 
-function getAlertProps(type: AlertType) {
-  return {
-    primary: {
-      type: "info",
-      Icon: Icons.InfoMedium,
-    },
-    secondary: {
-      type: "info",
-      Icon: Icons.InfoMedium,
-    },
-    success: {
-      type: "info",
-      Icon: Icons.CircledCheckMedium,
-    },
-    warning: {
-      type: "warning",
-      Icon: Icons.CircledAlertMedium,
-    },
-    error: {
-      type: "error",
-      Icon: Icons.CircledCrossMedium,
-    },
-    hint: {
-      type: "info",
-      Icon: Icons.LightbulbMedium,
-    },
-    security: {
-      type: "warning",
-      Icon: Icons.ShieldSecurityMedium,
-    },
-    help: {
-      type: "info",
-      Icon: Icons.ShieldSecurityMedium,
-    },
-    danger: {
-      type: "error",
-      Icon: Icons.ShieldSecurityMedium,
-    },
-    update: {
-      type: "warning",
-      Icon: Icons.WarningMedium,
-    },
-  }[type];
-}
-
-type IconType = React.ComponentType<{ size: number; color: string }>;
+const alertPropsByType: Record<
+  AlertType,
+  {
+    type: BaseAlertProps["type"];
+    Icon: BaseAlertProps["Icon"];
+  }
+> = {
+  primary: {
+    type: "info",
+    Icon: Icons.InfoMedium,
+  },
+  secondary: {
+    type: "info",
+    Icon: Icons.InfoMedium,
+  },
+  success: {
+    type: "info",
+    Icon: Icons.CircledCheckMedium,
+  },
+  warning: {
+    type: "warning",
+    Icon: Icons.CircledAlertMedium,
+  },
+  error: {
+    type: "error",
+    Icon: Icons.CircledCrossMedium,
+  },
+  hint: {
+    type: "info",
+    Icon: Icons.LightbulbMedium,
+  },
+  security: {
+    type: "warning",
+    Icon: Icons.ShieldSecurityMedium,
+  },
+  help: {
+    type: "info",
+    Icon: Icons.ShieldSecurityMedium,
+  },
+  danger: {
+    type: "error",
+    Icon: Icons.ShieldSecurityMedium,
+  },
+  update: {
+    type: "warning",
+    Icon: Icons.WarningMedium,
+  },
+};
 
 type LearnMoreLinkProps = {
   color: string;
@@ -149,7 +154,7 @@ export default function Alert(props: Props) {
 
   const alertProps = useMemo(
     () => ({
-      ...getAlertProps(type),
+      ...alertPropsByType[type],
       showIcon: !noIcon,
     }),
     [type, noIcon],

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,0 +1,195 @@
+import React, { useCallback, useMemo } from "react";
+import { Trans } from "react-i18next";
+import { StyleSheet, View, Linking } from "react-native";
+import { useSelector } from "react-redux";
+import { Icons, Text, Alert as BaseAlert } from "@ledgerhq/native-ui";
+import OldAlert from "./Alert.js";
+import { dismissedBannersSelector } from "../reducers/settings";
+
+import IconExternalLink from "../icons/ExternalLink";
+
+type AlertType =
+  | "primary"
+  | "secondary"
+  | "success"
+  | "warning"
+  | "error"
+  | "hint"
+  | "security"
+  | "help"
+  | "danger"
+  | "update";
+
+type Props = {
+  id?: string;
+  type: AlertType;
+  children: React.ReactNode;
+  left?: React.ReactNode;
+  bottom?: React.ReactNode;
+  title?: string;
+  vertical?: boolean;
+  noIcon?: boolean;
+  onLearnMore?: () => any;
+  learnMoreKey?: string;
+  learnMoreUrl?: string;
+  learnMoreIsInternal?: boolean;
+};
+
+function getAlertProps(type: AlertType) {
+  return {
+    primary: {
+      type: "info",
+      icon: Icons.InfoMedium,
+    },
+    secondary: {
+      type: "info",
+      icon: Icons.InfoMedium,
+    },
+    success: {
+      type: "info",
+      icon: Icons.CircledCheckMedium,
+    },
+    warning: {
+      type: "warning",
+      icon: Icons.CircledAlertMedium,
+    },
+    error: {
+      type: "error",
+      icon: Icons.CircledCrossMedium,
+    },
+    hint: {
+      type: "info",
+      icon: Icons.LightbulbMedium,
+    },
+    security: {
+      type: "warning",
+      icon: Icons.ShieldSecurityMedium,
+    },
+    help: {
+      type: "info",
+      icon: Icons.ShieldSecurityMedium,
+    },
+    danger: {
+      type: "warning",
+      icon: Icons.ShieldSecurityMedium,
+    },
+    update: {
+      type: "",
+      icon: null,
+    },
+  }[type];
+}
+
+export default function Alert(props: Props) {
+  const {
+    id,
+    type = "secondary",
+    children: description,
+    title,
+    vertical,
+    noIcon,
+    onLearnMore,
+    learnMoreUrl,
+    learnMoreKey,
+    learnMoreIsInternal = false,
+  } = props;
+
+  const dismissedBanners = useSelector(dismissedBannersSelector);
+
+  const alertProps = useMemo(
+    () => ({
+      ...getAlertProps(type),
+      showIcon: !noIcon,
+    }),
+    [type, noIcon],
+  );
+
+  const hasLearnMore = !!onLearnMore || !!learnMoreUrl;
+  const handleLearnMore = useCallback(
+    () =>
+      onLearnMore
+        ? onLearnMore()
+        : learnMoreUrl
+        ? Linking.openURL(learnMoreUrl)
+        : undefined,
+    [onLearnMore, learnMoreUrl],
+  );
+
+  const learnMore = hasLearnMore && (
+    <Text onPress={handleLearnMore}>
+      {" "}
+      <Text style={[styles.learnMore]} fontSize={3}>
+        <Trans i18nKey={learnMoreKey || "common.learnMore"} />
+      </Text>
+      {!learnMoreIsInternal && (
+        <>
+          {" "}
+          <IconExternalLink size={12} />
+        </>
+      )}
+    </Text>
+  );
+
+  const isDismissed = useMemo(() => dismissedBanners.includes(id), [
+    dismissedBanners,
+    id,
+  ]);
+
+  if (type === "update") return <OldAlert {...props} />;
+
+  /** TODO:
+   * - cleanup styles
+   * - use latest version of lib UI with customizable icon
+   * - implement proper design for learnMore link https://www.figma.com/file/wGzwuUVo0rkCJ3sM8cpbDY/LLM-%2F-Library?node-id=5913%3A67123
+   */
+
+  return (
+    !isDismissed && (
+      <BaseAlert {...alertProps}>
+        <View style={[styles.root]}>
+          <View style={[styles.container, vertical && styles.vertical]}>
+            <View style={vertical ? styles.verticalContent : styles.content}>
+              {title ? (
+                <Text style={[vertical && styles.textCentered]}>{title}</Text>
+              ) : null}
+              <Text style={[vertical && styles.textCentered]}>
+                <Text fontSize={3}>{description}</Text>
+                {learnMore}
+              </Text>
+            </View>
+          </View>
+        </View>
+      </BaseAlert>
+    )
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    width: "100%",
+    flexDirection: "column",
+  },
+  container: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  vertical: {
+    width: "100%",
+    flexDirection: "column",
+  },
+  content: {
+    flex: 1,
+    alignItems: "flex-start",
+  },
+  verticalContent: {
+    flex: 0,
+    alignItems: "center",
+  },
+  textCentered: {
+    textAlign: "center",
+  },
+  learnMore: {
+    textDecorationLine: "underline",
+    marginTop: 8,
+  },
+});

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -177,7 +177,7 @@ export default function Alert(props: Props) {
   ]);
 
   return (
-    !isDismissed && (
+    !isDismissed ? (
       <BaseAlert
         {...alertProps}
         renderContent={({ textColor }) => (
@@ -204,6 +204,6 @@ export default function Alert(props: Props) {
           </Container>
         )}
       />
-    )
+    ): null 
   );
 }

--- a/src/components/DeviceAction/getDeviceAnimation.js
+++ b/src/components/DeviceAction/getDeviceAnimation.js
@@ -84,8 +84,8 @@ const animations = {
     },
     bluetooth: {
       plugAndPinCode: {
-        light: null,
-        dark: null,
+        light: require("../../animations/nanoX/bluetooth/3EnterPinCode/light.json"),
+        dark: require("../../animations/nanoX/bluetooth/3EnterPinCode/dark.json"),
       },
       enterPinCode: {
         light: require("../../animations/nanoX/bluetooth/3EnterPinCode/light.json"),

--- a/src/components/DeviceAction/rendering.tsx
+++ b/src/components/DeviceAction/rendering.tsx
@@ -6,7 +6,7 @@ import { WrongDeviceForAccount, UnexpectedBootloader } from "@ledgerhq/errors";
 import { TokenCurrency } from "@ledgerhq/live-common/lib/types";
 import { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import { AppRequest } from "@ledgerhq/live-common/lib/hw/actions/app";
-import { InfiniteLoader, Text, Flex } from "@ledgerhq/native-ui";
+import { InfiniteLoader, Text, Flex, Tag, Icons } from "@ledgerhq/native-ui";
 import { setModalLock } from "../../actions/appstate";
 import { urls } from "../../config/urls";
 import Alert from "../Alert";
@@ -68,9 +68,8 @@ const DescriptionText = styled(CenteredText).attrs({
   color: "neutral.c70",
 })``;
 
-const ConnectDeviceNameText = styled(CenteredText).attrs({
-  marginBottom: "8px",
-  fontSize: "15px",
+const ConnectDeviceNameText = styled(Tag).attrs({
+  my: "8",
 })``;
 
 const ConnectDeviceLabelText = styled(CenteredText).attrs({
@@ -434,6 +433,7 @@ export function renderConnectYourDevice({
         <ConnectDeviceExtraContentWrapper>
           <ExternalLink
             text={t("DeviceAction.useAnotherDevice")}
+            Icon={Icons.ArrowRightMedium}
             onPress={onSelectDeviceLink}
           />
         </ConnectDeviceExtraContentWrapper>

--- a/src/components/DeviceAction/rendering.tsx
+++ b/src/components/DeviceAction/rendering.tsx
@@ -1,0 +1,583 @@
+import React, { useEffect } from "react";
+import { View, StyleSheet } from "react-native";
+import { useDispatch } from "react-redux";
+import Icon from "react-native-vector-icons/dist/Feather";
+import { WrongDeviceForAccount, UnexpectedBootloader } from "@ledgerhq/errors";
+import { TokenCurrency } from "@ledgerhq/live-common/lib/types";
+import { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
+import { AppRequest } from "@ledgerhq/live-common/lib/hw/actions/app";
+import { setModalLock } from "../../actions/appstate";
+import { urls } from "../../config/urls";
+import LText from "../LText";
+import Alert from "../Alert";
+import getWindowDimensions from "../../logic/getWindowDimensions";
+import Spinning from "../Spinning";
+import BigSpinner from "../../icons/BigSpinner";
+import { lighten } from "../../colors";
+import Button from "../Button";
+import { NavigatorName, ScreenName } from "../../const";
+import Animation from "../Animation";
+import getDeviceAnimation from "./getDeviceAnimation";
+import GenericErrorView from "../GenericErrorView";
+import Circle from "../Circle";
+import { MANAGER_TABS } from "../../screens/Manager/Manager";
+import ExternalLink from "../ExternalLink";
+import { track } from "../../analytics";
+import BigSpinner from "../../icons/BigSpinner";
+import Spinning from "../Spinning";
+
+type RawProps = {
+  t: (key: string, options?: { [key: string]: string | number }) => string;
+  colors?: any;
+  theme?: "light" | "dark";
+};
+
+export function renderRequestQuitApp({
+  t,
+  device,
+  theme,
+}: RawProps & {
+  device: Device;
+}) {
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.animationContainer}>
+        <Animation
+          source={getDeviceAnimation({ device, key: "quitApp", theme })}
+        />
+      </View>
+      <LText style={styles.text} semiBold>
+        {t("DeviceAction.quitApp")}
+      </LText>
+    </View>
+  );
+}
+
+export function renderRequiresAppInstallation({
+  t,
+  navigation,
+  appNames,
+}: RawProps & {
+  navigation: any;
+  appNames: string[];
+}) {
+  const appNamesCSV = appNames.join(", ");
+
+  return (
+    <View style={styles.wrapper}>
+      <LText style={styles.text} semiBold>
+        {t("DeviceAction.appNotInstalled", {
+          appName: appNamesCSV,
+          count: appNames.length,
+        })}
+      </LText>
+      <View style={styles.actionContainer}>
+        <Button
+          event="DeviceActionRequiresAppInstallationOpenManager"
+          type="primary"
+          title={t("DeviceAction.button.openManager")}
+          onPress={() =>
+            navigation.navigate(NavigatorName.Manager, {
+              screen: ScreenName.Manager,
+              params: { searchQuery: appNamesCSV },
+            })
+          }
+          containerStyle={styles.button}
+        />
+      </View>
+    </View>
+  );
+}
+
+export function renderVerifyAddress({
+  t,
+  device,
+  currencyName,
+  onPress,
+  address,
+  theme,
+}: RawProps & {
+  device: Device;
+  currencyName: string;
+  onPress?: () => void;
+  address?: string;
+}) {
+  return (
+    <View style={styles.wrapper}>
+      <View
+        style={[
+          styles.animationContainer,
+          device.modelId !== "blue" ? styles.verifyAddress : undefined,
+        ]}
+      >
+        <Animation
+          source={getDeviceAnimation({ device, key: "validate", theme })}
+        />
+      </View>
+      <LText style={[styles.text, styles.title]} semiBold>
+        {t("DeviceAction.verifyAddress.title")}
+      </LText>
+      <LText style={[styles.text, styles.description]} color="grey">
+        {t("DeviceAction.verifyAddress.description", { currencyName })}
+      </LText>
+      <View style={styles.actionContainer}>
+        {onPress && (
+          <Button
+            event="DeviceActionVerifyAddress"
+            type="primary"
+            title={t("common.continue")}
+            onPress={onPress}
+            containerStyle={styles.button}
+          />
+        )}
+        {address && (
+          <View>
+            <LText bold style={[styles.text, styles.title]}>
+              {address}
+            </LText>
+          </View>
+        )}
+      </View>
+    </View>
+  );
+}
+
+export function renderConfirmSwap({
+  t,
+  device,
+  theme,
+}: RawProps & {
+  device: Device;
+}) {
+  return (
+    <View style={[styles.wrapper, { width: "100%" }]}>
+      <Alert type="primary" learnMoreUrl={urls.swap.learnMore}>
+        {t("DeviceAction.confirmSwap.alert")}
+      </Alert>
+      <View
+        style={[
+          { marginTop: 16 },
+          styles.animationContainer,
+          device.modelId !== "blue" ? styles.verifyAddress : undefined,
+        ]}
+      >
+        <Animation
+          source={getDeviceAnimation({ device, key: "validate", theme })}
+        />
+      </View>
+      <LText style={[styles.text, styles.title]} semiBold>
+        {t("DeviceAction.confirmSwap.title")}
+      </LText>
+    </View>
+  );
+}
+
+export function renderConfirmSell({
+  t,
+  device,
+}: RawProps & {
+  device: Device;
+}) {
+  return (
+    <View style={styles.wrapper}>
+      <Alert type="primary" learnMoreUrl={urls.swap.learnMore}>
+        {t("DeviceAction.confirmSell.alert")}
+      </Alert>
+      <View
+        style={[
+          { marginTop: 16 },
+          styles.animationContainer,
+          device.modelId !== "blue" ? styles.verifyAddress : undefined,
+        ]}
+      >
+        <Animation source={getDeviceAnimation({ device, key: "validate" })} />
+      </View>
+      <LText style={[styles.text, styles.title]} semiBold>
+        {t("DeviceAction.confirmSell.title")}
+      </LText>
+    </View>
+  );
+}
+
+export function renderAllowManager({
+  t,
+  wording,
+  device,
+  theme,
+}: RawProps & {
+  wording: string;
+  device: Device;
+}) {
+  // TODO: disable gesture, modal close, hide header buttons
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.animationContainer}>
+        <Animation
+          source={getDeviceAnimation({ device, key: "allowManager", theme })}
+        />
+      </View>
+      <LText style={styles.text} semiBold>
+        {t("DeviceAction.allowManagerPermission", { wording })}
+      </LText>
+    </View>
+  );
+}
+
+const AllowOpeningApp = ({
+  t,
+  navigation,
+  wording,
+  tokenContext,
+  isDeviceBlocker,
+  device,
+  theme,
+}: RawProps & {
+  navigation: any;
+  wording: string;
+  tokenContext?: TokenCurrency | null | undefined;
+  isDeviceBlocker?: boolean;
+  device: Device;
+}) => {
+  useEffect(() => {
+    if (isDeviceBlocker) {
+      // TODO: disable gesture, modal close, hide header buttons
+      navigation.setOptions({
+        gestureEnabled: false,
+      });
+    }
+  }, [isDeviceBlocker, navigation]);
+
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.animationContainer}>
+        <Animation
+          source={getDeviceAnimation({ device, key: "openApp", theme })}
+        />
+      </View>
+      <LText style={styles.text} semiBold>
+        {t("DeviceAction.allowAppPermission", { wording })}
+      </LText>
+      {tokenContext ? (
+        <LText style={styles.text} semiBold>
+          {t("DeviceAction.allowAppPermissionSubtitleToken", {
+            token: tokenContext.name,
+          })}
+        </LText>
+      ) : null}
+    </View>
+  );
+};
+
+export function renderAllowOpeningApp({
+  t,
+  navigation,
+  wording,
+  tokenContext,
+  isDeviceBlocker,
+  device,
+  theme,
+}: RawProps & {
+  navigation: any;
+  wording: string;
+  tokenContext?: TokenCurrency | undefined | null;
+  isDeviceBlocker?: boolean;
+  device: Device;
+}) {
+  return (
+    <AllowOpeningApp
+      t={t}
+      navigation={navigation}
+      wording={wording}
+      tokenContext={tokenContext}
+      isDeviceBlocker={isDeviceBlocker}
+      device={device}
+      theme={theme}
+    />
+  );
+}
+
+export function renderInWrongAppForAccount({
+  t,
+  onRetry,
+  colors,
+  theme,
+}: RawProps & {
+  onRetry?: () => void;
+}) {
+  return renderError({
+    t,
+    error: new WrongDeviceForAccount(),
+    onRetry,
+    colors,
+    theme,
+  });
+}
+
+export function renderError({
+  t,
+  error,
+  onRetry,
+  managerAppName,
+  navigation,
+}: RawProps & {
+  navigation?: any;
+  error: Error;
+  onRetry?: () => void;
+  managerAppName?: string;
+}) {
+  const onPress = () => {
+    if (managerAppName && navigation) {
+      navigation.navigate(NavigatorName.Manager, {
+        screen: ScreenName.Manager,
+        params: {
+          tab: MANAGER_TABS.INSTALLED_APPS,
+          updateModalOpened: true,
+        },
+      });
+    } else if (onRetry) {
+      onRetry();
+    }
+  };
+  return (
+    <View style={styles.wrapper}>
+      <GenericErrorView error={error} withDescription withIcon />
+      {onRetry || managerAppName ? (
+        <View style={styles.actionContainer}>
+          <Button
+            event="DeviceActionErrorRetry"
+            type="primary"
+            title={
+              managerAppName
+                ? t("DeviceAction.button.openManager")
+                : t("common.retry")
+            }
+            onPress={onPress}
+            containerStyle={styles.button}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export function renderConnectYourDevice({
+  t,
+  unresponsive,
+  device,
+  theme,
+  onSelectDeviceLink,
+}: RawProps & {
+  unresponsive: boolean;
+  device: Device;
+  onSelectDeviceLink?: () => void;
+}) {
+  return (
+    <View style={styles.wrapper}>
+      <View
+        style={[
+          styles.animationContainer,
+          device.modelId !== "blue" ? styles.connectDeviceContainer : undefined,
+        ]}
+      >
+        <Animation
+          source={getDeviceAnimation({
+            device,
+            key: unresponsive ? "enterPinCode" : "plugAndPinCode",
+            theme,
+          })}
+        />
+      </View>
+      {device.deviceName && (
+        <LText style={[styles.text, styles.connectDeviceName]} semiBold>
+          {device.deviceName}
+        </LText>
+      )}
+      <LText style={[styles.text, styles.connectDeviceLabel]} semiBold>
+        {t(
+          unresponsive
+            ? "DeviceAction.unlockDevice"
+            : device.wired
+            ? "DeviceAction.connectAndUnlockDevice"
+            : "DeviceAction.turnOnAndUnlockDevice",
+        )}
+      </LText>
+      {onSelectDeviceLink ? (
+        <View style={styles.connectDeviceExtraContentWrapper}>
+          <ExternalLink
+            text={t("DeviceAction.useAnotherDevice")}
+            onPress={onSelectDeviceLink}
+          />
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+export function renderLoading({
+  t,
+  description,
+}: RawProps & {
+  description?: string;
+}) {
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.spinnerContainer}>
+        <Spinning clockwise>
+          <BigSpinner />
+        </Spinning>
+      </View>
+      <LText semiBold style={styles.text}>
+        {description ?? t("DeviceAction.loading")}
+      </LText>
+    </View>
+  );
+}
+
+export function LoadingAppInstall({
+  analyticsPropertyFlow = "unknown",
+  request,
+  ...props
+}: RawProps & {
+  analyticsPropertyFlow: string;
+  description?: string;
+  request?: AppRequest;
+}) {
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    // Nb Blocks closing the modal while the install is happening.
+    // releases the block on onmount.
+    dispatch(setModalLock(true));
+    return () => {
+      dispatch(setModalLock(false));
+    };
+  }, [dispatch]);
+
+  const currency = request?.currency || request?.account?.currency;
+  const appName = request?.appName || currency?.managerAppName;
+  useEffect(() => {
+    const trackingArgs = [
+      "In-line app install",
+      { appName, flow: analyticsPropertyFlow },
+    ];
+    track(...trackingArgs);
+  }, [appName, analyticsPropertyFlow]);
+  return renderLoading(props);
+}
+
+type WarningOutdatedProps = RawProps & {
+  colors: any;
+  navigation: any;
+  appName: string;
+  passWarning: () => void;
+};
+
+export function renderWarningOutdated({
+  t,
+  navigation,
+  appName,
+  passWarning,
+  colors,
+}: WarningOutdatedProps) {
+  function onOpenManager() {
+    navigation.navigate(NavigatorName.Manager);
+  }
+
+  return (
+    <View style={styles.wrapper}>
+      <View style={styles.iconContainer}>
+        <Circle size={60} bg={lighten(colors.yellow, 0.4)}>
+          <Icon size={28} name="alert-triangle" color={colors.yellow} />
+        </Circle>
+      </View>
+
+      <LText style={[styles.text, styles.title]} bold>
+        {t("DeviceAction.outdated")}
+      </LText>
+      <LText style={[styles.text, styles.description]} semiBold color="grey">
+        {t("DeviceAction.outdatedDesc", { appName })}
+      </LText>
+      <View style={styles.actionContainer}>
+        <Button
+          event="DeviceActionWarningOutdatedOpenManager"
+          type="primary"
+          title={t("DeviceAction.button.openManager")}
+          onPress={onOpenManager}
+          containerStyle={styles.button}
+        />
+        <Button
+          event="DeviceActionWarningOutdatedContinue"
+          type="secondary"
+          title={t("common.continue")}
+          onPress={passWarning}
+          outline={false}
+          containerStyle={styles.button}
+        />
+      </View>
+    </View>
+  );
+}
+
+export function renderBootloaderStep({ t, colors, theme }: RawProps) {
+  return renderError({
+    t,
+    error: new UnexpectedBootloader(),
+    colors,
+    theme,
+  });
+}
+
+const styles = StyleSheet.create({
+  wrapper: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 160,
+  },
+  anim: {
+    width: getWindowDimensions().width - 2 * 16,
+  },
+  text: {
+    textAlign: "center",
+  },
+  iconContainer: {
+    margin: 16,
+  },
+  title: {
+    padding: 8,
+    fontSize: 16,
+  },
+  description: {
+    padding: 8,
+  },
+  spinnerContainer: {
+    padding: 24,
+  },
+  button: {
+    margin: 8,
+  },
+  actionContainer: {
+    alignSelf: "stretch",
+  },
+  animationContainer: {
+    alignSelf: "stretch",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  connectDeviceContainer: {
+    height: 100,
+  },
+  connectDeviceName: {
+    marginBottom: 8,
+    fontSize: 15,
+  },
+  connectDeviceLabel: {
+    fontSize: 20,
+  },
+  verifyAddress: {
+    height: 72,
+  },
+  connectDeviceExtraContentWrapper: {
+    marginTop: 36,
+  },
+});

--- a/src/components/DeviceAction/rendering.tsx
+++ b/src/components/DeviceAction/rendering.tsx
@@ -48,7 +48,7 @@ const SpinnerContainer = styled(Flex).attrs({
 })``;
 
 const IconContainer = styled(Flex).attrs({
-  margin: "16px",
+  margin: 6,
 })``;
 
 const CenteredText = styled(Text).attrs({
@@ -78,10 +78,8 @@ const ConnectDeviceLabelText = styled(CenteredText).attrs({
 })``;
 
 const StyledButton = styled(Button).attrs({
-  containerStyle: {
-    marginVertical: 8,
-    alignSelf: "stretch",
-  },
+  mt: 6,
+  alignSelf: "stretch",
 })``;
 
 const ConnectDeviceExtraContentWrapper = styled(Flex).attrs({
@@ -182,7 +180,7 @@ export function renderVerifyAddress({
           />
         )}
         {address && (
-          <Flex>
+          <Flex marginTop="16px">
             <TitleText fontWeight="bold">{address}</TitleText>
           </Flex>
         )}

--- a/src/components/DeviceAction/rendering.tsx
+++ b/src/components/DeviceAction/rendering.tsx
@@ -28,8 +28,6 @@ import { MANAGER_TABS } from "../../screens/Manager/Manager";
 import ExternalLink from "../ExternalLink";
 import { track } from "../../analytics";
 
-// const Animation = () => null;
-
 const Wrapper = styled(Flex).attrs({
   flex: 1,
   alignItems: "center",
@@ -296,9 +294,7 @@ const AllowOpeningApp = ({
           source={getDeviceAnimation({ device, key: "openApp", theme })}
         />
       </AnimationContainer>
-      <TitleText>
-        {t("DeviceAction.allowAppPermission", { wording })}
-      </TitleText>
+      <TitleText>{t("DeviceAction.allowAppPermission", { wording })}</TitleText>
       {tokenContext ? (
         <CenteredText>
           {t("DeviceAction.allowAppPermissionSubtitleToken", {

--- a/src/components/DeviceAction/rendering.tsx
+++ b/src/components/DeviceAction/rendering.tsx
@@ -23,8 +23,6 @@ import Circle from "../Circle";
 import { MANAGER_TABS } from "../../screens/Manager/Manager";
 import ExternalLink from "../ExternalLink";
 import { track } from "../../analytics";
-import BigSpinner from "../../icons/BigSpinner";
-import Spinning from "../Spinning";
 
 type RawProps = {
   t: (key: string, options?: { [key: string]: string | number }) => string;

--- a/src/components/DeviceAction/rendering.tsx
+++ b/src/components/DeviceAction/rendering.tsx
@@ -6,7 +6,14 @@ import { WrongDeviceForAccount, UnexpectedBootloader } from "@ledgerhq/errors";
 import { TokenCurrency } from "@ledgerhq/live-common/lib/types";
 import { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import { AppRequest } from "@ledgerhq/live-common/lib/hw/actions/app";
-import { InfiniteLoader, Text, Flex, Tag, Icons } from "@ledgerhq/native-ui";
+import {
+  InfiniteLoader,
+  Text,
+  Flex,
+  Tag,
+  Icons,
+  Log,
+} from "@ledgerhq/native-ui";
 import { setModalLock } from "../../actions/appstate";
 import { urls } from "../../config/urls";
 import Alert from "../Alert";
@@ -20,6 +27,8 @@ import Circle from "../Circle";
 import { MANAGER_TABS } from "../../screens/Manager/Manager";
 import ExternalLink from "../ExternalLink";
 import { track } from "../../analytics";
+
+// const Animation = () => null;
 
 const Wrapper = styled(Flex).attrs({
   flex: 1,
@@ -56,10 +65,15 @@ const CenteredText = styled(Text).attrs({
   textAlign: "center",
 })``;
 
-const TitleText = styled(CenteredText).attrs({
-  py: "8px",
-  variant: "h2",
+const TitleContainer = styled(Flex).attrs({
+  py: 8,
 })``;
+
+const TitleText = ({ children }: { children: React.ReactNode }) => (
+  <TitleContainer>
+    <Log>{children}</Log>
+  </TitleContainer>
+);
 
 const DescriptionText = styled(CenteredText).attrs({
   variant: "bodyLineHeight",
@@ -72,17 +86,13 @@ const ConnectDeviceNameText = styled(Tag).attrs({
   my: "8",
 })``;
 
-const ConnectDeviceLabelText = styled(CenteredText).attrs({
-  variant: "h2",
-})``;
-
 const StyledButton = styled(Button).attrs({
   mt: 6,
   alignSelf: "stretch",
 })``;
 
 const ConnectDeviceExtraContentWrapper = styled(Flex).attrs({
-  marginTop: "36px",
+  mb: 8,
 })``;
 
 type RawProps = {
@@ -178,11 +188,7 @@ export function renderVerifyAddress({
             onPress={onPress}
           />
         )}
-        {address && (
-          <Flex marginTop="16px">
-            <TitleText fontWeight="bold">{address}</TitleText>
-          </Flex>
-        )}
+        {address && <TitleText fontWeight="bold">{address}</TitleText>}
       </ActionContainer>
     </Wrapper>
   );
@@ -290,9 +296,9 @@ const AllowOpeningApp = ({
           source={getDeviceAnimation({ device, key: "openApp", theme })}
         />
       </AnimationContainer>
-      <CenteredText>
+      <TitleText>
         {t("DeviceAction.allowAppPermission", { wording })}
-      </CenteredText>
+      </TitleText>
       {tokenContext ? (
         <CenteredText>
           {t("DeviceAction.allowAppPermissionSubtitleToken", {
@@ -420,7 +426,7 @@ export function renderConnectYourDevice({
       {device.deviceName && (
         <ConnectDeviceNameText>{device.deviceName}</ConnectDeviceNameText>
       )}
-      <ConnectDeviceLabelText>
+      <TitleText>
         {t(
           unresponsive
             ? "DeviceAction.unlockDevice"
@@ -428,7 +434,7 @@ export function renderConnectYourDevice({
             ? "DeviceAction.connectAndUnlockDevice"
             : "DeviceAction.turnOnAndUnlockDevice",
         )}
-      </ConnectDeviceLabelText>
+      </TitleText>
       {onSelectDeviceLink ? (
         <ConnectDeviceExtraContentWrapper>
           <ExternalLink
@@ -515,7 +521,6 @@ export function renderWarningOutdated({
           <Icon size={28} name="alert-triangle" color={colors.yellow} />
         </Circle>
       </IconContainer>
-
       <TitleText fontWeight="bold">{t("DeviceAction.outdated")}</TitleText>
       <DescriptionText>
         {t("DeviceAction.outdatedDesc", { appName })}

--- a/src/components/DeviceAction/rendering.tsx
+++ b/src/components/DeviceAction/rendering.tsx
@@ -40,7 +40,7 @@ const AnimationContainer = styled(Flex).attrs(p => ({
   alignItems: "center",
   justifyContent: "center",
   height: p.withConnectDeviceHeight
-    ? "100px"
+    ? "100px"<Ti
     : p.withVerifyAddressHeight
     ? "72px"
     : undefined,
@@ -186,7 +186,7 @@ export function renderVerifyAddress({
             onPress={onPress}
           />
         )}
-        {address && <TitleText fontWeight="bold">{address}</TitleText>}
+        {address && <TitleText>{address}</TitleText>}
       </ActionContainer>
     </Wrapper>
   );
@@ -517,7 +517,7 @@ export function renderWarningOutdated({
           <Icon size={28} name="alert-triangle" color={colors.yellow} />
         </Circle>
       </IconContainer>
-      <TitleText fontWeight="bold">{t("DeviceAction.outdated")}</TitleText>
+      <TitleText>{t("DeviceAction.outdated")}</TitleText>
       <DescriptionText>
         {t("DeviceAction.outdatedDesc", { appName })}
       </DescriptionText>

--- a/src/components/DeviceActionModal.tsx
+++ b/src/components/DeviceActionModal.tsx
@@ -2,13 +2,10 @@ import React from "react";
 import { View, StyleSheet } from "react-native";
 import { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/lib/bridge/react";
-import { useTheme } from "@react-navigation/native";
+import { Alert } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import DeviceAction from "./DeviceAction";
 import BottomModal from "./BottomModal";
-import ModalBottomAction from "./ModalBottomAction";
-
-import InfoBox from "./InfoBox";
 
 type Props = {
   // TODO: fix action type
@@ -35,7 +32,6 @@ export default function DeviceActionModal({
   onSelectDeviceLink,
   analyticsPropertyFlow,
 }: Props) {
-  const { colors } = useTheme();
   const { t } = useTranslation();
   return (
     <BottomModal
@@ -45,29 +41,23 @@ export default function DeviceActionModal({
       onModalHide={onModalHide}
     >
       {device && (
-        <ModalBottomAction
-          footer={
-            <View>
-              <View style={styles.footerContainer}>
-                <DeviceAction
-                  action={action}
-                  device={device}
-                  request={request}
-                  onClose={onClose}
-                  onResult={onResult}
-                  renderOnResult={renderOnResult}
-                  onSelectDeviceLink={onSelectDeviceLink}
-                  analyticsPropertyFlow={analyticsPropertyFlow}
-                />
-              </View>
-              {!device.wired ? (
-                <InfoBox forceColor={{ text: colors.live }}>
-                  {t("DeviceAction.stayInTheAppPlz")}
-                </InfoBox>
-              ) : null}
-            </View>
-          }
-        />
+        <View>
+          <View style={styles.footerContainer}>
+            <DeviceAction
+              action={action}
+              device={device}
+              request={request}
+              onClose={onClose}
+              onResult={onResult}
+              renderOnResult={renderOnResult}
+              onSelectDeviceLink={onSelectDeviceLink}
+              analyticsPropertyFlow={analyticsPropertyFlow}
+            />
+          </View>
+          {!device.wired ? (
+            <Alert type="info" title={t("DeviceAction.stayInTheAppPlz")} />
+          ) : null}
+        </View>
       )}
       {device && <SyncSkipUnderPriority priority={100} />}
     </BottomModal>
@@ -78,10 +68,5 @@ const styles = StyleSheet.create({
   footerContainer: {
     flexDirection: "row",
     marginBottom: 10,
-  },
-  close: {
-    position: "absolute",
-    right: 16,
-    top: 16,
   },
 });

--- a/src/components/DeviceActionModal.tsx
+++ b/src/components/DeviceActionModal.tsx
@@ -1,11 +1,15 @@
 import React from "react";
-import { View, StyleSheet } from "react-native";
 import { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import { SyncSkipUnderPriority } from "@ledgerhq/live-common/lib/bridge/react";
-import { Alert } from "@ledgerhq/native-ui";
+import styled from "styled-components/native";
+import { Alert, Flex } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import DeviceAction from "./DeviceAction";
 import BottomModal from "./BottomModal";
+
+const DeviceActionContainer = styled(Flex).attrs({
+  flexDirection: "row",
+})``;
 
 type Props = {
   // TODO: fix action type
@@ -33,6 +37,7 @@ export default function DeviceActionModal({
   analyticsPropertyFlow,
 }: Props) {
   const { t } = useTranslation();
+  const showAlert = !device?.wired;
   return (
     <BottomModal
       id="DeviceActionModal"
@@ -41,8 +46,8 @@ export default function DeviceActionModal({
       onModalHide={onModalHide}
     >
       {device && (
-        <View>
-          <View style={styles.footerContainer}>
+        <Flex>
+          <DeviceActionContainer marginBottom={showAlert ? "16px" : 0}>
             <DeviceAction
               action={action}
               device={device}
@@ -53,20 +58,13 @@ export default function DeviceActionModal({
               onSelectDeviceLink={onSelectDeviceLink}
               analyticsPropertyFlow={analyticsPropertyFlow}
             />
-          </View>
-          {!device.wired ? (
+          </DeviceActionContainer>
+          {showAlert && (
             <Alert type="info" title={t("DeviceAction.stayInTheAppPlz")} />
-          ) : null}
-        </View>
+          )}
+        </Flex>
       )}
       {device && <SyncSkipUnderPriority priority={100} />}
     </BottomModal>
   );
 }
-
-const styles = StyleSheet.create({
-  footerContainer: {
-    flexDirection: "row",
-    marginBottom: 10,
-  },
-});

--- a/src/components/DeviceActionModal.tsx
+++ b/src/components/DeviceActionModal.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
+import { SyncSkipUnderPriority } from "@ledgerhq/live-common/lib/bridge/react";
+import { useTheme } from "@react-navigation/native";
+import { useTranslation } from "react-i18next";
+import DeviceAction from "./DeviceAction";
+import BottomModal from "./BottomModal";
+import ModalBottomAction from "./ModalBottomAction";
+
+import InfoBox from "./InfoBox";
+
+type Props = {
+  // TODO: fix action type
+  action: any;
+  device: Device | null | undefined;
+  // TODO: fix request type
+  request?: any;
+  onClose?: () => void;
+  onModalHide?: () => void;
+  onResult?: $PropertyType<React$ElementProps<typeof DeviceAction>, "onResult">;
+  renderOnResult?: (p: any) => React.ReactNode;
+  onSelectDeviceLink?: () => void;
+  analyticsPropertyFlow?: string;
+};
+
+export default function DeviceActionModal({
+  action,
+  device,
+  request,
+  onClose,
+  onResult,
+  renderOnResult,
+  onModalHide,
+  onSelectDeviceLink,
+  analyticsPropertyFlow,
+}: Props) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  return (
+    <BottomModal
+      id="DeviceActionModal"
+      isOpened={!!device}
+      onClose={onClose}
+      onModalHide={onModalHide}
+    >
+      {device && (
+        <ModalBottomAction
+          footer={
+            <View>
+              <View style={styles.footerContainer}>
+                <DeviceAction
+                  action={action}
+                  device={device}
+                  request={request}
+                  onClose={onClose}
+                  onResult={onResult}
+                  renderOnResult={renderOnResult}
+                  onSelectDeviceLink={onSelectDeviceLink}
+                  analyticsPropertyFlow={analyticsPropertyFlow}
+                />
+              </View>
+              {!device.wired ? (
+                <InfoBox forceColor={{ text: colors.live }}>
+                  {t("DeviceAction.stayInTheAppPlz")}
+                </InfoBox>
+              ) : null}
+            </View>
+          }
+        />
+      )}
+      {device && <SyncSkipUnderPriority priority={100} />}
+    </BottomModal>
+  );
+}
+
+const styles = StyleSheet.create({
+  footerContainer: {
+    flexDirection: "row",
+    marginBottom: 10,
+  },
+  close: {
+    position: "absolute",
+    right: 16,
+    top: 16,
+  },
+});

--- a/src/components/DeviceActionModal.tsx
+++ b/src/components/DeviceActionModal.tsx
@@ -19,7 +19,7 @@ type Props = {
   request?: any;
   onClose?: () => void;
   onModalHide?: () => void;
-  onResult?: $PropertyType<React$ElementProps<typeof DeviceAction>, "onResult">;
+  onResult?: (payload: any) => Promise<void> | void;
   renderOnResult?: (p: any) => React.ReactNode;
   onSelectDeviceLink?: () => void;
   analyticsPropertyFlow?: string;
@@ -52,7 +52,6 @@ export default function DeviceActionModal({
               action={action}
               device={device}
               request={request}
-              onClose={onClose}
               onResult={onResult}
               renderOnResult={renderOnResult}
               onSelectDeviceLink={onSelectDeviceLink}

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -47,5 +47,5 @@ export default function ExternalLink({
     >
       {text}
     </BaseLink>
-  );Pfix
+  );
 }

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,0 +1,50 @@
+import React, { useCallback } from "react";
+import { Icons, Link as BaseLink } from "@ledgerhq/native-ui";
+import { LinkProps } from "@ledgerhq/native-ui/components/cta/Link";
+import { track } from "../analytics";
+
+type Props = {
+  disabled?: boolean;
+  event?: string;
+  eventProperties?: Object;
+  Icon?: React.ComponentType<{ color: string; size: number }>;
+  iconFirst?: boolean;
+  iconPosition?: LinkProps["iconPosition"];
+  onPress?: LinkProps["onPress"];
+  text: LinkProps["children"];
+  type?: LinkProps["type"];
+};
+
+export default function ExternalLink({
+  disabled,
+  event,
+  eventProperties,
+  Icon,
+  iconFirst,
+  iconPosition,
+  onPress,
+  text,
+  type,
+}: Props) {
+  const handlePress = useCallback(
+    nativeEvent => {
+      if (event) {
+        track(event, ...(eventProperties ? [eventProperties] : []));
+      }
+      onPress && onPress(nativeEvent);
+    },
+    [event, eventProperties, onPress],
+  );
+
+  return (
+    <BaseLink
+      disabled={disabled}
+      type={type || "color"}
+      Icon={Icon || Icons.ExternalLinkMedium}
+      iconPosition={iconPosition || (iconFirst ? "left" : "right")}
+      onPress={handlePress}
+    >
+      {text}
+    </BaseLink>
+  );Pfix
+}

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -8,6 +8,7 @@ type Props = {
   event?: string;
   eventProperties?: Object;
   Icon?: React.ComponentType<{ color: string; size: number }>;
+  /** deprecated, use `iconPosition` instead */
   iconFirst?: boolean;
   iconPosition?: LinkProps["iconPosition"];
   onPress?: LinkProps["onPress"];

--- a/src/components/GenericErrorView.tsx
+++ b/src/components/GenericErrorView.tsx
@@ -29,7 +29,7 @@ const GenericErrorView = ({
   const subtitleError = outerError ? error : null;
 
   return (
-    <Flex flexDirection={"column"} alignItems={"center"}>
+    <Flex flexDirection={"column"} alignItems={"center"} alignSelf="stretch">
       {withIcon ? (
         <Box mb={7}>
           <IconBox
@@ -63,6 +63,7 @@ const GenericErrorView = ({
       {hasExportLogButton ? (
         <>
           <Button
+            alignSelf="stretch"
             type={"main"}
             outline={true}
             Icon={DownloadFileIcon}

--- a/src/components/ValidateOnDevice.tsx
+++ b/src/components/ValidateOnDevice.tsx
@@ -1,0 +1,252 @@
+import React from "react";
+import invariant from "invariant";
+import { ScrollView } from "react-native";
+import { useTranslation } from "react-i18next";
+import {
+  Account,
+  AccountLike,
+  Transaction,
+  TransactionStatus,
+} from "@ledgerhq/live-common/lib/types";
+import {
+  getMainAccount,
+  getAccountUnit,
+} from "@ledgerhq/live-common/lib/account";
+import { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
+
+import { getDeviceTransactionConfig } from "@ledgerhq/live-common/lib/transaction";
+import { DeviceTransactionField } from "@ledgerhq/live-common/lib/transaction";
+import { getDeviceModel } from "@ledgerhq/devices";
+
+import { useTheme } from "@react-navigation/native";
+import styled from "styled-components/native";
+import { Flex, Log } from "@ledgerhq/native-ui";
+import Alert from "./Alert";
+import perFamilyTransactionConfirmFields from "../generated/TransactionConfirmFields";
+import { DataRowUnitValue, TextValueField } from "./ValidateOnDeviceDataRow";
+import Animation from "./Animation";
+import getDeviceAnimation from "./DeviceAction/getDeviceAnimation";
+
+export type FieldComponentProps = {
+  account: AccountLike;
+  parentAccount: Account | undefined | null;
+  transaction: Transaction;
+  status: TransactionStatus;
+  field: DeviceTransactionField;
+};
+
+export type FieldComponent = React.ComponentType<FieldComponentProps>;
+
+function AmountField({
+  account,
+  parentAccount,
+  status,
+  field,
+}: FieldComponentProps) {
+  let unit;
+  if (account.type === "TokenAccount") {
+    unit = getAccountUnit(account);
+  } else {
+    const mainAccount = getMainAccount(account, parentAccount);
+    unit = getAccountUnit(mainAccount);
+  }
+  return (
+    <DataRowUnitValue label={field.label} unit={unit} value={status.amount} />
+  );
+}
+
+function FeesField({
+  account,
+  parentAccount,
+  status,
+  field,
+}: FieldComponentProps) {
+  const mainAccount = getMainAccount(account, parentAccount);
+  const { estimatedFees } = status;
+  const feesUnit = getAccountUnit(mainAccount);
+  return (
+    <DataRowUnitValue
+      label={field.label}
+      unit={feesUnit}
+      value={estimatedFees}
+    />
+  );
+}
+
+function AddressField({ field }: FieldComponentProps) {
+  invariant(field.type === "address", "AddressField invalid");
+  return <TextValueField label={field.label} value={field.address} />;
+}
+
+// NB Leaving AddressField although I think it's redundant at this point
+// in case we want specific styles for addresses.
+function TextField({ field }: FieldComponentProps) {
+  invariant(field.type === "text", "TextField invalid");
+  return <TextValueField label={field.label} value={field.value} />;
+}
+
+const commonFieldComponents: { [key: any]: FieldComponent } = {
+  amount: AmountField,
+  fees: FeesField,
+  address: AddressField,
+  text: TextField,
+};
+
+type Props = {
+  device: Device,
+  status: TransactionStatus,
+  transaction: Transaction,
+  account: AccountLike,
+  parentAccount: Account | null | undefined,
+};
+
+export default function ValidateOnDevice({
+  device,
+  account,
+  parentAccount,
+  status,
+  transaction,
+}: Props) {
+  const { dark } = useTheme();
+  const theme = dark ? "dark" : "light";
+  const { t } = useTranslation();
+  const mainAccount = getMainAccount(account, parentAccount);
+  const r = perFamilyTransactionConfirmFields[mainAccount.currency.family];
+
+  const fieldComponents = {
+    ...commonFieldComponents,
+    ...(r && r.fieldComponents),
+  };
+  const Warning = r && r.warning;
+  const Title = r && r.title;
+  const Footer = r && r.footer;
+
+  const fields = getDeviceTransactionConfig({
+    account,
+    parentAccount,
+    transaction,
+    status,
+  });
+
+  const transRecipientWording = t(
+    `ValidateOnDevice.recipientWording.${transaction.mode || "send"}`,
+  );
+  const recipientWording =
+    transRecipientWording !==
+    `ValidateOnDevice.recipientWording.${transaction.mode || "send"}`
+      ? transRecipientWording
+      : t("ValidateOnDevice.recipientWording.send");
+
+  const transTitleWording = t(
+    `ValidateOnDevice.title.${transaction.mode || "send"}`,
+    getDeviceModel(device.modelId),
+  );
+  const titleWording =
+    transTitleWording !== `ValidateOnDevice.title.${transaction.mode || "send"}`
+      ? transTitleWording
+      : t("ValidateOnDevice.title.send", getDeviceModel(device.modelId));
+
+  return (
+    <RootContainer>
+      <ScrollContainer>
+        <InnerContainer>
+          <AnimationContainer>
+            <Animation
+              source={getDeviceAnimation({ device, key: "validate", theme })}
+            />
+          </AnimationContainer>
+          {Title ? (
+            <Title
+              account={account}
+              parentAccount={parentAccount}
+              transaction={transaction}
+              status={status}
+            />
+          ) : (
+            <TitleText>
+              {titleWording}
+            </TitleText>
+          )}
+
+          <DataRowsContainer>
+            {fields.map((field, i) => {
+              const MaybeComponent = fieldComponents[field.type];
+              if (!MaybeComponent) {
+                console.warn(
+                  `TransactionConfirm field ${field.type} is not implemented! add a generic implementation in components/TransactionConfirm.js or inside families/*/TransactionConfirmFields.js`,
+                );
+                return null;
+              }
+              return (
+                <MaybeComponent
+                  key={i}
+                  field={field}
+                  account={account}
+                  parentAccount={parentAccount}
+                  transaction={transaction}
+                  status={status}
+                />
+              );
+            })}
+
+            {Warning ? (
+              <Warning
+                account={account}
+                parentAccount={parentAccount}
+                transaction={transaction}
+                recipientWording={recipientWording}
+                status={status}
+              />
+            ) : null}
+          </DataRowsContainer>
+        </InnerContainer>
+      </ScrollContainer>
+      {Footer ? (
+        <Footer transaction={transaction} recipientWording={recipientWording} />
+      ) : (
+        <FooterContainer>
+          <Alert type="help">{recipientWording}</Alert>
+        </FooterContainer>
+      )}
+    </RootContainer>
+  );
+}
+
+const RootContainer = styled(Flex).attrs({
+  flex: 1,
+})``;
+
+const DataRowsContainer = styled(Flex).attrs({
+  marginVertical: 24,
+  alignSelf: "stretch",
+})``;
+
+const InnerContainer = styled(Flex).attrs({
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  flex: 1,
+})``;
+
+const FooterContainer = styled(Flex).attrs({
+  padding: 16,
+})``;
+
+const AnimationContainer = styled(Flex).attrs({
+  marginBottom: 40,
+})``;
+
+const ScrollContainer = styled(ScrollView)`
+  flex: 1;
+  padding: 16px;
+`;
+
+const TitleContainer = styled(Flex).attrs({
+  py: 8,
+})``;
+
+const TitleText = ({ children }: { children: React.ReactNode }) => (
+  <TitleContainer>
+    <Log>{children}</Log>
+  </TitleContainer>
+);

--- a/src/components/ValidateOnDevice.tsx
+++ b/src/components/ValidateOnDevice.tsx
@@ -14,8 +14,10 @@ import {
 } from "@ledgerhq/live-common/lib/account";
 import { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 
-import { getDeviceTransactionConfig } from "@ledgerhq/live-common/lib/transaction";
-import { DeviceTransactionField } from "@ledgerhq/live-common/lib/transaction";
+import {
+  getDeviceTransactionConfig,
+  DeviceTransactionField,
+} from "@ledgerhq/live-common/lib/transaction";
 import { getDeviceModel } from "@ledgerhq/devices";
 
 import { useTheme } from "@react-navigation/native";
@@ -93,11 +95,11 @@ const commonFieldComponents: { [key: any]: FieldComponent } = {
 };
 
 type Props = {
-  device: Device,
-  status: TransactionStatus,
-  transaction: Transaction,
-  account: AccountLike,
-  parentAccount: Account | null | undefined,
+  device: Device;
+  status: TransactionStatus;
+  transaction: Transaction;
+  account: AccountLike;
+  parentAccount: Account | null | undefined;
 };
 
 export default function ValidateOnDevice({
@@ -163,9 +165,7 @@ export default function ValidateOnDevice({
               status={status}
             />
           ) : (
-            <TitleText>
-              {titleWording}
-            </TitleText>
+            <TitleText>{titleWording}</TitleText>
           )}
 
           <DataRowsContainer>


### PR DESCRIPTION
This PR contains:
- v3 Restyling of `DeviceActionModal`, `DeviceAction/rendering` & `ValidateOnDevice`. Full removal of stylesheet, replaced by styled components.
- `GenericErrorView` fix of alignement (`alignSelf="stretch"`) so that it uses the full width available 
- Reimplementation of LLM's `Alert` component to use the UI lib's `Alert` component. Matching the old types with the new ones & different icons depending on the case. Also **got rid of legacy props of this component** that were not relevant in the new design system (`vertical`) or not being used at all (`left`, `bottom`, `closeable` etc., thank god they were not used by the way 😅 )
- Reimplementation of LLM's `ExternalLink` component to use the UI lib's `Link` component. Here I **removed some props** regarding styling etc. (`ltextProps`, `color`, `style`, `fontSize`) so **the changes are potentially breaking but only style-wise**, and since we use the UI lib there shouldn't be anything visually "incorrect". We'll fix as we go I guess 🤷‍♂️ 

### Demo time 💥 👀 
Device actions for bitcoin _add account_, _send_ (see following screenshot for `ValidateOnDevice` screen as it was implemented after recording the video) & _receive_ flows:

> https://user-images.githubusercontent.com/91890529/158355288-45bc161d-4373-486c-80fe-b40958f3819e.mp4

> ![adb-screencap(2)](https://user-images.githubusercontent.com/91890529/158369788-8a806aa7-df9f-4f22-a4c2-5bd215e0c116.png)


### Type

Rebranding

### Context

[LIVE-1621]

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LIVE-1621]: https://ledgerhq.atlassian.net/browse/LIVE-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ