### PR TITLE
Add React Native Performance plugin

### DIFF
--- a/android/app/src/debug/java/com/ledger/live/ReactNativeFlipper.java
+++ b/android/app/src/debug/java/com/ledger/live/ReactNativeFlipper.java
@@ -23,6 +23,7 @@ import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.modules.network.NetworkingModule;
 import okhttp3.OkHttpClient;
+import tech.bam.rnperformance.flipper.RNPerfMonitorPlugin;
 
 public class ReactNativeFlipper {
   public static void initializeFlipper(Context context, ReactInstanceManager reactInstanceManager) {
@@ -34,6 +35,7 @@ public class ReactNativeFlipper {
       client.addPlugin(new DatabasesFlipperPlugin(context));
       client.addPlugin(new SharedPreferencesFlipperPlugin(context));
       client.addPlugin(CrashReporterPlugin.getInstance());
+      client.addPlugin(new RNPerfMonitorPlugin(reactInstanceManager));
 
       NetworkFlipperPlugin networkFlipperPlugin = new NetworkFlipperPlugin();
       NetworkingModule.setCustomClientBuilder(

--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
     "patch-package": "^6.4.7",
     "prettier": "^1.19.1",
     "react-native-debugger-open": "^0.3.25",
+    "react-native-flipper-performance-plugin": "^0.2.0",
     "rn-nodeify": "10.3.0",
     "typescript": "^4.4.4",
     "ws": "^7.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13990,6 +13990,11 @@ react-native-fast-image@^8.5.11:
   version "6.0.0"
   resolved "git+https://github.com/hieuvp/react-native-fingerprint-scanner.git#f1d136f605412d58e4de9e7e155d6f818ba24731"
 
+react-native-flipper-performance-plugin@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/react-native-flipper-performance-plugin/-/react-native-flipper-performance-plugin-0.2.0.tgz#df1914fc19266cdee82eef8683eb8cdbc9f2d2aa"
+  integrity sha512-1VAm5Kp3eGBa1IF54YPV457x6sVNDBbuU/n+tMxe3ss1+LpEeCTI1+seM2M9FvWJJHcXuOEBgGaaY/LRgAmXgg==
+
 react-native-gesture-handler@^1.10.3:
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-1.10.3.tgz#942bbf2963bbf49fa79593600ee9d7b5dab3cfc0"


### PR DESCRIPTION
Add React Native Performance plugin, Lighthouse like monitor for Flipper

### Type

Packet install 

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
