### PR TITLE
Fix blank videos in onboarding

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -12,4 +12,4 @@ apply from: new File(["node", "--print", "require.resolve('expo/package.json')"]
 useExpoModules()
 
 include ':react-native-video'
-project(':react-native-video').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-video/android')
+project(':react-native-video').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-video/android-exoplayer')

--- a/src/components/useIsAppInBackground.tsx
+++ b/src/components/useIsAppInBackground.tsx
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+import { AppState } from "react-native";
+
+export default function useIsAppInBackground() {
+  const [isInBackground, setIsInBackground] = useState(
+    AppState.currentState !== "active",
+  );
+  useEffect(() => {
+    const listener = AppState.addEventListener("change", evt => {
+      if (evt === "active") setIsInBackground(false);
+      else setIsInBackground(true);
+    });
+    return () => {
+      listener.remove();
+    };
+  });
+  return isInBackground;
+}

--- a/src/screens/BuyDeviceScreen.tsx
+++ b/src/screens/BuyDeviceScreen.tsx
@@ -90,6 +90,7 @@ export default function BuyDeviceScreen() {
       <Flex height={250} width="100%" position="relative" overflow="hidden">
         {videoMounted && (
           <Video
+            disableFocus
             source={theme === "light" ? sourceLight : sourceDark}
             style={{
               height: "100%",

--- a/src/screens/BuyDeviceScreen.tsx
+++ b/src/screens/BuyDeviceScreen.tsx
@@ -16,6 +16,7 @@ import Button from "../components/wrappedUi/Button";
 import { urls } from "../config/urls";
 import { useNavigationInterceptor } from "./Onboarding/onboardingContext";
 import { NavigatorName, ScreenName } from "../const";
+import useIsAppInBackground from "../components/useIsAppInBackground";
 
 const StyledSafeAreaView = styled(SafeAreaView)`
   flex: 1;
@@ -71,6 +72,8 @@ export default function BuyDeviceScreen() {
     Linking.openURL(urls.buyNanoX);
   }, []);
 
+  const videoMounted = !useIsAppInBackground();
+
   return (
     <StyledSafeAreaView>
       <Flex
@@ -85,22 +88,24 @@ export default function BuyDeviceScreen() {
         <Button Icon={Icons.ArrowLeftMedium} onPress={handleBack} />
       </Flex>
       <Flex height={250} width="100%" position="relative" overflow="hidden">
-        <Video
-          source={theme === "light" ? sourceLight : sourceDark}
-          style={{
-            height: "100%",
-            width: "100%",
-            position: "absolute",
-            top: 0,
-            left: 0,
-            bottom: 0,
-            right: 0,
-            backgroundColor: colors.background.main,
-            transform: [{ scale: 1.5 }],
-          }}
-          muted
-          resizeMode={"cover"}
-        />
+        {videoMounted && (
+          <Video
+            source={theme === "light" ? sourceLight : sourceDark}
+            style={{
+              height: "100%",
+              width: "100%",
+              position: "absolute",
+              top: 0,
+              left: 0,
+              bottom: 0,
+              right: 0,
+              backgroundColor: colors.background.main,
+              transform: [{ scale: 1.5 }],
+            }}
+            muted
+            resizeMode={"cover"}
+          />
+        )}
       </Flex>
       <Flex flex={1} p={6} pt={0}>
         <Flex mt={0} mb={8} justifyContent="center" alignItems="stretch">

--- a/src/screens/Onboarding/steps/welcome.tsx
+++ b/src/screens/Onboarding/steps/welcome.tsx
@@ -15,6 +15,7 @@ import StyledStatusBar from "../../../components/StyledStatusBar";
 import { urls } from "../../../config/urls";
 import { useTermsAccept } from "../../../logic/terms";
 import { setAnalytics } from "../../../actions/settings";
+import useIsAppInBackground from "../../../components/useIsAppInBackground";
 
 const source = require("../../../../assets/videos/onboarding.mp4");
 
@@ -65,16 +66,20 @@ function OnboardingStepWelcome({ navigation }: any) {
     navigation.navigate({ name: ScreenName.OnboardingPostWelcomeSelection });
   }, [setAccepted, dispatch, navigation]);
 
+  const videoMounted = !useIsAppInBackground();
+
   return (
     <Flex flex={1} position="relative" bg="constant.black">
       <StyledStatusBar barStyle="light-content" />
-      <Video
-        source={source}
-        style={absoluteStyle}
-        muted
-        repeat
-        resizeMode={"cover"}
-      />
+      {videoMounted && (
+        <Video
+          source={source}
+          style={absoluteStyle}
+          muted
+          repeat
+          resizeMode={"cover"}
+        />
+      )}
       <Svg
         style={absoluteStyle}
         width="100%"

--- a/src/screens/Onboarding/steps/welcome.tsx
+++ b/src/screens/Onboarding/steps/welcome.tsx
@@ -73,6 +73,7 @@ function OnboardingStepWelcome({ navigation }: any) {
       <StyledStatusBar barStyle="light-content" />
       {videoMounted && (
         <Video
+          disableFocus
           source={source}
           style={absoluteStyle}
           muted


### PR DESCRIPTION
Issue: when the app is displaying a video (either welcome screen or buy nano scren) goes in the background and is then resumed, the video is sometimes blank.

This issue happens on both iOS and Android, especially.

This PR contains the only solution I could find to prevent this from happening, basically unmounting the video component when the app goes in the background and then remounting it when the app comes back in the foreground.

It is far from perfect and has a side effect of restarting the video, but I could not reproduce the issue anymore so I guess it does the job 🤷‍♂️ It's better than having a blank space where the video should be.

**NB:** I also changed the video player on Android from MediaPlayer to ExoPlayer (which is the recommended player for react-native-video). The reason we were using MediaPlayer is that with ExoPlayer it was stopping the media playing in other apps, but there is actually the prop `disableFocus` to prevent that from happening.

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

v3 pre-release

### Parts of the app affected / Test plan

Onboarding welcome screen & "i don't have a Ledger" screen
