### PR TITLE
Fix regression on discreet mode

### DIFF
--- a/src/components/CounterValue.js
+++ b/src/components/CounterValue.js
@@ -35,6 +35,7 @@ type Props = {
   Wrapper?: React$ComponentType<*>,
   subMagnitude?: number,
   joinFragmentsSeparator?: string,
+  alwaysShowValue?: boolean,
 };
 
 export const NoCountervaluePlaceholder = () => {

--- a/src/components/CurrencyRate.tsx
+++ b/src/components/CurrencyRate.tsx
@@ -22,9 +22,9 @@ export default function CurrencyRate({ currency }: Props) {
       fontWeight={"semiBold"}
       color="neutral.c100"
     >
-      <CurrencyUnitValue unit={currency.units[0]} value={one} />
+      <CurrencyUnitValue unit={currency.units[0]} value={one} alwaysShowValue />
       {" = "}
-      <CounterValue currency={currency} value={one} />
+      <CounterValue currency={currency} value={one} alwaysShowValue />
     </Text>
   );
 }

--- a/src/components/CurrencyUnitValue.tsx
+++ b/src/components/CurrencyUnitValue.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import React, { useContext } from "react";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/lib/currencies";
 import { Unit } from "@ledgerhq/live-common/lib/types";
 import { useSelector } from "react-redux";
 import { BigNumber } from "bignumber.js";
-
 import { useLocale } from "../context/Locale";
+import DiscreetModeContext from "../context/DiscreetModeContext";
 import { discreetModeSelector } from "../reducers/settings";
 
 type Props = {
@@ -12,6 +12,7 @@ type Props = {
   value: BigNumber | number;
   showCode?: boolean;
   alwaysShowSign?: boolean;
+  alwaysShowValue?: boolean;
   before?: string;
   after?: string;
   disableRounding?: boolean;
@@ -23,6 +24,7 @@ const CurrencyUnitValue = ({
   value: valueProp,
   showCode = true,
   alwaysShowSign,
+  alwaysShowValue,
   before = "",
   after = "",
   disableRounding = false,
@@ -30,6 +32,7 @@ const CurrencyUnitValue = ({
 }: Props): JSX.Element => {
   const { locale } = useLocale();
   const discreet = useSelector(discreetModeSelector);
+  const shouldApplyDiscreetMode = useContext(DiscreetModeContext);
   const value =
     valueProp instanceof BigNumber ? valueProp : new BigNumber(valueProp);
 
@@ -42,7 +45,7 @@ const CurrencyUnitValue = ({
               alwaysShowSign,
               locale,
               disableRounding,
-              discreet,
+              discreet: !alwaysShowValue && shouldApplyDiscreetMode && discreet,
               joinFragmentsSeparator,
             })
           : "") +

--- a/src/screens/Account/index.tsx
+++ b/src/screens/Account/index.tsx
@@ -42,6 +42,7 @@ import NoOperationFooter from "../../components/NoOperationFooter";
 import { useScrollToTop } from "../../navigation/utils";
 
 import { getListHeaderComponents } from "./ListHeaderComponent";
+import { withDiscreetMode } from "../../context/DiscreetModeContext";
 
 type Props = {
   navigation: any;
@@ -70,7 +71,7 @@ function keyExtractor(item: Operation) {
 
 const stickySectionHeight = 56;
 
-export default function AccountScreen({ route }: Props) {
+function AccountScreen({ route }: Props) {
   const { account, parentAccount } = useSelector(accountScreenSelector(route));
   if (!account) return null;
   return <AccountScreenInner account={account} parentAccount={parentAccount} />;
@@ -319,3 +320,5 @@ const styles = StyleSheet.create({
     zIndex: 0,
   },
 });
+
+export default withDiscreetMode(AccountScreen);

--- a/src/screens/Analytics/Allocation.tsx
+++ b/src/screens/Analytics/Allocation.tsx
@@ -7,6 +7,7 @@ import RingChart from "./RingChart";
 import { useDistribution } from "../../actions/general";
 import DistributionCard, { DistributionItem } from "./DistributionCard";
 import { TrackScreen } from "../../analytics";
+import { withDiscreetMode } from "../../context/DiscreetModeContext";
 
 const Container = styled(Flex).attrs({
   paddingHorizontal: 16,
@@ -63,4 +64,4 @@ function Allocation() {
   );
 }
 
-export default memo(Allocation);
+export default withDiscreetMode(memo(Allocation));

--- a/src/screens/Analytics/DistributionCard.tsx
+++ b/src/screens/Analytics/DistributionCard.tsx
@@ -12,6 +12,7 @@ import ProgressBar from "../../components/ProgressBar";
 import CounterValue from "../../components/CounterValue";
 import { ensureContrast } from "../../colors";
 import CurrencyIcon from "../../components/CurrencyIcon";
+import { withDiscreetMode } from "../../context/DiscreetModeContext";
 
 export type DistributionItem = {
   currency: CryptoCurrency | TokenCurrency;
@@ -61,7 +62,7 @@ const DistributionRow = styled(Flex).attrs({
   alignItems: "center",
 })``;
 
-export default function DistributionCard({
+function DistributionCard({
   item: { currency, amount, distribution },
 }: Props) {
   const { colors } = useTheme();
@@ -126,3 +127,5 @@ export default function DistributionCard({
     </Container>
   );
 }
+
+export default withDiscreetMode(DistributionCard);

--- a/src/screens/Analytics/Operations.tsx
+++ b/src/screens/Analytics/Operations.tsx
@@ -28,6 +28,7 @@ import LoadingFooter from "../../components/LoadingFooter";
 import Button from "../../components/Button";
 import { ScreenName } from "../../const";
 import { TrackScreen } from "../../analytics";
+import { withDiscreetMode } from "../../context/DiscreetModeContext";
 
 type Props = {
   navigation: any;
@@ -141,4 +142,4 @@ export function Operations({ navigation }: Props) {
   );
 }
 
-export default memo<Props>(Operations);
+export default withDiscreetMode(memo<Props>(Operations));

--- a/src/screens/Portfolio/Assets.tsx
+++ b/src/screens/Portfolio/Assets.tsx
@@ -3,6 +3,7 @@ import { FlatList } from "react-native";
 import { BalanceHistory } from "@ledgerhq/live-common/lib/types";
 import { useNavigation } from "@react-navigation/native";
 import AccountRow from "../Accounts/AccountRow";
+import { withDiscreetMode } from "../../context/DiscreetModeContext";
 
 type ListProps = {
   balanceHistory: BalanceHistory;
@@ -37,4 +38,4 @@ const AssetsList = ({ balanceHistory, assets }: ListProps) => {
   );
 };
 
-export default AssetsList;
+export default withDiscreetMode(AssetsList);

--- a/src/screens/Portfolio/GraphCardContainer.tsx
+++ b/src/screens/Portfolio/GraphCardContainer.tsx
@@ -10,6 +10,7 @@ import { Portfolio } from "@ledgerhq/live-common/lib/portfolio/v2/types";
 import { currenciesSelector } from "../../reducers/accounts";
 import CurrencyDownStatusAlert from "../../components/CurrencyDownStatusAlert";
 import GraphCard from "../../components/GraphCard";
+import { withDiscreetMode } from "../../context/DiscreetModeContext";
 
 const GraphCardContainer = ({
   portfolio,
@@ -38,4 +39,4 @@ const GraphCardContainer = ({
   );
 };
 
-export default GraphCardContainer;
+export default withDiscreetMode(GraphCardContainer);


### PR DESCRIPTION
This fixes a regression on the _selective discreet mode_ bug fix: discreet mode only applies to some screens/component, i.e. portfolio, distribution screen & account screen, instead of applying to all displayed currency values in the app.
This bug fix/feature had been [implemented here](https://github.com/LedgerHQ/ledger-live-mobile/pull/2220/) but only in js/jsx files while tsx files already existed for v3, so it was missing in v3.

https://user-images.githubusercontent.com/91890529/160873794-d558237c-9443-4570-9cb6-872a6ede026f.mp4


### Type

Bug fix / regression

### Context

v3 pre-release
<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

Portfolio, distribution screen, account page. In general all amounts displayed in the app, but now discreet mode is _opt-in_ (from a dev perspective) so _by default_ (without this opt-in) all currency amounts displayed in the app will just be in clear text.
