### PR TITLE
doc/setup update

### DIFF
--- a/docs/linux_setup.md
+++ b/docs/linux_setup.md
@@ -147,21 +147,17 @@ export JRE_HOME
 export PATH
 
 ANDROID_SDK_ROOT=~/Android/Sdk
-
 export ANDROID_SDK_ROOT
 export ANDROID_HOME=~/Android/Sdk
 
 export PATH=$PATH:$HOME"/Android/Sdk/platform-tools"
-
 export PATH=$PATH:$HOME"/Android/Sdk/emulator/emulator"
-
 export PATH=$PATH:$HOME"/Android/Sdk/tools"
-
 export PATH="$(yarn global bin):$PATH"
-
 export PATH=$PATH:$HOME"/watchman/linux/bin"
-
 export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"
+
+export NODE_OPTIONS=--max-old-space-size=8192
 ```
 
 #### Dev on android


### PR DESCRIPTION
# Add export node options

@LFBarreto informed the team to add a new env variable : NODE_OPTIONS to add more memory on build of app.
It seems to be mandatory to be able to build the app with Hermes.

### Type

Documentation

### Parts of the app affected / Test plan

Only documentation