### PR TITLE
fix: update version code to match latest nightly release

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -152,7 +152,7 @@ android {
         multiDexEnabled true
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 4195731
+        versionCode 36176127
         versionName "2.40.0"
         resValue "string", "build_config_package", "com.ledger.live"
         testBuildType System.getProperty('testBuildType', 'debug')


### PR DESCRIPTION
### Bump the version code so that it matches the latest nightly release in the Play Console.

**🤜  Unblocks nightly releases.** 

It has been increased a lot when testing monorepo nightly releases (which now serialize the package version into version codes instead of incrementing the code).

Without this change the regular nightly release flow fails because it tries to upload artifacts having a version code lower than the max.

<img width="1792" alt="Capture d’écran 2022-03-21 à 11 41 40" src="https://user-images.githubusercontent.com/3428394/159245740-2697ab05-a948-435e-aeee-ab4a9fefff9d.png">

### Type

Fix

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
