### PR TITLE
Regions v3 regression

### DIFF
--- a/src/components/AccountGraphCard.tsx
+++ b/src/components/AccountGraphCard.tsx
@@ -15,6 +15,7 @@ import { Box, Flex, Text, ChartCard } from "@ledgerhq/native-ui";
 
 import { useTranslation } from "react-i18next";
 import { rangeDataTable } from "@ledgerhq/live-common/lib/market/utils/rangeDataTable";
+import { useSelector } from "react-redux";
 import { ensureContrast } from "../colors";
 import { useTimeRange } from "../actions/settings";
 import Delta from "./Delta";
@@ -24,8 +25,8 @@ import Placeholder from "./Placeholder";
 import { Item } from "./Graph/types";
 import CurrencyRate from "./CurrencyRate";
 import { useBalanceHistoryWithCountervalue } from "../actions/portfolio";
-import { useLocale } from "../context/Locale";
 import { counterValueFormatter } from "../screens/Market/utils";
+import { localeSelector } from "../reducers/settings";
 
 type HeaderProps = {
   account: AccountLike;
@@ -102,7 +103,7 @@ function AccountGraphCard({
   renderAccountSummary,
 }: Props) {
   const { colors } = useTheme();
-  const { locale } = useLocale();
+  const locale = useSelector(localeSelector);
   const { t } = useTranslation();
 
   const [rangeRequest, setRangeRequest] = useState("24h");

--- a/src/components/CurrencyUnitValue.tsx
+++ b/src/components/CurrencyUnitValue.tsx
@@ -4,8 +4,7 @@ import { Unit } from "@ledgerhq/live-common/lib/types";
 import { useSelector } from "react-redux";
 import { BigNumber } from "bignumber.js";
 
-import { useLocale } from "../context/Locale";
-import { discreetModeSelector } from "../reducers/settings";
+import { discreetModeSelector, localeSelector } from "../reducers/settings";
 
 type Props = {
   unit: Unit;
@@ -28,7 +27,7 @@ const CurrencyUnitValue = ({
   disableRounding = false,
   joinFragmentsSeparator = "",
 }: Props): JSX.Element => {
-  const { locale } = useLocale();
+  const locale = useSelector(localeSelector);
   const discreet = useSelector(discreetModeSelector);
   const value =
     valueProp instanceof BigNumber ? valueProp : new BigNumber(valueProp);

--- a/src/components/RequireTerms.js
+++ b/src/components/RequireTerms.js
@@ -12,7 +12,7 @@ import {
 import { useTheme } from "@react-navigation/native";
 import { useTerms, useTermsAccept, url } from "../logic/terms";
 import getWindowDimensions from "../logic/getWindowDimensions";
-import { useLocale } from "../context/Locale";
+import { useTranslationLocale } from "../context/Locale";
 import LText from "./LText";
 import SafeMarkdown from "./SafeMarkdown";
 import Button from "./Button";
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
 
 const RequireTermsModal = () => {
   const { colors } = useTheme();
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   const [markdown, error, retry] = useTerms(locale);
   const [accepted, accept] = useTermsAccept();
   const [toggle, setToggle] = useState(false);
@@ -147,7 +147,7 @@ export const TermModals = ({
   close: () => void,
 }) => {
   const { colors } = useTheme();
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   const [markdown, error, retry] = useTerms(locale);
   const height = getWindowDimensions().height - 320;
 

--- a/src/components/RequireTerms.tsx
+++ b/src/components/RequireTerms.tsx
@@ -12,7 +12,7 @@ import { GraphGrowAltMedium } from "@ledgerhq/native-ui/assets/icons";
 import { BottomDrawer } from "@ledgerhq/native-ui";
 import { useTerms, useTermsAccept, url } from "../logic/terms";
 import getWindowDimensions from "../logic/getWindowDimensions";
-import { useLocale } from "../context/Locale";
+import { useTranslationLocale } from "../context/Locale";
 import LText from "./LText";
 import SafeMarkdown from "./SafeMarkdown";
 import Button from "./Button";
@@ -64,7 +64,7 @@ const styles = StyleSheet.create({
 
 const RequireTermsModal = () => {
   const { colors } = useTheme();
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   const [markdown, error, retry] = useTerms(locale);
   const [accepted, accept] = useTermsAccept();
   const [toggle, setToggle] = useState(false);
@@ -149,7 +149,7 @@ export const TermModals = ({
   const { t } = useTranslation();
 
   const { colors } = useTheme();
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   const [markdown, error, retry] = useTerms(locale);
   const height = getWindowDimensions().height - 320;
 

--- a/src/context/Locale.js
+++ b/src/context/Locale.js
@@ -74,7 +74,16 @@ export default function LocaleProvider({ children }: Props) {
   );
 }
 
-export function useLocale() {
+/**
+ * This returns an object containing the "language setting" locale, to be used for
+ * translation purposes.
+ *
+ * /!\ Do not use this for number or date formatting.
+ * For number or date formatting (according to the "region setting" locale),
+ * use instead `useSelector(localeSelector)` where `localeSelector` comes from
+ * `src/reducers/settings.js`.
+ * */
+export function useTranslationLocale() {
   return useContext(LocaleContext);
 }
 

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -85,8 +85,10 @@ export type SettingsState = {
   osTheme: ?string,
   carouselVisibility: any,
   discreetMode: boolean,
+  /** Used for translations. In the UI, this is the "language" setting. */
   language: string,
   languageIsSetByUser: boolean,
+  /** Used for number & date formatting. In the UI, this is the "region" setting. */
   locale: ?string,
   swap: {
     hasAcceptedIPSharing: false,

--- a/src/screens/Analytics/DistributionCard.tsx
+++ b/src/screens/Analytics/DistributionCard.tsx
@@ -14,6 +14,8 @@ import ProgressBar from "../../components/ProgressBar";
 import CounterValue from "../../components/CounterValue";
 import ParentCurrencyIcon from "../../components/ParentCurrencyIcon";
 import { ensureContrast } from "../../colors";
+import { useSelector } from "react-redux";
+import { localeSelector } from "../../reducers/settings";
 
 export type DistributionItem = {
   currency: CryptoCurrency | TokenCurrency,
@@ -68,6 +70,7 @@ export default function DistributionCard({
   item: { currency, amount, distribution },
 }: Props) {
   const { colors } = useTheme();
+  const locale = useSelector(localeSelector);
   const color = useMemo(
     () => ensureContrast(getCurrencyColor(currency), colors.background.main),
     [colors, currency],
@@ -86,7 +89,7 @@ export default function DistributionCard({
               {currency.name}
             </Text>
             <Text variant="large" color="neutral.c100" fontWeight="semiBold">
-              {`${percentage}%`}
+              {`${percentage.toLocaleString(locale)}%`}
             </Text>
           </CurrencyRow>
           {distribution ? (

--- a/src/screens/Market/MarketDetail/MarketStats.tsx
+++ b/src/screens/Market/MarketDetail/MarketStats.tsx
@@ -4,9 +4,10 @@ import styled from "styled-components/native";
 import { Flex, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import { CurrencyData } from "@ledgerhq/live-common/lib/market/types";
-import { useTranslationLocale } from "../../../context/Locale";
+import { useSelector } from "react-redux";
 import { counterValueFormatter, getDateFormatter } from "../utils";
 import DeltaVariation from "../DeltaVariation";
+import { localeSelector } from "../../../reducers/settings";
 
 const StatRowContainer = styled(Flex).attrs({
   flexDirection: "row",
@@ -70,7 +71,7 @@ export default function MarketStats({
   counterCurrency: string;
 }) {
   const { t } = useTranslation();
-  const { locale } = useTranslationLocale();
+  const locale = useSelector(localeSelector);
 
   const {
     marketcap,

--- a/src/screens/Market/MarketDetail/MarketStats.tsx
+++ b/src/screens/Market/MarketDetail/MarketStats.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components/native";
 import { Flex, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import { CurrencyData } from "@ledgerhq/live-common/lib/market/types";
-import { useLocale } from "../../../context/Locale";
+import { useTranslationLocale } from "../../../context/Locale";
 import { counterValueFormatter, getDateFormatter } from "../utils";
 import DeltaVariation from "../DeltaVariation";
 
@@ -70,7 +70,7 @@ export default function MarketStats({
   counterCurrency: string;
 }) {
   const { t } = useTranslation();
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
 
   const {
     marketcap,

--- a/src/screens/Market/MarketDetail/index.tsx
+++ b/src/screens/Market/MarketDetail/index.tsx
@@ -20,10 +20,10 @@ import { Image, RefreshControl } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 // import { Account } from "@ledgerhq/live-common/lib/types";
 import {
+  localeSelector,
   starredMarketCoinsSelector,
   swapSelectableCurrenciesSelector,
 } from "../../../reducers/settings";
-import { useLocale } from "../../../context/Locale";
 import { NavigatorName, ScreenName } from "../../../const";
 import { isCurrencySupported } from "../../Exchange/coinifyConfig";
 import CircleCurrencyIcon from "../../../components/CircleCurrencyIcon";
@@ -82,7 +82,7 @@ function MarketDetail({
   const { currencyId, resetSearchOnUmount } = params;
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { locale } = useLocale();
+  const locale = useSelector(localeSelector);
   const dispatch = useDispatch();
   const starredMarketCoins: string[] = useSelector(starredMarketCoinsSelector);
   const isStarred = starredMarketCoins.includes(currencyId);

--- a/src/screens/Market/index.tsx
+++ b/src/screens/Market/index.tsx
@@ -25,9 +25,11 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { MarketListRequestParams } from "@ledgerhq/live-common/lib/market/types";
-import { starredMarketCoinsSelector } from "../../reducers/settings";
+import {
+  localeSelector,
+  starredMarketCoinsSelector,
+} from "../../reducers/settings";
 import MarketRowItem from "./MarketRowItem";
-import { useLocale } from "../../context/Locale";
 import SortBadge, { Badge } from "./SortBadge";
 import SearchHeader from "./SearchHeader";
 import { ScreenName } from "../../const";
@@ -222,7 +224,7 @@ const BottomSection = ({
 export default function Market({ navigation }: { navigation: any }) {
   const { t } = useTranslation();
   const { colors } = useTheme();
-  const { locale } = useLocale();
+  const locale = useSelector(localeSelector);
 
   useProviders();
 

--- a/src/screens/NotificationCenter/NotificationsProvider.js
+++ b/src/screens/NotificationCenter/NotificationsProvider.js
@@ -11,7 +11,7 @@ import VersionNumber from "react-native-version-number";
 import Config from "react-native-config";
 import { getEnv } from "@ledgerhq/live-common/lib/env";
 import { getNotifications, saveNotifications } from "../../db";
-import { useLocale } from "../../context/Locale";
+import { useTranslationLocale } from "../../context/Locale";
 import { cryptoCurrenciesSelector } from "../../reducers/accounts";
 import { track } from "../../analytics";
 import { lastSeenDeviceSelector } from "../../reducers/settings";
@@ -31,7 +31,7 @@ type Props = {
 };
 
 export default function NotificationsProvider({ children }: Props) {
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   const currenciesRaw: CryptoCurrency[] = useSelector(cryptoCurrenciesSelector);
   const lastSeenDevice = useSelector(lastSeenDeviceSelector);
 

--- a/src/screens/Onboarding/steps/language.js
+++ b/src/screens/Onboarding/steps/language.js
@@ -15,7 +15,7 @@ import { TrackScreen } from "../../../analytics";
 import Button from "../../../components/Button";
 import LText from "../../../components/LText";
 import CheckBox from "../../../components/CheckBox";
-import { useLocale } from "../../../context/Locale";
+import { useTranslationLocale } from "../../../context/Locale";
 import { languages, supportedLocales } from "../../../languages";
 import { setLanguage } from "../../../actions/settings";
 
@@ -25,7 +25,7 @@ function OnboardingStepLanguage({ navigation }: *) {
   const next = useCallback(() => {
     navigation.goBack();
   }, [navigation]);
-  const { locale: currentLocale } = useLocale();
+  const { locale: currentLocale } = useTranslationLocale();
 
   const changeLanguage = useCallback(
     l => {

--- a/src/screens/Onboarding/steps/language.tsx
+++ b/src/screens/Onboarding/steps/language.tsx
@@ -10,7 +10,7 @@ import {
 } from "@ledgerhq/native-ui";
 import { StackScreenProps } from "@react-navigation/stack";
 import { useDispatch } from "react-redux";
-import { useLocale } from "../../../context/Locale";
+import { useTranslationLocale } from "../../../context/Locale";
 import { supportedLocales } from "../../../languages";
 import Button from "../../../components/Button";
 import { ScreenName } from "../../../const";
@@ -39,7 +39,7 @@ const languages = {
 };
 
 function OnboardingStepLanguage({ navigation }: StackScreenProps<{}>) {
-  const { locale: currentLocale } = useLocale();
+  const { locale: currentLocale } = useTranslationLocale();
   const dispatch = useDispatch();
 
   const next = useCallback(() => {

--- a/src/screens/Onboarding/steps/terms.js
+++ b/src/screens/Onboarding/steps/terms.js
@@ -18,7 +18,7 @@ import ExternalLink from "../../../components/ExternalLink";
 import Touchable from "../../../components/Touchable";
 import AnimatedHeaderView from "../../../components/AnimatedHeader";
 
-import { useLocale } from "../../../context/Locale";
+import { useTranslationLocale } from "../../../context/Locale";
 
 import { urls } from "../../../config/urls";
 import ArrowRight from "../../../icons/ArrowRight";
@@ -49,7 +49,7 @@ const LinkBox = React.memo(({ style, text, url, event }: LinkBoxProps) => {
 
 function OnboardingStepTerms({ navigation }: *) {
   const { colors } = useTheme();
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   const dispatch = useDispatch();
   const [, accept] = useTermsAccept();
   const [toggle, setToggle] = useState(false);

--- a/src/screens/Onboarding/steps/terms.tsx
+++ b/src/screens/Onboarding/steps/terms.tsx
@@ -11,7 +11,7 @@ import { TrackScreen } from "../../../analytics";
 import { ScreenName } from "../../../const";
 import { setAnalytics } from "../../../actions/settings";
 import { useTermsAccept } from "../../../logic/terms";
-import { useLocale } from "../../../context/Locale";
+import { useTranslationLocale } from "../../../context/Locale";
 import { urls } from "../../../config/urls";
 import OnboardingView from "../OnboardingView";
 import StyledStatusBar from "../../../components/StyledStatusBar";
@@ -49,7 +49,7 @@ const LinkBox = React.memo(({ text, url, event, mb = 0 }: LinkBoxProps) => (
 ));
 
 function OnboardingStepTerms() {
-  const { locale = "en" } = useLocale();
+  const { locale = "en" } = useTranslationLocale();
   const dispatch = useDispatch();
   const [, setAccepted] = useTermsAccept();
   const [toggle, setToggle] = useState(false);

--- a/src/screens/Onboarding/steps/welcome.tsx
+++ b/src/screens/Onboarding/steps/welcome.tsx
@@ -9,7 +9,7 @@ import { Linking } from "react-native";
 import Svg, { Defs, LinearGradient, Rect, Stop } from "react-native-svg";
 import { useDispatch } from "react-redux";
 import Button from "../../../components/Button";
-import { useLocale } from "../../../context/Locale";
+import { useTranslationLocale } from "../../../context/Locale";
 import { ScreenName } from "../../../const";
 import StyledStatusBar from "../../../components/StyledStatusBar";
 import { urls } from "../../../config/urls";
@@ -39,7 +39,7 @@ function OnboardingStepWelcome({ navigation }: any) {
     [navigation],
   );
 
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
 
   const onTermsLink = useCallback(() => Linking.openURL(urls.terms[locale]), [
     locale,

--- a/src/screens/Platform/AppCard.js
+++ b/src/screens/Platform/AppCard.js
@@ -8,7 +8,7 @@ import { useTranslation } from "react-i18next";
 import type { AppManifest } from "@ledgerhq/live-common/lib/platform/types";
 import { translateContent } from "@ledgerhq/live-common/lib/platform/logic";
 
-import { useLocale } from "../../context/Locale";
+import { useTranslationLocale } from "../../context/Locale";
 
 import LText from "../../components/LText";
 import IconChevron from "../../icons/ArrowRight";
@@ -56,7 +56,7 @@ const AppCard = ({
   onPress: (manifest: AppManifest) => void,
 }) => {
   const { colors } = useTheme();
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   const { t } = useTranslation();
   const isDisabled = manifest.branch === "soon";
 

--- a/src/screens/Portfolio/MarketSection.tsx
+++ b/src/screens/Portfolio/MarketSection.tsx
@@ -6,10 +6,11 @@ import { useTranslation } from "react-i18next";
 import { useMarketData } from "@ledgerhq/live-common/lib/market/MarketDataProvider";
 import { CurrencyData } from "@ledgerhq/live-common/lib/market/types";
 import { NavigatorName, ScreenName } from "../../const";
-import { useLocale } from "../../context/Locale";
 import { useProviders } from "../Swap/SwapEntry";
 import MarketRowItem from "../Market/MarketRowItem";
 import Placeholder from "../../components/Placeholder";
+import { useSelector } from "react-redux";
+import { localeSelector } from "../../reducers/settings";
 
 function getTopGainers(
   coins: CurrencyData[] | undefined = [],
@@ -23,7 +24,7 @@ function getTopGainers(
 export default function MarketSection() {
   const { t } = useTranslation();
   const navigation = useNavigation();
-  const { locale } = useLocale();
+  const locale = useSelector(localeSelector);
   const [topGainers, setTopGainers] = useState<CurrencyData[] | undefined>();
 
   useProviders();

--- a/src/screens/Settings/About/PrivacyPolicyRow.js
+++ b/src/screens/Settings/About/PrivacyPolicyRow.js
@@ -6,11 +6,11 @@ import { View, Linking, StyleSheet } from "react-native";
 import SettingsRow from "../../../components/SettingsRow";
 import { urls } from "../../../config/urls";
 import ExternalLink from "../../../icons/ExternalLink";
-import { useLocale } from "../../../context/Locale";
+import { useTranslationLocale } from "../../../context/Locale";
 
 function PrivacyPolicyRow() {
   const { colors } = useTheme();
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   return (
     <SettingsRow
       event="PrivacyPolicyRow"

--- a/src/screens/Settings/About/PrivacyPolicyRow.tsx
+++ b/src/screens/Settings/About/PrivacyPolicyRow.tsx
@@ -4,10 +4,10 @@ import { Linking } from "react-native";
 import { ExternalLinkMedium } from "@ledgerhq/native-ui/assets/icons";
 import SettingsRow from "../../../components/SettingsRow";
 import { urls } from "../../../config/urls";
-import { useLocale } from "../../../context/Locale";
+import { useTranslationLocale } from "../../../context/Locale";
 
 function PrivacyPolicyRow() {
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   return (
     <SettingsRow
       event="PrivacyPolicyRow"

--- a/src/screens/Settings/Debug/index.tsx
+++ b/src/screens/Settings/Debug/index.tsx
@@ -39,7 +39,7 @@ export function DebugMocks() {
           dataStr={config.BRIDGESTREAM_DATA}
         />
       ) : null}
-      {accounts.length === 0 ? (
+      {true || accounts.length === 0 ? (
         <GenerateMockAccounts title="Generate 10 mock Accounts" count={10} />
       ) : null}
       <OpenDebugLogs />

--- a/src/screens/Settings/General/LanguageRow.js
+++ b/src/screens/Settings/General/LanguageRow.js
@@ -5,7 +5,7 @@ import { useTranslation } from "react-i18next";
 import SettingsRow from "../../../components/SettingsRow";
 import LText from "../../../components/LText";
 import { NavigatorName, ScreenName } from "../../../const";
-import { useLocale } from "../../../context/Locale";
+import { useTranslationLocale } from "../../../context/Locale";
 
 export const languageLabels = {
   de: "Deutsch",
@@ -30,7 +30,7 @@ export const languageLabels = {
 };
 
 export default function LanguageSettingsRow() {
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   const { t } = useTranslation();
   const { navigate } = useNavigation();
   const onNavigate = useCallback(() => {

--- a/src/screens/Settings/General/LanguageRow.tsx
+++ b/src/screens/Settings/General/LanguageRow.tsx
@@ -4,7 +4,7 @@ import { Trans } from "react-i18next";
 import { Text } from "@ledgerhq/native-ui";
 import SettingsRow from "../../../components/SettingsRow";
 import { NavigatorName, ScreenName } from "../../../const";
-import { useLocale } from "../../../context/Locale";
+import { useTranslationLocale } from "../../../context/Locale";
 
 export const languageLabels = {
   de: "Deutsch",
@@ -29,7 +29,7 @@ export const languageLabels = {
 };
 
 export default function LanguageSettingsRow() {
-  const { locale } = useLocale();
+  const { locale } = useTranslationLocale();
   const { navigate } = useNavigation();
   const onNavigate = useCallback(() => {
     navigate(ScreenName.OnboardingLanguage);

--- a/src/screens/Settings/General/RegionRow.js
+++ b/src/screens/Settings/General/RegionRow.js
@@ -2,9 +2,9 @@
 import React from "react";
 import { useNavigation } from "@react-navigation/native";
 import { Trans } from "react-i18next";
+import { Text } from "@ledgerhq/native-ui";
 import { useSelector } from "react-redux";
 import SettingsRow from "../../../components/SettingsRow";
-import LText from "../../../components/LText";
 import { ScreenName } from "../../../const";
 import { localeSelector } from "../../../reducers/settings";
 import regionsByKey from "./regions.json";
@@ -22,9 +22,9 @@ export default function RegionRow() {
       onPress={() => navigate(ScreenName.RegionSettings)}
       alignedTop
     >
-      <LText semiBold color="grey">
+      <Text variant="body" fontWeight="medium" color="primary.c80">
         {region ? `${region.regionDisplayName} (${locale})` : locale}
-      </LText>
+      </Text>
     </SettingsRow>
   );
 }

--- a/src/screens/Settings/General/index.tsx
+++ b/src/screens/Settings/General/index.tsx
@@ -8,6 +8,7 @@ import AnalyticsRow from "./AnalyticsRow";
 import CarouselRow from "./CarouselRow";
 import LanguageRow from "./LanguageRow";
 import SettingsNavigationScrollView from "../SettingsNavigationScrollView";
+import RegionRow from "./RegionRow";
 
 export default function GeneralSettings() {
   return (
@@ -15,6 +16,7 @@ export default function GeneralSettings() {
       <TrackScreen category="Settings" name="General" />
       <CountervalueSettingsRow />
       <LanguageRow />
+      <RegionRow />
       <ThemeSettingsRow />
       <AuthSecurityToggle />
       <ReportErrorsRow />


### PR DESCRIPTION
- [x] Put region settings back in the general settings UI.
- [x] Reimplement of "searchable" list in `makeGenericSelectScreen.tsx`, this was a regression of v3 as it was implemented in the .js version already.
- [x] Fix regression in components using the incorrect locale (things that were implemented in V2 but not in V3 components), used this PR as a base #1941.
- [x] Fix remaining incorrect uses of `useLocale()` when doing number/date formatting (instead, using `localeSelector`), see following point for explanation.
- [x] Rename `useLocale()` (in `Locale.js`) to `useTranslationLocale()` & document it to avoid confusions & uses in wrong context (it should be used only for handling translatable content, not for number & date formatting).
- [ ] Ensure Intl polyfills (for Hermes) are working for all selectable regions.

### Type

Bug fix

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
