### PR TITLE
Bugfix/account name not displayed in add account specific cases

### DIFF
--- a/src/components/AccountCard.tsx
+++ b/src/components/AccountCard.tsx
@@ -65,7 +65,7 @@ const AccountCard = ({
           flexDirection="row"
           alignItems="center"
         >
-          <Flex flexShrink={1}>
+          <Flex minWidth={20} flexShrink={1}>
             <Text
               variant="paragraph"
               fontWeight="semiBold"
@@ -77,9 +77,9 @@ const AccountCard = ({
             </Text>
             {AccountSubTitle}
           </Flex>
-          {tag && <Tag marginLeft={5}>{tag}</Tag>}
+          {tag && <Tag marginLeft={3}>{tag}</Tag>}
         </Flex>
-        <Flex marginLeft={5} alignItems="flex-end">
+        <Flex marginLeft={3} alignItems="flex-end">
           <Text variant="small" fontWeight="medium" color="neutral.c70">
             <CurrencyUnitValue
               showCode

--- a/src/components/SelectableAccountsList.tsx
+++ b/src/components/SelectableAccountsList.tsx
@@ -293,7 +293,7 @@ const SelectableAccount = ({
         />
       </Flex>
       {!isDisabled && (
-        <Flex marginLeft={6}>
+        <Flex marginLeft={4}>
           <CheckBox isChecked={!!isSelected} />
         </Flex>
       )}


### PR DESCRIPTION
- Before : The account name could be hidden if the address type and the amount were too big, here is what would have been displayed on a small screen (simulated by adding some horizontal margins) :
<img src="https://user-images.githubusercontent.com/17146928/160851345-e2c4ebfb-6342-4e22-a6d3-97171cba4e0f.jpg" width="300" height="600" /> 

- After : minWidth added to always display at least the beginning of the account name and some margins reduced to optimise the space :
<img src="https://user-images.githubusercontent.com/17146928/160851332-56fc2a13-267f-4ab7-8923-77b60aa88cd2.jpg" width="300" height="600" />
What would now be rendered on a small screen (simulated by adding some horizontal margins) :
<img src="https://user-images.githubusercontent.com/17146928/160851340-d7fdc709-87bb-4a0c-a59b-8faefed64ac4.jpg" width="300" height="600" />

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
