### PR TITLE
bugfix/fix-onboarding-quizz-always-redirecting-to-fail-screen

### DIFF
--- a/src/screens/Onboarding/OnboardingQuizFinal.tsx
+++ b/src/screens/Onboarding/OnboardingQuizFinal.tsx
@@ -54,6 +54,7 @@ function OnboardingStepQuizFinal() {
           />
         ),
         drawer: null,
+        success,
       },
     ],
     [success],
@@ -75,6 +76,7 @@ function OnboardingStepQuizFinal() {
         steps={scenes}
         metadata={metadata}
         deviceModelId={deviceModelId}
+        params={{ success }}
       />
     </>
   );

--- a/src/screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx
+++ b/src/screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx
@@ -108,11 +108,13 @@ export function BaseStepperView({
   steps,
   metadata,
   deviceModelId,
+  params,
 }: {
   onNext: () => void;
   steps: any[];
   metadata: Metadata[];
   deviceModelId: DeviceNames;
+  params: any;
 }) {
   const [index, setIndex] = React.useState(0);
   const navigation = useNavigation();
@@ -151,7 +153,11 @@ export function BaseStepperView({
               >
                 {metadata[i]?.illustration}
               </Flex>
-              <Children onNext={nextPage} deviceModelId={deviceModelId} />
+              <Children
+                onNext={nextPage}
+                deviceModelId={deviceModelId}
+                {...params}
+              />
             </ScrollListContainer>
             {Children.Next ? (
               <Flex p={6}>


### PR DESCRIPTION
The quizz result screen didn't have access to the success props so it was always displaying the fail screen by default

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
