### PR TITLE
V3 - Cleanup screens to use right background color and same tab navigator as the rest of the app

### DIFF
--- a/src/colors.tsx
+++ b/src/colors.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import color from "color";
+import { useTheme } from "@react-navigation/native";
+
+export const ensureContrast = (color1: string, color2: string) => {
+  const colorL1 = color(color1).luminosity() + 0.05;
+  const colorL2 = color(color2).luminosity() + 0.05;
+
+  const lRatio = colorL1 > colorL2 ? colorL1 / colorL2 : colorL2 / colorL1;
+
+  if (lRatio < 1.5) {
+    return color(color1)
+      .rotate(180)
+      .negate()
+      .string();
+  }
+  return color1;
+};
+
+export const rgba = (c: string, a: number) =>
+  color(c)
+    .alpha(a)
+    .rgb()
+    .toString();
+
+export const darken = (c: string, a: number) =>
+  color(c)
+    .darken(a)
+    .toString();
+
+export const lighten = (c: string, a: number) =>
+  color(c)
+    .lighten(a)
+    .toString();
+
+export function withTheme(Component: React.ElementType) {
+  return (props: any) => {
+    const { colors } = useTheme();
+    return <Component colors={colors} {...props} />;
+  };
+}
+
+export const lightTheme = {
+  dark: false,
+  colors: {
+    primary: "rgb(255, 45, 85)",
+    background: "hsla(0, 0%, 100%, 1)",
+    card: "#FFFFFF",
+    text: "rgb(28, 28, 30)",
+    border: "rgb(199, 199, 204)",
+    notification: "rgb(255, 69, 58)",
+    contrastBackground: "#142533",
+    contrastBackgroundText: "#ffffff",
+    /* MAIN */
+    live: "#6490f1",
+    alert: "#ea2e49",
+    success: "#66BE54",
+    darkBlue: "#142533",
+    smoke: "#666666",
+    grey: "#999999",
+    fog: "#D8D8D8",
+    white: "#ffffff",
+    green: "rgb(102, 190, 84)",
+    ledgerGreen: "#41ccb4",
+    black: "#000000",
+    orange: "#ff7701",
+    yellow: "#ffd24a",
+    separator: "#ebebeb",
+    warning: "#ff9900",
+    darkWarning: "#E08700",
+
+    /* DERIVATIVES */
+    lightLive: "#4b84ff19",
+    lightAlert: "#ea2e490c",
+    lightFog: "#EEEEEE",
+    lightGrey: "#F9F9F9",
+    lightOrange: "#FF984F",
+    translucentGreen: "rgba(102, 190, 84, 0.2)",
+    translucentGrey: "rgba(153, 153, 153, 0.2)",
+    lightLiveBg: "#eef0ff",
+
+    errorBg: "#ff0042",
+
+    /* PILLS */
+    pillForeground: "#999999",
+    pillActiveBackground: rgba("#6490f1", 0.1),
+    pillActiveForeground: "#6490f1",
+    pillActiveDisabledForeground: "#999999",
+
+    /** SNACKBAR */
+    snackBarBg: "#142533",
+    snackBarColor: "#FFF",
+
+    /** SKELETON */
+    skeletonBg: "#E9EAEB",
+  },
+};
+
+export const darkTheme = {
+  dark: true,
+  colors: {
+    primary: "rgb(255, 45, 85)",
+    card: "#1C1D1F",
+    background: "hsla(0, 0%, 10%, 1)",
+    text: "#FFFFFF",
+    border: "rgba(255, 255, 255, 0.1)",
+    notification: "rgb(255, 69, 58)",
+    contrastBackground: "#223544",
+    contrastBackgroundText: "#ffffff",
+    /* MAIN */
+    live: "#6490f1",
+    alert: "#ea2e49",
+    success: "#66BE54",
+    darkBlue: "#FAFAFA",
+    smoke: "#aaa",
+    grey: "#aaa",
+    fog: "#A8A8A8",
+    white: "#000000",
+    green: "rgb(102, 190, 84)",
+    ledgerGreen: "#41ccb4",
+    black: "#FFFFFF",
+    orange: "#ff7701",
+    yellow: "#ffd24a",
+    separator: "#ebebeb",
+    warning: "#ff9900",
+    darkWarning: "#E08700",
+
+    /* DERIVATIVES */
+    lightLive: "#4b84ff19",
+    lightAlert: "#ea2e490c",
+    lightFog: "#1c202b",
+    lightGrey: "rgba(255,255,255, 0.05)",
+    lightOrange: "#FF984F",
+    translucentGreen: "rgba(102, 190, 84, 0.2)",
+    translucentGrey: "rgba(153, 153, 153, 0.2)",
+    lightLiveBg: "#222635",
+
+    errorBg: "#ff0042",
+
+    /* PILLS */
+    pillForeground: "#999999",
+    pillActiveBackground: rgba("#6490f1", 0.1),
+    pillActiveForeground: "#6490f1",
+    pillActiveDisabledForeground: "#999999",
+
+    /** SNACKBAR */
+    snackBarBg: "#000000",
+    snackBarColor: "#FFF",
+
+    /** SKELETON */
+    skeletonBg: "#2a2d33",
+  },
+};

--- a/src/components/RootNavigator/BaseNavigator.tsx
+++ b/src/components/RootNavigator/BaseNavigator.tsx
@@ -1,0 +1,553 @@
+import React, { useMemo } from "react";
+import {
+  createStackNavigator,
+  CardStyleInterpolators,
+  TransitionPresets,
+} from "@react-navigation/stack";
+import { useTranslation } from "react-i18next";
+import { Flex, Icons } from "@ledgerhq/native-ui";
+import { useSelector } from "react-redux";
+import { useTheme } from "styled-components/native";
+import { ScreenName, NavigatorName } from "../../const";
+import * as families from "../../families";
+import OperationDetails, {
+  BackButton,
+  CloseButton,
+} from "../../screens/OperationDetails";
+import PairDevices from "../../screens/PairDevices";
+import EditDeviceName from "../../screens/EditDeviceName";
+import Distribution from "../../screens/Distribution";
+import Asset, { HeaderTitle } from "../../screens/Asset";
+import ScanRecipient from "../../screens/SendFunds/ScanRecipient";
+import WalletConnectScan from "../../screens/WalletConnect/Scan";
+import WalletConnectConnect from "../../screens/WalletConnect/Connect";
+import WalletConnectDeeplinkingSelectAccount from "../../screens/WalletConnect/DeeplinkingSelectAccount";
+import FallbackCameraSend from "../FallbackCamera/FallbackCameraSend";
+import Main from "./MainNavigator";
+import { ErrorHeaderInfo } from "./BaseOnboardingNavigator";
+import SettingsNavigator from "./SettingsNavigator";
+import ReceiveFundsNavigator from "./ReceiveFundsNavigator";
+import SendFundsNavigator from "./SendFundsNavigator";
+import SignMessageNavigator from "./SignMessageNavigator";
+import SignTransactionNavigator from "./SignTransactionNavigator";
+import FreezeNavigator from "./FreezeNavigator";
+import UnfreezeNavigator from "./UnfreezeNavigator";
+import ClaimRewardsNavigator from "./ClaimRewardsNavigator";
+import AddAccountsNavigator from "./AddAccountsNavigator";
+import ExchangeBuyFlowNavigator from "./ExchangeBuyFlowNavigator";
+import ExchangeSellFlowNavigator from "./ExchangeSellFlowNavigator";
+import ExchangeNavigator from "./ExchangeNavigator";
+import FirmwareUpdateNavigator from "./FirmwareUpdateNavigator";
+import AccountSettingsNavigator from "./AccountSettingsNavigator";
+import ImportAccountsNavigator from "./ImportAccountsNavigator";
+import PasswordAddFlowNavigator from "./PasswordAddFlowNavigator";
+import PasswordModifyFlowNavigator from "./PasswordModifyFlowNavigator";
+import MigrateAccountsFlowNavigator from "./MigrateAccountsFlowNavigator";
+import SwapNavigator from "./SwapNavigator";
+import LendingNavigator from "./LendingNavigator";
+import LendingInfoNavigator from "./LendingInfoNavigator";
+import LendingEnableFlowNavigator from "./LendingEnableFlowNavigator";
+import LendingSupplyFlowNavigator from "./LendingSupplyFlowNavigator";
+import LendingWithdrawFlowNavigator from "./LendingWithdrawFlowNavigator";
+import NotificationCenterNavigator from "./NotificationCenterNavigator";
+import AnalyticsNavigator from "./AnalyticsNavigator";
+import NftNavigator from "./NftNavigator";
+import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
+import Account from "../../screens/Account";
+import TransparentHeaderNavigationOptions from "../../navigation/TransparentHeaderNavigationOptions";
+import styles from "../../navigation/styles";
+import HeaderRightClose from "../HeaderRightClose";
+import StepHeader from "../StepHeader";
+import AccountHeaderTitle from "../../screens/Account/AccountHeaderTitle";
+import AccountHeaderRight from "../../screens/Account/AccountHeaderRight";
+import PortfolioHistory from "../../screens/Portfolio/PortfolioHistory";
+import RequestAccountNavigator from "./RequestAccountNavigator";
+import VerifyAccount from "../../screens/VerifyAccount";
+import PlatformApp from "../../screens/Platform/App";
+import ManagerNavigator from "./ManagerNavigator";
+
+import SwapFormSelectAccount from "../../screens/Swap/FormSelection/SelectAccountScreen";
+import SwapFormSelectCurrency from "../../screens/Swap/FormSelection/SelectCurrencyScreen";
+import SwapFormSelectFees from "../../screens/Swap/FormSelection/SelectFeesScreen";
+import SwapFormSelectProviderRate from "../../screens/Swap/FormSelection/SelectProviderRateScreen";
+
+import BuyDeviceScreen from "../../screens/BuyDeviceScreen";
+import { readOnlyModeEnabledSelector } from "../../reducers/settings";
+
+export default function BaseNavigator() {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const stackNavigationConfig = useMemo(
+    () => getStackNavigatorConfig(colors, true),
+    [colors],
+  );
+  const readOnlyModeEnabled = useSelector(readOnlyModeEnabledSelector);
+
+  return (
+    <Stack.Navigator
+      screenOptions={{
+        ...stackNavigationConfig,
+        ...TransitionPresets.ModalPresentation,
+      }}
+    >
+      <Stack.Screen
+        name={NavigatorName.Main}
+        component={Main}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={ScreenName.BuyDeviceScreen}
+        component={BuyDeviceScreen}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.Settings}
+        component={SettingsNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.ReceiveFunds}
+        component={ReceiveFundsNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.SendFunds}
+        component={SendFundsNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={ScreenName.PlatformApp}
+        component={PlatformApp}
+        options={({ route }) => ({
+          headerBackImage: () => (
+            <Flex pl="16px">
+              <Icons.CloseMedium color="neutral.c100" size="20px" />
+            </Flex>
+          ),
+          headerStyle: styles.headerNoShadow,
+          title: route.params.name,
+        })}
+      />
+      <Stack.Screen
+        name={NavigatorName.SignMessage}
+        component={SignMessageNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.SignTransaction}
+        component={SignTransactionNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.Swap}
+        component={SwapNavigator}
+        options={{
+          ...stackNavigationConfig,
+          headerLeft: null,
+          title: t("transfer.swap.form.tab"),
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.SwapV2FormSelectAccount}
+        component={SwapFormSelectAccount}
+        options={({ route }) => ({
+          headerTitle: () => (
+            <StepHeader
+              title={
+                route.params.target === "from"
+                  ? t("transfer.swap.form.from")
+                  : t("transfer.swap.form.to")
+              }
+            />
+          ),
+          headerRight: null,
+        })}
+      />
+      <Stack.Screen
+        name={ScreenName.SwapV2FormSelectCurrency}
+        component={SwapFormSelectCurrency}
+        options={{
+          headerTitle: () => <StepHeader title={t("transfer.swap.form.to")} />,
+          headerRight: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.SwapFormSelectProviderRate}
+        component={SwapFormSelectProviderRate}
+        options={{
+          headerTitle: () => (
+            <StepHeader title={t("transfer.swap.form.summary.method")} />
+          ),
+          headerRight: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.SwapV2FormSelectFees}
+        component={SwapFormSelectFees}
+        options={{
+          headerTitle: () => (
+            <StepHeader title={t("transfer.swap.form.summary.fees")} />
+          ),
+          headerRight: null,
+        }}
+      />
+      <Stack.Screen
+        name={NavigatorName.Lending}
+        component={LendingNavigator}
+        options={{
+          ...stackNavigationConfig,
+          headerStyle: styles.headerNoShadow,
+          headerLeft: null,
+          title: t("transfer.lending.title"),
+        }}
+      />
+      <Stack.Screen
+        name={NavigatorName.LendingInfo}
+        component={LendingInfoNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.LendingEnableFlow}
+        component={LendingEnableFlowNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.LendingSupplyFlow}
+        component={LendingSupplyFlowNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.LendingWithdrawFlow}
+        component={LendingWithdrawFlowNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.Freeze}
+        component={FreezeNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.Unfreeze}
+        component={UnfreezeNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.ClaimRewards}
+        component={ClaimRewardsNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.AddAccounts}
+        component={AddAccountsNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.RequestAccount}
+        component={RequestAccountNavigator}
+        options={{
+          headerShown: false,
+        }}
+        listeners={({ route }) => ({
+          beforeRemove: () => {
+            /**
+              react-navigation workaround try to fetch params from current route params
+              or fallback to child navigator route params
+              since this listener is on top of another navigator
+            */
+            const onError =
+              route.params?.onError || route.params?.params?.onError;
+            // @TODO replace with correct error
+            if (onError && typeof onError === "function")
+              onError(
+                route.params.error ||
+                  new Error("Request account interrupted by user"),
+              );
+          },
+        })}
+      />
+      <Stack.Screen
+        name={ScreenName.VerifyAccount}
+        component={VerifyAccount}
+        options={{
+          headerLeft: null,
+          title: t("transfer.receive.headerTitle"),
+        }}
+        listeners={({ route }) => ({
+          beforeRemove: () => {
+            const onClose =
+              route.params?.onClose || route.params?.params?.onClose;
+            if (onClose && typeof onClose === "function") {
+              onClose();
+            }
+          },
+        })}
+      />
+      <Stack.Screen
+        name={NavigatorName.FirmwareUpdate}
+        component={FirmwareUpdateNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.Exchange}
+        {...(readOnlyModeEnabled
+          ? {
+              component: BuyDeviceScreen,
+              options: {
+                ...TransitionPresets.ModalTransition,
+                headerShown: false,
+              },
+            }
+          : {
+              component: ExchangeNavigator,
+              options: { headerStyle: styles.headerNoShadow, headerLeft: null },
+            })}
+      />
+      <Stack.Screen
+        name={NavigatorName.ExchangeBuyFlow}
+        component={
+          readOnlyModeEnabled ? BuyDeviceScreen : ExchangeBuyFlowNavigator
+        }
+        initialParams={{ mode: "buy" }}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.ExchangeSellFlow}
+        component={
+          readOnlyModeEnabled ? BuyDeviceScreen : ExchangeSellFlowNavigator
+        }
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={ScreenName.OperationDetails}
+        component={OperationDetails}
+        options={({ route, navigation }) => {
+          if (route.params?.isSubOperation) {
+            return {
+              headerTitle: () => (
+                <StepHeader
+                  subtitle={t("operationDetails.title")}
+                  title={
+                    route.params?.operation?.type
+                      ? t(`operations.types.${route.params.operation.type}`)
+                      : ""
+                  }
+                />
+              ),
+              headerLeft: () => <BackButton navigation={navigation} />,
+              headerRight: () => <CloseButton navigation={navigation} />,
+            };
+          }
+
+          return {
+            headerTitle: () => (
+              <StepHeader
+                subtitle={t("operationDetails.title")}
+                title={
+                  route.params?.operation?.type
+                    ? t(`operations.types.${route.params.operation.type}`)
+                    : ""
+                }
+              />
+            ),
+            headerLeft: () => <BackButton navigation={navigation} />,
+            headerRight: null,
+          };
+        }}
+      />
+      <Stack.Screen
+        name={NavigatorName.AccountSettings}
+        component={AccountSettingsNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.ImportAccounts}
+        component={ImportAccountsNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={ScreenName.PairDevices}
+        component={PairDevices}
+        options={({ navigation, route }) => ({
+          title: null,
+          headerRight: () => (
+            <ErrorHeaderInfo
+              route={route}
+              navigation={navigation}
+              colors={colors}
+            />
+          ),
+          headerShown: true,
+          headerStyle: styles.headerNoShadow,
+        })}
+      />
+      <Stack.Screen
+        name={ScreenName.EditDeviceName}
+        component={EditDeviceName}
+        options={{
+          title: t("EditDeviceName.title"),
+          headerLeft: null,
+          ...TransitionPresets.ModalPresentationIOS,
+        }}
+      />
+      <Stack.Screen
+        name={NavigatorName.PasswordAddFlow}
+        component={PasswordAddFlowNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.PasswordModifyFlow}
+        component={PasswordModifyFlowNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={NavigatorName.MigrateAccountsFlow}
+        component={MigrateAccountsFlowNavigator}
+        options={{ headerShown: false }}
+      />
+      <Stack.Screen
+        name={ScreenName.Distribution}
+        component={Distribution}
+        options={{
+          ...stackNavigationConfig,
+          title: t("distribution.header"),
+          headerLeft: null,
+        }}
+      />
+      <Stack.Screen
+        name={NavigatorName.Analytics}
+        component={AnalyticsNavigator}
+        options={{
+          title: t("analytics.title"),
+          headerRight: null,
+          cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.Asset}
+        component={readOnlyModeEnabled ? BuyDeviceScreen : Asset}
+        options={{
+          headerTitle: () => <HeaderTitle />,
+          headerRight: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.PortfolioOperationHistory}
+        component={PortfolioHistory}
+        options={{
+          headerTitle: t("tabs.portfolio"),
+          headerRight: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.Account}
+        component={readOnlyModeEnabled ? BuyDeviceScreen : Account}
+        options={({ route, navigation }) => ({
+          headerLeft: () => (
+            <BackButton navigation={navigation} route={route} />
+          ),
+          headerTitle: () => <AccountHeaderTitle />,
+          headerRight: () => <AccountHeaderRight />,
+        })}
+      />
+      <Stack.Screen
+        name={ScreenName.ScanRecipient}
+        component={ScanRecipient}
+        options={{
+          ...TransparentHeaderNavigationOptions,
+          title: t("send.scan.title"),
+          headerRight: () => (
+            <HeaderRightClose color={colors.white} preferDismiss={false} />
+          ),
+          headerLeft: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.WalletConnectScan}
+        component={WalletConnectScan}
+        options={{
+          ...TransparentHeaderNavigationOptions,
+          title: "Wallet Connect",
+          headerRight: () => (
+            <HeaderRightClose color={colors.white} preferDismiss={false} />
+          ),
+          headerLeft: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.WalletConnectDeeplinkingSelectAccount}
+        component={WalletConnectDeeplinkingSelectAccount}
+        options={{
+          title: t("walletconnect.deeplinkingTitle"),
+          headerRight: () => <HeaderRightClose preferDismiss={false} />,
+          headerLeft: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.WalletConnectConnect}
+        component={WalletConnectConnect}
+        options={{
+          title: "Wallet Connect",
+          headerLeft: null,
+          gestureEnabled: false,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.FallbackCameraSend}
+        component={FallbackCameraSend}
+        options={{
+          title: t("send.scan.fallback.header"),
+          headerLeft: null,
+        }}
+      />
+      <Stack.Screen
+        name={NavigatorName.NotificationCenter}
+        component={NotificationCenterNavigator}
+        options={({ navigation }) => ({
+          title: t("notificationCenter.title"),
+          headerLeft: null,
+          headerRight: () => <CloseButton navigation={navigation} />,
+          cardStyleInterpolator: CardStyleInterpolators.forVerticalIOS,
+        })}
+      />
+      <Stack.Screen
+        name={NavigatorName.NftNavigator}
+        component={NftNavigator}
+        options={({ navigation }) => ({
+          title: null,
+          headerRight: null,
+          headerLeft: () => <CloseButton navigation={navigation} />,
+        })}
+      />
+      <Stack.Screen
+        name={NavigatorName.Manager}
+        {...(readOnlyModeEnabled
+          ? {
+              component: BuyDeviceScreen,
+              options: {
+                ...TransitionPresets.ModalTransition,
+                headerShown: false,
+              },
+            }
+          : {
+              component: ManagerNavigator,
+              options: {
+                headerShown: false,
+              },
+            })}
+      />
+      {Object.keys(families).map(name => {
+        const { component, options } = families[name];
+        return (
+          <Stack.Screen
+            key={name}
+            name={name}
+            component={component}
+            options={options}
+          />
+        );
+      })}
+    </Stack.Navigator>
+  );
+}
+
+const Stack = createStackNavigator();

--- a/src/components/RootNavigator/ExchangeNavigator.tsx
+++ b/src/components/RootNavigator/ExchangeNavigator.tsx
@@ -1,46 +1,47 @@
 import React, { useMemo } from "react";
 import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
 import { useTranslation } from "react-i18next";
-import { useTheme } from "styled-components";
+import { useTheme } from "styled-components/native";
 import { Text } from "@ledgerhq/native-ui";
-
-import AnalyticsAllocation from "../../screens/Analytics/Allocation";
-import AnalyticsOperations from "../../screens/Analytics/Operations";
 import { ScreenName } from "../../const";
+import Sell from "../../screens/Exchange/Sell";
+import BuyNavigator from "./BuyNavigator";
 import { getLineTabNavigatorConfig } from "../../navigation/tabNavigatorConfig";
 
-const Tab = createMaterialTopTabNavigator();
+type TabLabelProps = {
+  focused: boolean;
+  color: string;
+};
 
-export default function AnalyticsNavigator() {
+export default function ExchangeNavigator() {
   const { t } = useTranslation();
   const { colors } = useTheme();
+
   const tabNavigationConfig = useMemo(() => getLineTabNavigatorConfig(colors), [
     colors,
   ]);
-
-  // Fixme Typescript: Update react-native-tab-view to 3.1.1 to remove Tab.navigator ts error
   return (
     <Tab.Navigator {...tabNavigationConfig}>
       <Tab.Screen
-        name={ScreenName.AnalyticsAllocation}
-        component={AnalyticsAllocation}
+        name={ScreenName.ExchangeBuy}
+        component={BuyNavigator}
         options={{
-          title: t("analytics.allocation.title"),
-          tabBarLabel: (props: any) => (
+          title: t("exchange.buy.tabTitle"),
+          tabBarLabel: (props: TabLabelProps) => (
             <Text variant="body" fontWeight="semiBold" {...props}>
-              {t("analytics.allocation.title")}
+              {t("exchange.buy.tabTitle")}
             </Text>
           ),
         }}
       />
       <Tab.Screen
-        name={ScreenName.AnalyticsOperations}
-        component={AnalyticsOperations}
+        name={ScreenName.ExchangeSell}
+        component={Sell}
         options={{
-          title: t("analytics.operations.title"),
-          tabBarLabel: (props: any) => (
+          title: t("exchange.sell.tabTitle"),
+          tabBarLabel: (props: TabLabelProps) => (
             <Text variant="body" fontWeight="semiBold" {...props}>
-              {t("analytics.operations.title")}
+              {t("exchange.sell.tabTitle")}
             </Text>
           ),
         }}
@@ -48,3 +49,5 @@ export default function AnalyticsNavigator() {
     </Tab.Navigator>
   );
 }
+
+const Tab = createMaterialTopTabNavigator();

--- a/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/src/components/RootNavigator/SettingsNavigator.tsx
@@ -1,11 +1,10 @@
-// @flow
 import React, { useMemo } from "react";
 import {
   createStackNavigator,
   TransitionPresets,
 } from "@react-navigation/stack";
 import { useTranslation } from "react-i18next";
-import { useTheme } from "@react-navigation/native";
+import { useTheme } from "styled-components/native";
 import { ScreenName } from "../../const";
 import BenchmarkQRStream from "../../screens/BenchmarkQRStream";
 import DebugSwap from "../../screens/DebugSwap";

--- a/src/components/RootNavigator/SwapFormNavigator.tsx
+++ b/src/components/RootNavigator/SwapFormNavigator.tsx
@@ -1,0 +1,70 @@
+import React, { useMemo } from "react";
+import { createMaterialTopTabNavigator } from "@react-navigation/material-top-tabs";
+import { useTranslation } from "react-i18next";
+
+import { Account, AccountLike } from "@ledgerhq/live-common/lib/types/account";
+
+import { useTheme } from "styled-components/native";
+import { Text } from "@ledgerhq/native-ui";
+import { ScreenName } from "../../const";
+import Swap from "../../screens/Swap";
+import History from "../../screens/Swap/History";
+import { getLineTabNavigatorConfig } from "../../navigation/tabNavigatorConfig";
+
+type TabLabelProps = {
+  focused: boolean;
+  color: string;
+};
+
+type RouteParams = {
+  defaultAccount?: AccountLike;
+  defaultParentAccount?: Account;
+  providers: any;
+  provider: string;
+};
+
+export default function SwapFormNavigator({
+  route,
+}: {
+  route: { params: RouteParams };
+}) {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const { params: routeParams } = route;
+
+  const tabNavigationConfig = useMemo(() => getLineTabNavigatorConfig(colors), [
+    colors,
+  ]);
+
+  return (
+    <Tab.Navigator {...tabNavigationConfig}>
+      <Tab.Screen
+        name={ScreenName.SwapForm}
+        options={{
+          title: t("transfer.swap.form.tab"),
+          tabBarLabel: (props: TabLabelProps) => (
+            <Text variant="body" fontWeight="semiBold" {...props}>
+              {t("transfer.swap.form.tab")}
+            </Text>
+          ),
+        }}
+      >
+        {_props => <Swap {..._props} {...routeParams} />}
+      </Tab.Screen>
+      <Tab.Screen
+        name={ScreenName.SwapHistory}
+        component={History}
+        options={{
+          title: t("exchange.buy.tabTitle"),
+          tabBarLabel: (props: TabLabelProps) => (
+            <Text variant="body" fontWeight="semiBold" {...props}>
+              {t("transfer.swap.history.tab")}
+            </Text>
+          ),
+        }}
+      />
+    </Tab.Navigator>
+  );
+}
+
+const Tab = createMaterialTopTabNavigator();

--- a/src/components/RootNavigator/SwapNavigator.tsx
+++ b/src/components/RootNavigator/SwapNavigator.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo } from "react";
+import { createStackNavigator } from "@react-navigation/stack";
+
+import { useTranslation } from "react-i18next";
+import { useTheme } from "styled-components/native";
+import { ScreenName } from "../../const";
+import SwapError from "../../screens/Swap/Error";
+import SwapKYC from "../../screens/Swap/KYC";
+import SwapKYCStates from "../../screens/Swap/KYC/StateSelect";
+import Swap from "../../screens/Swap/SwapEntry";
+import SwapFormNavigator from "./SwapFormNavigator";
+import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
+import StepHeader from "../StepHeader";
+import SwapOperationDetails from "../../screens/Swap/OperationDetails";
+import { BackButton } from "../../screens/OperationDetails";
+import SwapPendingOperation from "../../screens/Swap/PendingOperation";
+
+export default function SwapNavigator() {
+  const { t } = useTranslation();
+  const { colors } = useTheme();
+  const stackNavigationConfig = useMemo(
+    () => getStackNavigatorConfig(colors, true),
+    [colors],
+  );
+
+  return (
+    <Stack.Navigator
+      screenOptions={{ ...stackNavigationConfig, headerShown: false }}
+    >
+      <Stack.Screen
+        name={ScreenName.Swap}
+        component={Swap}
+        options={{
+          title: t("transfer.swap.landing.header"),
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.SwapFormOrHistory}
+        component={SwapFormNavigator}
+        options={{
+          title: t("transfer.swap.form.tab"),
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.SwapKYC}
+        component={SwapKYC}
+        options={{
+          headerTitle: () => <StepHeader title={t("transfer.swap.title")} />,
+          headerRight: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.SwapKYCStates}
+        component={SwapKYCStates}
+        options={{
+          headerTitle: () => (
+            <StepHeader title={t("transfer.swap.kyc.states")} />
+          ),
+          headerRight: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.SwapError}
+        component={SwapError}
+        options={{
+          headerTitle: () => <StepHeader title={t("transfer.swap.title")} />,
+          headerLeft: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.SwapPendingOperation}
+        component={SwapPendingOperation}
+        options={{
+          headerTitle: () => <StepHeader title={t("transfer.swap.title")} />,
+          headerLeft: null,
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.SwapOperationDetails}
+        component={SwapOperationDetails}
+        options={({ navigation }) => ({
+          headerTitle: () => <StepHeader title={t("transfer.swap.title")} />,
+          headerLeft: () => <BackButton navigation={navigation} />,
+          headerRight: null,
+        })}
+      />
+    </Stack.Navigator>
+  );
+}
+
+const Stack = createStackNavigator();

--- a/src/navigation/navigatorConfig.tsx
+++ b/src/navigation/navigatorConfig.tsx
@@ -14,7 +14,14 @@ export const defaultNavigationOptions = {
 
 export const getStackNavigatorConfig = (c: any, closable: boolean = false) => ({
   ...defaultNavigationOptions,
-  cardStyle: { backgroundColor: c.background.main || c.white },
+  cardStyle: { backgroundColor: c.background.main || c.background },
+  headerStyle: {
+    backgroundColor: c.background.main || c.background,
+    borderBottomColor: c.neutral?.c40 || c.white,
+    // borderBottomWidth: 1,
+    elevation: 0, // remove shadow on Android
+    shadowOpacity: 0, // remove shadow on iOS
+  },
   headerTitleAlign: "center",
   headerTitleStyle: {
     color: c.darkBlue,

--- a/src/navigation/tabNavigatorConfig.tsx
+++ b/src/navigation/tabNavigatorConfig.tsx
@@ -1,0 +1,20 @@
+import { ColorPalette } from "@ledgerhq/native-ui";
+
+export const getLineTabNavigatorConfig = (colors: ColorPalette) => ({
+  screenOptions: {
+    tabBarActiveTintColor: colors.neutral.c100,
+    tabBarInactiveTintColor: colors.neutral.c80,
+    tabBarIndicatorStyle: {
+      backgroundColor: colors.primary.c70,
+      height: 3,
+    },
+    tabBarStyle: {
+      backgroundColor: colors.background.main,
+      borderBottomWidth: 1,
+      borderColor: colors.neutral.c40,
+    },
+  },
+  sceneContainerStyle: {
+    backgroundColor: colors.background.main,
+  },
+});

--- a/src/screens/Accounts/AccountRow.tsx
+++ b/src/screens/Accounts/AccountRow.tsx
@@ -99,6 +99,7 @@ const AccountRow = ({
           <ProgressLoader
             strokeWidth={2}
             mainColor={color}
+            secondaryColor={colors.neutral.c40}
             progress={portfolioPercentage}
             radius={22}
           >

--- a/src/screens/Settings/HelpButton.tsx
+++ b/src/screens/Settings/HelpButton.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+import { TouchableOpacity } from "react-native";
+import { useNavigation } from "@react-navigation/native";
+import { HelpMedium } from "@ledgerhq/native-ui/assets/icons";
+import { ScreenName } from "../../const";
+
+const HelpButton = () => {
+  const { navigate } = useNavigation();
+  return (
+    <>
+      <TouchableOpacity
+        style={{ marginRight: 16 }}
+        onPress={() => navigate(ScreenName.Resources)}
+      >
+        <HelpMedium size={24} color={"neutral.c100"} />
+      </TouchableOpacity>
+    </>
+  );
+};
+
+export default HelpButton;


### PR DESCRIPTION
Cleanup screens to use right background color and same tab navigator as the rest of the app

### Type

Ui polish

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

Buy, Swap, Analytics, Notification Center