### PR TITLE
Settings language row now updating properly when changing language

### DIFF
--- a/src/screens/Settings/General/LanguageRow.tsx
+++ b/src/screens/Settings/General/LanguageRow.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import { useNavigation } from "@react-navigation/native";
-import { Trans } from "react-i18next";
+import { useTranslation } from "react-i18next";
 import { Text } from "@ledgerhq/native-ui";
 import SettingsRow from "../../../components/SettingsRow";
 import { ScreenName } from "../../../const";
@@ -28,18 +28,20 @@ export const languageLabels = {
   zh: "简体中文",
 };
 
-export default function LanguageSettingsRow() {
+const LanguageSettingsRow = () => {
   const { locale } = useLocale();
   const { navigate } = useNavigation();
   const onNavigate = useCallback(() => {
     navigate(ScreenName.OnboardingLanguage);
   }, [navigate]);
 
+  const { t } = useTranslation();
+
   return (
     <SettingsRow
       event="LanguageSettingsRow"
-      title={<Trans i18nKey="settings.display.language" />}
-      desc={<Trans i18nKey="settings.display.languageDesc" />}
+      title={t("settings.display.language")}
+      desc={t("settings.display.languageDesc")}
       arrowRight
       onPress={onNavigate}
     >
@@ -48,4 +50,6 @@ export default function LanguageSettingsRow() {
       </Text>
     </SettingsRow>
   );
-}
+};
+
+export default LanguageSettingsRow;


### PR DESCRIPTION
Before : Go to Settings > General, change Language, the text for "Display language" doesn't change until user exits General menu and comes back

Now : Fixed
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
