### PR TITLE
V3 - Add links between parent children accounts

### DIFF
--- a/src/screens/Accounts/AccountRow.tsx
+++ b/src/screens/Accounts/AccountRow.tsx
@@ -37,6 +37,8 @@ type Props = {
   portfolioValue: number;
   navigationParams?: any[];
   hideDelta?: boolean;
+  topLink?: boolean;
+  bottomLink?: boolean;
 };
 
 const AccountRow = ({
@@ -46,10 +48,12 @@ const AccountRow = ({
   portfolioValue,
   navigationParams,
   hideDelta,
+  topLink,
+  bottomLink
 }: Props) => {
   // makes it refresh if this changes
   useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
-  const { colors } = useTheme();
+  const { colors, space } = useTheme();
 
   const currency = getAccountCurrency(account);
   const name = getAccountName(account);
@@ -119,7 +123,16 @@ const AccountRow = ({
 
   return (
     <TouchableOpacity onPress={onAccountPress}>
-      <Flex flexDirection="row" py={5}>
+      {topLink && (
+        <Flex
+          width="1px"
+          height={space[4]}
+          marginLeft="21px"
+          backgroundColor={colors.neutral.c40}
+          mb={2}
+        />
+      )}
+      <Flex flexDirection="row" pt={topLink ? 0 : 6} pb={bottomLink ? 0 : 6}>
         <Flex mr={6}>
           <ProgressLoader
             strokeWidth={2}
@@ -189,6 +202,15 @@ const AccountRow = ({
           </Flex>
         </Flex>
       </Flex>
+      {bottomLink && (
+        <Flex
+          width="1px"
+          height={space[4]}
+          marginLeft="21px"
+          backgroundColor={colors.neutral.c40}
+          mt={2}
+        />
+      )}
     </TouchableOpacity>
   );
 };

--- a/src/screens/Accounts/index.tsx
+++ b/src/screens/Accounts/index.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState, useEffect, memo } from "react";
 import { FlatList, TouchableOpacity } from "react-native";
 import { useSelector } from "react-redux";
 import { useFocusEffect } from "@react-navigation/native";
-import { Account } from "@ledgerhq/live-common/lib/types";
+import { Account, TokenAccount } from "@ledgerhq/live-common/lib/types";
 import { findCryptoCurrencyByKeyword } from "@ledgerhq/live-common/lib/currencies";
 import { Box, Flex, Icons, Text } from "@ledgerhq/native-ui";
 import { RefreshMedium } from "@ledgerhq/native-ui/assets/icons";
@@ -83,7 +83,7 @@ function Accounts({ navigation, route }: Props) {
   }, [params, accounts, navigation]);
 
   const renderItem = useCallback(
-    ({ item, index }: { item: Account; index: number }) => (
+    ({ item, index }: { item: Account | TokenAccount; index: number }) => (
       <AccountRow
         navigation={navigation}
         account={item}
@@ -93,6 +93,8 @@ function Accounts({ navigation, route }: Props) {
         portfolioValue={
           portfolio.balanceHistory[portfolio.balanceHistory.length - 1].value
         }
+        topLink={item.type === "TokenAccount"}
+        bottomLink={flattenedAccounts[index + 1]?.type === "TokenAccount"}
       />
     ),
     [navigation, accounts.length, portfolio.balanceHistory],


### PR DESCRIPTION
Accounts page - Add links between parent and children rows

![Screenshot_20220331-175455_LL  DEV](https://user-images.githubusercontent.com/89014981/161102539-a639cd95-a82c-4262-8b1a-36b0158ef2e2.jpg)

https://user-images.githubusercontent.com/89014981/161102562-4f45e677-8216-4e03-8295-8cfd0708106f.mp4



### Type

UI Polish

### Context

https://docs.google.com/spreadsheets/d/16kFSnt7z6p3ro1yAl09FIxsFMm_bkVm00mHgfFfD2fs/edit#gid=0

### Parts of the app affected / Test plan

Accounts page (Assets)