### PR TITLE
V3 - Fix Accounts navigation with learn

### DIFF
--- a/src/components/RootNavigator/BaseNavigator.tsx
+++ b/src/components/RootNavigator/BaseNavigator.tsx
@@ -65,6 +65,7 @@ import RequestAccountNavigator from "./RequestAccountNavigator";
 import VerifyAccount from "../../screens/VerifyAccount";
 import PlatformApp from "../../screens/Platform/App";
 import ManagerNavigator from "./ManagerNavigator";
+import AccountsNavigator from "./AccountsNavigator";
 
 import SwapFormSelectAccount from "../../screens/Swap/FormSelection/SelectAccountScreen";
 import SwapFormSelectCurrency from "../../screens/Swap/FormSelection/SelectCurrencyScreen";
@@ -534,6 +535,11 @@ export default function BaseNavigator() {
                 headerShown: false,
               },
             })}
+      />
+      <Stack.Screen
+        name={NavigatorName.Accounts}
+        component={AccountsNavigator}
+        options={{ headerShown: false }}
       />
       {Object.keys(families).map(name => {
         const { component, options } = families[name];


### PR DESCRIPTION
 Fix Accounts navigation, accounts navigator wasn't indexed when Learn tab was present

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

baseNavigator