### PR TITLE
LL-1320 Queued in place of installing on next installed apps

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -2806,6 +2806,7 @@
         "title": "Installing {{appName}}",
         "desc": "Please wait for the {{appName}} app to be installed",
         "button": "Installing...",
+        "queued": "Queued",
         "button_plural": "Installing... {{progressPercentage}}%"
       },
       "done": {

--- a/src/screens/Manager/AppsList/AppInstallProgress.js
+++ b/src/screens/Manager/AppsList/AppInstallProgress.js
@@ -40,7 +40,9 @@ export const InstallProgress = ({
             i18nKey={
               updating
                 ? "AppAction.update.loading"
-                : "AppAction.install.loading.button"
+                : installing
+                ? "AppAction.install.loading.button"
+                : "AppAction.install.loading.queued"
             }
           />
         </LText>


### PR DESCRIPTION
This PR have to ensure the LLM handle and wording of multiple app installs are consistent.

### Context

[LL-1320]

### Parts of the app affected / Test plan

Only the manager on the button install who have a new state if this app is installing or just in queue.

![Screenshot_2022-03-16-09-31-41-08_99c1b3bb631177f8a9e1379ae5b12ffe](https://user-images.githubusercontent.com/90627435/158550315-deee4853-0946-4deb-9d00-de06a6b811b7.jpg)
 

[LL-1320]: https://ledgerhq.atlassian.net/browse/LL-1320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ