### PR TITLE
Can't submit the bitcoin customize fees form with zero as value when sending bitcoins

### DIFF
--- a/src/families/bitcoin/ScreenEditCustomFees.js
+++ b/src/families/bitcoin/ScreenEditCustomFees.js
@@ -52,6 +52,8 @@ function BitcoinEditCustomFees({ navigation, route }: Props) {
   };
 
   const onValidateText = useCallback(() => {
+    if (BigNumber(ownSatPerByte || 0).isZero()) return;
+
     Keyboard.dismiss();
 
     setSatPerByte(BigNumber(ownSatPerByte || 0));
@@ -122,7 +124,7 @@ const styles = StyleSheet.create({
     flex: 1,
     flexDirection: "row",
     justifyContent: "space-between",
-    alignItems: "flex-start",
+    alignItems: "center",
     padding: 20,
   },
   body: {


### PR DESCRIPTION
We are now preventing the user to submit the CustomizeFees form if the value is zero as it causes an InternalError in the Bitcoin Send Flow

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
