### PR TITLE
Fixes Tezos JS import

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2537,7 +2537,7 @@
 
 "@ledgerhq/live-common@https://github.com/LedgerHQ/ledger-live-common.git#develop":
   version "21.34.1-cosmos.4"
-  resolved "https://github.com/LedgerHQ/ledger-live-common.git#4709a08677fc0220c1b53c635bde7ef210093110"
+  resolved "https://github.com/LedgerHQ/ledger-live-common.git#893c4a1a66b8d4147ccb1fce860f48d82d0af949"
   dependencies:
     "@celo/contractkit" "^1.5.2"
     "@celo/wallet-base" "^1.5.2"


### PR DESCRIPTION
### Type

bugfix on tezos experimental

### Context

LIVE-1689

### Parts of the app affected / Test plan

the impact is exclusively on Tezos and on mobile. It fixes the ability to do transactions after importing Tezos accounts from Ledger Live Desktop. you must remove previous accounts if you had them imported. It is to me not necessary to test on both iOS and Android, the bug was cross platform.

The fix was reproduced by the bot and then proven to be fixed by the bot in this PR: https://github.com/LedgerHQ/ledger-live-common/pull/1818

Builds

- https://github.com/LedgerHQ/ledger-live-build/actions/runs/2000458062
- https://github.com/LedgerHQ/ledger-live-build/actions/runs/2000457466