### PR TITLE
V3 - Fix error when adding a Solana account by adding a polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     }
   },
   "dependencies": {
+    "@azure/core-asynciterator-polyfill": "^1.0.2",
     "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.8",
     "@formatjs/intl-datetimeformat": "^5.0.0",
     "@formatjs/intl-getcanonicallocales": "^1.9.1",

--- a/src/polyfill.js
+++ b/src/polyfill.js
@@ -34,6 +34,9 @@ import "@formatjs/intl-datetimeformat/locale-data/ja";
 import "@formatjs/intl-datetimeformat/locale-data/ko";
 import "@formatjs/intl-datetimeformat/add-all-tz";
 
+// Fix error when adding Solana account
+import "@azure/core-asynciterator-polyfill";
+
 global.Buffer = require("buffer").Buffer;
 
 if (!console.assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,11 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
+"@azure/core-asynciterator-polyfill@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.2.tgz#0dd3849fb8d97f062a39db0e5cadc9ffaf861fec"
+  integrity sha512-3rkP4LnnlWawl0LZptJOdXNrT/fHp2eQMadoasa6afspXdpGrtPZuAQc2PD0cpgyuoXtUWyC3tv7xfntjGS5Dw==
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"


### PR DESCRIPTION
Added a polyfill for [Symbol.asyncIterator](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator) as it seems to be needed by Solana
It was causing an error when adding an account  

Error screen  : 
![image](https://user-images.githubusercontent.com/89014981/161248720-74233351-383d-42b2-8b2c-6b4721f17ddf.png)

### Type

Bug fix

### Context

https://docs.google.com/spreadsheets/d/16kFSnt7z6p3ro1yAl09FIxsFMm_bkVm00mHgfFfD2fs/edit#gid=0

### Parts of the app affected / Test plan

