### PR TITLE
Fix crash on Learn v3 navigation

### DIFF
--- a/src/components/RootNavigator/BaseNavigator.tsx
+++ b/src/components/RootNavigator/BaseNavigator.tsx
@@ -138,6 +138,7 @@ export default function BaseNavigator() {
           component={Learn}
           options={{
             headerShown: false,
+            animationEnabled: false,
           }}
         />
       ) : null}

--- a/src/components/RootNavigator/DiscoverNavigator.tsx
+++ b/src/components/RootNavigator/DiscoverNavigator.tsx
@@ -3,7 +3,6 @@
 import React, { useMemo } from "react";
 import { createStackNavigator } from "@react-navigation/stack";
 import { useTheme } from "styled-components/native";
-import useFeature from "@ledgerhq/live-common/lib/featureFlags/useFeature";
 import { ScreenName } from "../../const";
 import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import Discover from "../../screens/Discover";
@@ -15,7 +14,6 @@ export default function DiscoverNavigator() {
     () => getStackNavigatorConfig(colors, true),
     [colors],
   );
-  const learn = useFeature("learn");
 
   return (
     <Stack.Navigator screenOptions={stackNavigationConfig}>

--- a/src/components/Skeleton.js
+++ b/src/components/Skeleton.js
@@ -44,9 +44,11 @@ const Skeleton = ({
 
   const animatedStyle = useMemo(
     () => [
-      style,
       {
         backgroundColor: colors.skeletonBg,
+      },
+      style,
+      {
         opacity: opacityAnim,
       },
     ],

--- a/src/screens/Learn/LoadingScreen.tsx
+++ b/src/screens/Learn/LoadingScreen.tsx
@@ -3,7 +3,11 @@ import { Flex, Text } from "@ledgerhq/native-ui";
 import styled from "@ledgerhq/native-ui/components/styled";
 import { TouchableOpacity, ScrollView } from "react-native";
 import { useTranslation } from "react-i18next";
-import Skeleton from "../../components/Skeleton";
+import BaseSkeleton from "../../components/Skeleton";
+
+const Skeleton = styled(BaseSkeleton).attrs({
+  backgroundColor: "neutral.c30",
+})``;
 
 const PlaceholderBig = styled(Skeleton).attrs({ loading: true })`
   border-radius: 4px;


### PR DESCRIPTION
**TL;DR: webview + opacity animation + hardware acceleration = 💥** 

On Android, the Learn page was crashing upon being navigated to.
The reason is that the WebView inside was being faded-in (its opacity was animated) as part of the navigation animation and that causes a crash.

The solution here is to simply disable that animation.
_An alternative solution would be to keep the animation but disable hardware acceleration for rendering that one WebView._

### Type

Bug fix

### Context

v3 crashes 

### Parts of the app affected / Test plan

Learn page
