### PR TITLE
Bugfix/accounts eth btc fixes 3

### DIFF
--- a/src/components/Carousel/Slide.tsx
+++ b/src/components/Carousel/Slide.tsx
@@ -56,6 +56,7 @@ const Slide = ({
               type="color"
               Icon={Icons.ArrowRightMedium}
               iconPosition="right"
+              onPress={onClick}
             >
               {cta}
             </TextLink>

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -82,8 +82,6 @@ const Carousel = ({ cardsVisibility }: Props) => {
     [cardsVisibility],
   );
 
-  console.log(slides.length);
-
   const onHide = useCallback(
     cardId => {
       const slide = SLIDES.find(slide => slide.name === cardId);

--- a/src/components/CopyLink.js
+++ b/src/components/CopyLink.js
@@ -3,9 +3,8 @@
 import React, { PureComponent } from "react";
 import { StyleSheet } from "react-native";
 import Clipboard from "@react-native-community/clipboard";
-import Icon from "react-native-vector-icons/dist/Feather";
+import { Icons, Text } from "@ledgerhq/native-ui";
 import Touchable from "./Touchable";
-import LText from "./LText";
 import { withTheme } from "../colors";
 
 type Props = {
@@ -40,7 +39,7 @@ class CopyLink extends PureComponent<Props, State> {
   };
 
   render() {
-    const { style, children, replacement, colors } = this.props;
+    const { style, children, replacement } = this.props;
     const { copied } = this.state;
     return (
       <Touchable
@@ -48,18 +47,18 @@ class CopyLink extends PureComponent<Props, State> {
         style={[styles.linkContainer, style]}
         onPress={this.onPress}
       >
-        <Icon
-          name="copy"
+        <Icons.CopyMedium
           size={16}
-          color={copied ? colors.grey : colors.live}
+          color={copied ? "neutral.c70" : "primary.c80"}
         />
-        <LText
-          style={[styles.linkText]}
-          color={copied ? "grey" : "live"}
-          semiBold
+        <Text
+          variant="body"
+          fontWeight="semiBold"
+          color={copied ? "neutral.c70" : "primary.c80"}
+          ml={3}
         >
           {copied && replacement ? replacement : children}
-        </LText>
+        </Text>
       </Touchable>
     );
   }

--- a/src/components/ShareLink.js
+++ b/src/components/ShareLink.js
@@ -2,9 +2,8 @@
 
 import React, { PureComponent } from "react";
 import { StyleSheet, Share } from "react-native";
-import Icon from "react-native-vector-icons/dist/Feather";
+import { Icons, Text } from "@ledgerhq/native-ui";
 import Touchable from "./Touchable";
-import LText from "./LText";
 import { withTheme } from "../colors";
 
 type Props = {
@@ -22,7 +21,7 @@ class ShareLink extends PureComponent<Props> {
   };
 
   render() {
-    const { children, colors } = this.props;
+    const { children } = this.props;
 
     return (
       <Touchable
@@ -30,10 +29,10 @@ class ShareLink extends PureComponent<Props> {
         style={styles.linkContainer}
         onPress={this.onPress}
       >
-        <Icon name="share" size={16} color={colors.live} />
-        <LText style={[styles.linkText]} color="live" semiBold>
+        <Icons.ShareMedium size={16} color="primary.c80" />
+        <Text variant="body" fontWeight="semiBold" color="primary.c80" ml={3}>
           {children}
-        </LText>
+        </Text>
       </Touchable>
     );
   }
@@ -46,8 +45,5 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     flexDirection: "row",
-  },
-  linkText: {
-    marginLeft: 6,
   },
 });

--- a/src/screens/Account/NftCollectionsList.tsx
+++ b/src/screens/Account/NftCollectionsList.tsx
@@ -51,7 +51,7 @@ export default function NftCollectionsList({ account }: Props) {
   // Forced to use useCallback here to avoid a non sensical warning...
   const navigateToCollection = useCallback(
     collection =>
-      navigation.navigate(NavigatorName.Accounts, {
+      navigation.navigate(NavigatorName.PortfolioAccounts, {
         screen: ScreenName.NftCollection,
         params: {
           collection,
@@ -63,7 +63,7 @@ export default function NftCollectionsList({ account }: Props) {
   );
 
   const navigateToGallery = useCallback(() => {
-    navigation.navigate(NavigatorName.Accounts, {
+    navigation.navigate(NavigatorName.PortfolioAccounts, {
       screen: ScreenName.NftGallery,
       params: {
         title: t("nft.gallery.allNft"),

--- a/src/screens/Accounts/index.tsx
+++ b/src/screens/Accounts/index.tsx
@@ -97,7 +97,7 @@ function Accounts({ navigation, route }: Props) {
         renderItem={renderItem}
         keyExtractor={i => i.id}
         ListEmptyComponent={<NoAccounts />}
-        contentContainerStyle={{ padding: 16 }}
+        contentContainerStyle={{ paddingHorizontal: 16 }}
       />
     ),
     [renderItem],
@@ -145,6 +145,7 @@ function Accounts({ navigation, route }: Props) {
           list={flattenedAccounts}
           inputWrapperStyle={{
             paddingHorizontal: 16,
+            paddingBottom: 16,
           }}
           renderList={renderList}
           renderEmptySearch={renderEmptySearch}

--- a/src/screens/ImportAccounts/DisplayResult.tsx
+++ b/src/screens/ImportAccounts/DisplayResult.tsx
@@ -117,7 +117,7 @@ class DisplayResult extends Component<Props, State> {
     }
 
     if (onFinish) onFinish();
-    else navigation.navigate(NavigatorName.Accounts);
+    else navigation.navigate(NavigatorName.PortfolioAccounts);
   };
 
   onSwitchResultItem = (checked: boolean, account: Account) => {

--- a/src/screens/Swap/Connect.js
+++ b/src/screens/Swap/Connect.js
@@ -44,7 +44,7 @@ const Connect = ({
         onClose={setDevice}
         onModalHide={onModalHide}
         device={result ? null : device}
-        onResult={setLocalResult}
+        onResult={setResult}
         action={action}
         request={null}
         onSelectDeviceLink={() => setDevice()}


### PR DESCRIPTION
Several bug fixes
https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/3589046311/Pre-QA+feedbacks#:~:text=CheckBox%20can%20be%20outside%20the%20screen%20if%20we%20have%20a%20long%20account%20name

- Fixed nfts navigation in account screen (when going back in nfts collection it was redirecting to the portfolio home screen, it is now redirecting to the parent account)
- Fixed recommended cards on portfolio, click on button didn't do anything, we had to click on the card to trigger the action, now both are working
- Fixed navigation redirection when importing accounts from desktop
- Fixed sell btc (it wasn't redirecting to the next step when selecting a device)
- Light mode copy and share link color fixed in receive screen

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
