### PR TITLE
use tags without uppercase

### DIFF
--- a/src/components/DeviceAction/rendering.tsx
+++ b/src/components/DeviceAction/rendering.tsx
@@ -81,6 +81,7 @@ const DescriptionText = styled(CenteredText).attrs({
 
 const ConnectDeviceNameText = styled(Tag).attrs({
   my: "8",
+  uppercase: false,
 })``;
 
 const StyledButton = styled(Button).attrs({


### PR DESCRIPTION
Last week I updated the lib UI to add a prop to Tag component.
The goal was to be able to remove uppercase on all device name on manager page.
It's the only last one I had to update.