### PR TITLE
Live-1711: Migrate LLM from the old live app provider to the new one

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@ledgerhq/errors": "6.10.0",
     "@ledgerhq/hw-transport": "6.24.1",
     "@ledgerhq/hw-transport-http": "6.26.0",
-    "@ledgerhq/live-common": "https://github.com/LedgerHQ/ledger-live-common.git#develop",
+    "@ledgerhq/live-common": "21.35.0",
     "@ledgerhq/logs": "6.10.0",
     "@ledgerhq/native-ui": "^0.7.0",
     "@ledgerhq/react-native-hid": "6.24.1",

--- a/src/components/TabIcon.js
+++ b/src/components/TabIcon.js
@@ -2,8 +2,8 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import { useTranslation } from "react-i18next";
-import LText from "./LText";
 import styled from "styled-components/native";
+import LText from "./LText";
 
 const ICON_SIZE = 24;
 

--- a/src/families/index.js
+++ b/src/families/index.js
@@ -9,4 +9,3 @@ export * from "./algorand";
 export * from "./polkadot";
 export * from "./solana";
 export * from "./crypto_org";
-

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ import { pairId } from "@ledgerhq/live-common/lib/countervalues/helpers";
 import { NftMetadataProvider } from "@ledgerhq/live-common/lib/nft";
 import { ToastProvider } from "@ledgerhq/live-common/lib/notifications/ToastProvider";
 import { RemoteLiveAppProvider } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
+import { LocalLiveAppProvider } from "@ledgerhq/live-common/src/platform/providers/LocalLiveAppProvider";
 import { GlobalCatalogProvider } from "@ledgerhq/live-common/lib/platform/providers/GlobalCatalogProvider";
 import { RampCatalogProvider } from "@ledgerhq/live-common/lib/platform/providers/RampCatalogProvider";
 
@@ -467,58 +468,60 @@ export default class Root extends Component<
                     provider={provider}
                     updateFrequency={AUTO_UPDATE_DEFAULT_DELAY}
                   >
-                    <GlobalCatalogProvider
-                      provider={provider}
-                      updateFrequency={AUTO_UPDATE_DEFAULT_DELAY}
-                    >
-                      <RampCatalogProvider
+                    <LocalLiveAppProvider>
+                      <GlobalCatalogProvider
                         provider={provider}
                         updateFrequency={AUTO_UPDATE_DEFAULT_DELAY}
                       >
-                        <FirebaseRemoteConfigProvider>
-                          <FirebaseFeatureFlagsProvider>
-                            <DeepLinkingNavigator>
-                              <SafeAreaProvider>
-                                <StyledStatusBar />
-                                <NavBarColorHandler />
-                                <AuthPass>
-                                  <I18nextProvider i18n={i18n}>
-                                    <LocaleProvider>
-                                      <BridgeSyncProvider>
-                                        <CounterValuesProvider
-                                          initialState={initialCountervalues}
-                                        >
-                                          <ButtonUseTouchable.Provider
-                                            value={true}
+                        <RampCatalogProvider
+                          provider={provider}
+                          updateFrequency={AUTO_UPDATE_DEFAULT_DELAY}
+                        >
+                          <FirebaseRemoteConfigProvider>
+                            <FirebaseFeatureFlagsProvider>
+                              <DeepLinkingNavigator>
+                                <SafeAreaProvider>
+                                  <StyledStatusBar />
+                                  <NavBarColorHandler />
+                                  <AuthPass>
+                                    <I18nextProvider i18n={i18n}>
+                                      <LocaleProvider>
+                                        <BridgeSyncProvider>
+                                          <CounterValuesProvider
+                                            initialState={initialCountervalues}
                                           >
-                                            <OnboardingContextProvider>
-                                              <ToastProvider>
-                                                <NotificationsProvider>
-                                                  <SnackbarContainer />
-                                                  <NftMetadataProvider>
-                                                    <MarketDataProvider>
-                                                      <App
-                                                        importDataString={
-                                                          importDataString
-                                                        }
-                                                      />
-                                                    </MarketDataProvider>
-                                                  </NftMetadataProvider>
-                                                </NotificationsProvider>
-                                              </ToastProvider>
-                                            </OnboardingContextProvider>
-                                          </ButtonUseTouchable.Provider>
-                                        </CounterValuesProvider>
-                                      </BridgeSyncProvider>
-                                    </LocaleProvider>
-                                  </I18nextProvider>
-                                </AuthPass>
-                              </SafeAreaProvider>
-                            </DeepLinkingNavigator>
-                          </FirebaseFeatureFlagsProvider>
-                        </FirebaseRemoteConfigProvider>
-                      </RampCatalogProvider>
-                    </GlobalCatalogProvider>
+                                            <ButtonUseTouchable.Provider
+                                              value={true}
+                                            >
+                                              <OnboardingContextProvider>
+                                                <ToastProvider>
+                                                  <NotificationsProvider>
+                                                    <SnackbarContainer />
+                                                    <NftMetadataProvider>
+                                                      <MarketDataProvider>
+                                                        <App
+                                                          importDataString={
+                                                            importDataString
+                                                          }
+                                                        />
+                                                      </MarketDataProvider>
+                                                    </NftMetadataProvider>
+                                                  </NotificationsProvider>
+                                                </ToastProvider>
+                                              </OnboardingContextProvider>
+                                            </ButtonUseTouchable.Provider>
+                                          </CounterValuesProvider>
+                                        </BridgeSyncProvider>
+                                      </LocaleProvider>
+                                    </I18nextProvider>
+                                  </AuthPass>
+                                </SafeAreaProvider>
+                              </DeepLinkingNavigator>
+                            </FirebaseFeatureFlagsProvider>
+                          </FirebaseRemoteConfigProvider>
+                        </RampCatalogProvider>
+                      </GlobalCatalogProvider>
+                    </LocalLiveAppProvider>
                   </RemoteLiveAppProvider>
                 </WalletConnectProvider>
               </>

--- a/src/index.js
+++ b/src/index.js
@@ -36,8 +36,9 @@ import { pairId } from "@ledgerhq/live-common/lib/countervalues/helpers";
 
 import { NftMetadataProvider } from "@ledgerhq/live-common/lib/nft";
 import { ToastProvider } from "@ledgerhq/live-common/lib/notifications/ToastProvider";
-import { PlatformAppProvider } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider";
-import { getProvider } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider/providers";
+import { RemoteLiveAppProvider } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
+import { GlobalCatalogProvider } from "@ledgerhq/live-common/lib/platform/providers/GlobalCatalogProvider";
+import { RampCatalogProvider } from "@ledgerhq/live-common/lib/platform/providers/RampCatalogProvider";
 
 import logger from "./logger";
 import { saveAccounts, saveBle, saveSettings, saveCountervalues } from "./db";
@@ -421,6 +422,8 @@ const DeepLinkingNavigator = ({ children }: { children: React$Node }) => {
   );
 };
 
+const AUTO_UPDATE_DEFAULT_DELAY = 1800 * 1000; // 1800 seconds
+
 export default class Root extends Component<
   { importDataString?: string },
   { appState: * },
@@ -448,6 +451,8 @@ export default class Root extends Component<
   render() {
     const importDataString = __DEV__ ? this.props.importDataString : "";
 
+    const provider = "production";
+
     return (
       <RebootProvider onRebootStart={this.onRebootStart}>
         <LedgerStoreProvider onInitFinished={this.onInitFinished}>
@@ -458,50 +463,63 @@ export default class Root extends Component<
                 <HookSentry />
                 <HookAnalytics store={store} />
                 <WalletConnectProvider>
-                  <PlatformAppProvider
-                    platformAppsServerURL={getProvider("production").url}
+                  <RemoteLiveAppProvider
+                    provider={provider}
+                    updateFrequency={AUTO_UPDATE_DEFAULT_DELAY}
                   >
-                    <FirebaseRemoteConfigProvider>
-                      <FirebaseFeatureFlagsProvider>
-                        <DeepLinkingNavigator>
-                          <SafeAreaProvider>
-                            <StyledStatusBar />
-                            <NavBarColorHandler />
-                            <AuthPass>
-                              <I18nextProvider i18n={i18n}>
-                                <LocaleProvider>
-                                  <BridgeSyncProvider>
-                                    <CounterValuesProvider
-                                      initialState={initialCountervalues}
-                                    >
-                                      <ButtonUseTouchable.Provider value={true}>
-                                        <OnboardingContextProvider>
-                                          <ToastProvider>
-                                            <NotificationsProvider>
-                                              <SnackbarContainer />
-                                              <NftMetadataProvider>
-                                                <MarketDataProvider>
-                                                  <App
-                                                    importDataString={
-                                                      importDataString
-                                                    }
-                                                  />
-                                                </MarketDataProvider>
-                                              </NftMetadataProvider>
-                                            </NotificationsProvider>
-                                          </ToastProvider>
-                                        </OnboardingContextProvider>
-                                      </ButtonUseTouchable.Provider>
-                                    </CounterValuesProvider>
-                                  </BridgeSyncProvider>
-                                </LocaleProvider>
-                              </I18nextProvider>
-                            </AuthPass>
-                          </SafeAreaProvider>
-                        </DeepLinkingNavigator>
-                      </FirebaseFeatureFlagsProvider>
-                    </FirebaseRemoteConfigProvider>
-                  </PlatformAppProvider>
+                    <GlobalCatalogProvider
+                      provider={provider}
+                      updateFrequency={AUTO_UPDATE_DEFAULT_DELAY}
+                    >
+                      <RampCatalogProvider
+                        provider={provider}
+                        updateFrequency={AUTO_UPDATE_DEFAULT_DELAY}
+                      >
+                        <FirebaseRemoteConfigProvider>
+                          <FirebaseFeatureFlagsProvider>
+                            <DeepLinkingNavigator>
+                              <SafeAreaProvider>
+                                <StyledStatusBar />
+                                <NavBarColorHandler />
+                                <AuthPass>
+                                  <I18nextProvider i18n={i18n}>
+                                    <LocaleProvider>
+                                      <BridgeSyncProvider>
+                                        <CounterValuesProvider
+                                          initialState={initialCountervalues}
+                                        >
+                                          <ButtonUseTouchable.Provider
+                                            value={true}
+                                          >
+                                            <OnboardingContextProvider>
+                                              <ToastProvider>
+                                                <NotificationsProvider>
+                                                  <SnackbarContainer />
+                                                  <NftMetadataProvider>
+                                                    <MarketDataProvider>
+                                                      <App
+                                                        importDataString={
+                                                          importDataString
+                                                        }
+                                                      />
+                                                    </MarketDataProvider>
+                                                  </NftMetadataProvider>
+                                                </NotificationsProvider>
+                                              </ToastProvider>
+                                            </OnboardingContextProvider>
+                                          </ButtonUseTouchable.Provider>
+                                        </CounterValuesProvider>
+                                      </BridgeSyncProvider>
+                                    </LocaleProvider>
+                                  </I18nextProvider>
+                                </AuthPass>
+                              </SafeAreaProvider>
+                            </DeepLinkingNavigator>
+                          </FirebaseFeatureFlagsProvider>
+                        </FirebaseRemoteConfigProvider>
+                      </RampCatalogProvider>
+                    </GlobalCatalogProvider>
+                  </RemoteLiveAppProvider>
                 </WalletConnectProvider>
               </>
             ) : (

--- a/src/navigation/useDeepLinking.js
+++ b/src/navigation/useDeepLinking.js
@@ -1,7 +1,7 @@
 // @flow
 import { useCallback, useMemo } from "react";
 import { useNavigation } from "@react-navigation/native";
-import { usePlatformApp } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider";
+import { useRemoteLiveAppContext } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
 import { filterPlatformApps } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider/helpers";
 import { NavigatorName, ScreenName } from "../const";
 
@@ -36,7 +36,8 @@ function getSettingsScreen(pathname) {
 
 export function useDeepLinkHandler() {
   const { navigate } = useNavigation();
-  const { manifests } = usePlatformApp();
+  const { state } = useRemoteLiveAppContext();
+  const manifests = state.value.liveAppByIndex;
 
   const filteredManifests = useMemo(() => {
     const branches = ["stable", "soon"];

--- a/src/screens/Exchange/Buy.js
+++ b/src/screens/Exchange/Buy.js
@@ -5,7 +5,7 @@ import { View, StyleSheet, Platform } from "react-native";
 import SafeAreaView from "react-native-safe-area-view";
 import { useTranslation } from "react-i18next";
 import { useNavigation, useTheme } from "@react-navigation/native";
-import { usePlatformApp } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider";
+import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
 import extraStatusBarPadding from "../../logic/extraStatusBarPadding";
 import TrackScreen from "../../analytics/TrackScreen";
 import Button from "../../components/Button";
@@ -25,15 +25,14 @@ export default function Buy() {
   const { colors } = useTheme();
 
   const [provider, setProvider] = useState<Provider>(null);
-  const { manifests } = usePlatformApp();
 
+  const moonPayManifest = useRemoteLiveAppManifest("moonpay");
   const navigateToMoonPay = useCallback(() => {
-    const manifest = manifests.get("moonpay");
     navigation.navigate(ScreenName.PlatformApp, {
-      platform: manifest.id,
-      name: manifest.name,
+      platform: moonPayManifest.id,
+      name: moonPayManifest.name,
     });
-  }, [navigation, manifests]);
+  }, [navigation, moonPayManifest]);
 
   const navigateToCoinify = useCallback(() => {
     navigation.navigate(ScreenName.Coinify);

--- a/src/screens/Platform/App.js
+++ b/src/screens/Platform/App.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
+import { useLocalLiveAppManifest } from "@ledgerhq/live-common/lib/platform/providers/LocalLiveAppProvider";
 import type { StackScreenProps } from "@react-navigation/stack";
 import { useTheme } from "@react-navigation/native";
 import TrackScreen from "../../analytics/TrackScreen";
@@ -10,7 +11,9 @@ import WebPlatformPlayer from "../../components/WebPlatformPlayer";
 const PlatformApp = ({ route }: StackScreenProps) => {
   const { dark } = useTheme();
   const { platform: appId, ...params } = route.params;
-  const manifest = useRemoteLiveAppManifest(appId);
+  const localManifest = useLocalLiveAppManifest(appId);
+  const remoteManifest = useRemoteLiveAppManifest(appId);
+  const manifest = localManifest || remoteManifest;
   const themeType = dark ? "dark" : "light";
 
   return manifest ? (

--- a/src/screens/Platform/App.js
+++ b/src/screens/Platform/App.js
@@ -1,7 +1,7 @@
 // @flow
 
 import React from "react";
-import { usePlatformApp } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider";
+import { useRemoteLiveAppManifest } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
 import type { StackScreenProps } from "@react-navigation/stack";
 import { useTheme } from "@react-navigation/native";
 import TrackScreen from "../../analytics/TrackScreen";
@@ -10,8 +10,7 @@ import WebPlatformPlayer from "../../components/WebPlatformPlayer";
 const PlatformApp = ({ route }: StackScreenProps) => {
   const { dark } = useTheme();
   const { platform: appId, ...params } = route.params;
-  const { manifests } = usePlatformApp();
-  const manifest = manifests.get(appId);
+  const manifest = useRemoteLiveAppManifest(appId);
   const themeType = dark ? "dark" : "light";
 
   return manifest ? (

--- a/src/screens/Platform/index.js
+++ b/src/screens/Platform/index.js
@@ -4,7 +4,7 @@ import React, { useMemo, useCallback, useState, useEffect } from "react";
 import { StyleSheet, View } from "react-native";
 import { Trans } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
-import { usePlatformApp } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider";
+import { useRemoteLiveAppContext } from "@ledgerhq/live-common/lib/platform/providers/RemoteLiveAppProvider";
 import { filterPlatformApps } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider/helpers";
 import type { AccountLike, Account } from "@ledgerhq/live-common/lib/types";
 import type { AppManifest } from "@ledgerhq/live-common/lib/platform/types";
@@ -35,7 +35,8 @@ const PlatformCatalog = ({ route }: { route: { params: RouteParams } }) => {
   const { platform, ...routeParams } = route.params ?? {};
   const navigation = useNavigation();
 
-  const { manifests } = usePlatformApp();
+  const { state } = useRemoteLiveAppContext();
+  const manifests = state.value.liveAppByIndex;
   const experimental = useEnv("PLATFORM_EXPERIMENTAL_APPS");
 
   const filteredManifests = useMemo(() => {
@@ -118,7 +119,7 @@ const PlatformCatalog = ({ route }: { route: { params: RouteParams } }) => {
       <CatalogTwitterBanner />
       {filteredManifests.map(manifest => (
         <AppCard
-          key={manifest.id}
+          key={`${manifest.id}.${manifest.branch}`}
           manifest={manifest}
           onPress={handlePressCard}
         />

--- a/src/screens/Settings/Developer/CustomManifest.js
+++ b/src/screens/Settings/Developer/CustomManifest.js
@@ -2,7 +2,7 @@
 import React, { useState, useMemo, useCallback } from "react";
 import { TextInput, StyleSheet } from "react-native";
 import { useTheme, NavigationProp } from "@react-navigation/native";
-import { usePlatformApp } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider";
+import { useLocalLiveAppContext } from "@ledgerhq/live-common/src/platform/providers/LocalLiveAppProvider";
 import NavigationScrollView from "../../../components/NavigationScrollView";
 import Button from "../../../components/Button";
 import { ScreenName } from "../../../const";
@@ -62,7 +62,7 @@ export default function CustomManifest({
 
 function useCustomManifest() {
   const [manifest, setManifest] = useState("");
-  const { addLocalManifest } = usePlatformApp();
+  const { addLocalManifest } = useLocalLiveAppContext();
 
   const onChange = useCallback(val => {
     try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2535,9 +2535,10 @@
     bignumber.js "^9.0.1"
     json-rpc-2.0 "^0.2.16"
 
-"@ledgerhq/live-common@https://github.com/LedgerHQ/ledger-live-common.git#develop":
-  version "21.34.1-cosmos.4"
-  resolved "https://github.com/LedgerHQ/ledger-live-common.git#4709a08677fc0220c1b53c635bde7ef210093110"
+"@ledgerhq/live-common@21.35.0":
+  version "21.35.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-21.35.0.tgz#e724b342472779737e93cc052420159c0771250b"
+  integrity sha512-GUiOZXDN7K4OhNyCo4IgJAM0UNLj5eZEEteiDoxls0WpuHWV5/YtNJH183ra4nB8MYhyKvHXEGCjFvVPvIUoyA==
   dependencies:
     "@celo/contractkit" "^1.5.2"
     "@celo/wallet-base" "^1.5.2"


### PR DESCRIPTION
Replaced old `PlatformAppProvider` with `RampCatalogProvider `, `LocalLiveAppProvider `, `GlobalCatalogProvider ` and `RemoteLiveAppProvider ` from ledger-live-common repo. 

Reworked logic to use new providers

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LIVE-1711

### Parts of the app affected / Test plan
React context providers for app manifests and used crypto currencies
