### PR TITLE
Fix InstalledAppsModal close button hidden behind status bar

### DIFF
--- a/src/screens/Manager/Modals/InstalledAppsModal.tsx
+++ b/src/screens/Manager/Modals/InstalledAppsModal.tsx
@@ -6,6 +6,7 @@ import { App } from "@ledgerhq/live-common/lib/types/manager";
 import { State, Action } from "@ledgerhq/live-common/lib/apps";
 import { Trans } from "react-i18next";
 import { ListAppsResult } from "@ledgerhq/live-common/lib/apps/types";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import AppIcon from "../AppsList/AppIcon";
 import ByteSize from "../../../components/ByteSize";
 import AppUninstallButton from "../AppsList/AppUninstallButton";
@@ -185,12 +186,21 @@ const InstalledAppsModal = ({
     if (!appList || !appList.length) onClose();
   }, [appList]);
 
+  const insets = useSafeAreaInsets();
+  const { top: safeAreaTop, bottom: safeAreaBottom } = insets;
+
   return (
     <BaseModal
       isOpen={isOpen}
       onClose={onClose}
       modalStyle={modalStyleOverrides.modal}
-      containerStyle={modalStyleOverrides.container}
+      containerStyle={[
+        modalStyleOverrides.container,
+        {
+          paddingTop: safeAreaTop,
+          paddingBottom: safeAreaBottom,
+        },
+      ]}
       propagateSwipe={true}
     >
       <Flex flex={1}>


### PR DESCRIPTION
Fix the "my apps" modal in the manager page, **close button was hidden behind StatusBar**.
Fixed by adding a padding from `useSafeAreaInsets`.
Also did it in the bottom as it might affect screens on Android for instance when there is a transparent status bar.

![modal-safe-area-close](https://user-images.githubusercontent.com/91890529/160806623-24646273-6e39-4cc5-a9e7-4063b0884019.jpg)


### Type

Bug fix

### Context

v3 pre-release pixel polish

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
