### PR TITLE
Fix pre quizz modal blocking on small screens

### DIFF
--- a/src/components/RootNavigator/OnboardingNavigator.tsx
+++ b/src/components/RootNavigator/OnboardingNavigator.tsx
@@ -113,7 +113,7 @@ function OnboardingPreQuizModalNavigator(props: StackScreenProps<{}>) {
       {...props}
       backgroundColor="constant.purple"
       deadZoneProps={{ flex: 1 }}
-      contentContainerProps={{ maxHeight: "50%" }}
+      contentContainerProps={{ maxHeight: "55%" }}
     >
       <OnboardingPreQuizModalStack.Navigator>
         <OnboardingPreQuizModalStack.Screen

--- a/src/screens/Onboarding/steps/setupDevice/drawers/OnboardingPreQuizModal.tsx
+++ b/src/screens/Onboarding/steps/setupDevice/drawers/OnboardingPreQuizModal.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { Flex, Button, Text, Icons, IconBox } from "@ledgerhq/native-ui";
 import { useNavigation, useRoute, RouteProp } from "@react-navigation/native";
+import { ScrollView } from "react-native";
 
 type WarningRouteProps = RouteProp<
   { params: { onNext?: () => void } },
@@ -20,7 +21,7 @@ const OnboardingPreQuizModal = () => {
 
   return (
     <Flex flex={1} justifyContent="space-between" bg="constant.purple">
-      <Flex alignItems="center">
+      <ScrollView contentContainerStyle={{ alignItems: "center" }}>
         <IconBox
           Icon={Icons.TrophyMedium}
           color="constant.black"
@@ -39,7 +40,7 @@ const OnboardingPreQuizModal = () => {
         <Text variant="body" color="constant.black" mt={6} textAlign="center">
           {t("onboarding.stepSetupDevice.hideRecoveryPhrase.warning.desc")}
         </Text>
-      </Flex>
+      </ScrollView>
       <Button type="main" size="large" onPress={handlePress}>
         {t("onboarding.stepSetupDevice.hideRecoveryPhrase.warning.cta")}
       </Button>


### PR DESCRIPTION
This is a quick fix, ideally we'd have a dynamic height that adapts to the content of these modals but I haven't been able to implement that with react-navigation 🤔 
#### Before
(in some cases the button is completely out of the screen)
![Screenshot_1648810951](https://user-images.githubusercontent.com/91890529/161251380-54e84e32-84c4-4686-95ab-4f6201de0157.png)
#### After (more height so it fits by default + scrollable content if it's still too small)
![Screenshot_1648810966](https://user-images.githubusercontent.com/91890529/161251624-889e914e-29a8-432f-86ec-9049159a2d53.png)



### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
