### PR TITLE
fix/LL 1665 device info rendering

### DIFF
--- a/src/screens/Manager/Device/DeviceAppStorage.tsx
+++ b/src/screens/Manager/Device/DeviceAppStorage.tsx
@@ -50,6 +50,7 @@ const DeviceAppStorage = ({
         flexDirection={"row"}
         alignItems={"center"}
         justifyContent={"space-between"}
+        flexWrap={"wrap"}
         mb={3}
       >
         <Flex flexDirection={"row"} alignItems={"center"}>
@@ -64,7 +65,7 @@ const DeviceAppStorage = ({
               fontWeight={"medium"}
               color={"palette.neutral.c80"}
             >
-              Used
+              <Trans i18nKey="manager.storage.used" />
             </Text>{" "}
             <ByteSize
               value={appsSpaceBytes}


### PR DESCRIPTION
![Screenshot_20220315-144632](https://user-images.githubusercontent.com/90627435/159877077-297b2f7b-aba6-4e08-84b0-9ae1f70429d3.png)

### Type

Fix

### Context

[LL-1665] relative to @ychen-ledger report 

### Parts of the app affected / Test plan

![Screenshot_2022-03-24-09-45-25-96_99c1b3bb631177f8a9e1379ae5b12ffe](https://user-images.githubusercontent.com/90627435/159882939-2f8906a6-4476-4c05-8878-400c930535f6.jpg)

manager page on device storage info:
- translation key for used (to check in english and another lang)
- wrap of device info when too much info

[LL-1665]: https://ledgerhq.atlassian.net/browse/LL-1665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ