### PR TITLE
Add debug screen to generate mock accounts from a handpicked selection of currencies

### DIFF
--- a/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/src/components/RootNavigator/SettingsNavigator.tsx
@@ -42,6 +42,7 @@ import { getStackNavigatorConfig } from "../../navigation/navigatorConfig";
 import Button from "../Button";
 import HelpButton from "../../screens/Settings/HelpButton";
 import OnboardingStepLanguage from "../../screens/Onboarding/steps/language";
+import { GenerateMockAccountSelectScreen } from "../../screens/Settings/Debug/GenerateMockAccountsSelect";
 
 export default function SettingsNavigator() {
   const { t } = useTranslation();
@@ -166,6 +167,13 @@ export default function SettingsNavigator() {
         component={DebugMocks}
         options={{
           title: "Mock & Test",
+        }}
+      />
+      <Stack.Screen
+        name={ScreenName.DebugMockGenerateAccounts}
+        component={GenerateMockAccountSelectScreen}
+        options={{
+          title: "Generate mock accounts",
         }}
       />
       <Stack.Screen

--- a/src/const/navigation.js
+++ b/src/const/navigation.js
@@ -39,6 +39,7 @@ export const ScreenName = {
   DebugLogs: "DebugLogs",
   DebugLottie: "DebugLottie",
   DebugMocks: "DebugMocks",
+  DebugMockGenerateAccounts: "DebugMockGenerateAccounts",
   DebugPlayground: "DebugPlayground",
   DebugSettings: "DebugSettings",
   DebugStore: "DebugStore",

--- a/src/screens/Settings/Debug/GenerateMockAccounts.js
+++ b/src/screens/Settings/Debug/GenerateMockAccounts.js
@@ -1,6 +1,7 @@
 // @flow
 import React from "react";
 import sample from "lodash/sample";
+import { Alert } from "react-native";
 import { genAccount } from "@ledgerhq/live-common/lib/mock/account";
 import { listSupportedCurrencies } from "@ledgerhq/live-common/lib/currencies";
 import SettingsRow from "../../../components/SettingsRow";
@@ -33,9 +34,25 @@ export default function GenerateMockAccountsButton({
   return (
     <SettingsRow
       title={title}
-      onPress={async () => {
-        await injectMockAccountsInDB(count);
-        reboot();
+      onPress={() => {
+        Alert.alert(
+          "This will erase existing accounts",
+          "Continue?",
+          [
+            {
+              text: "Cancel",
+              onPress: () => {},
+            },
+            {
+              text: "Ok",
+              onPress: async () => {
+                await injectMockAccountsInDB(count);
+                reboot();
+              },
+            },
+          ],
+          { cancelable: true },
+        );
       }}
     />
   );

--- a/src/screens/Settings/Debug/GenerateMockAccountsSelect.tsx
+++ b/src/screens/Settings/Debug/GenerateMockAccountsSelect.tsx
@@ -1,0 +1,117 @@
+import React, { useCallback, useState } from "react";
+import { genAccount } from "@ledgerhq/live-common/lib/mock/account";
+import { listSupportedCurrencies } from "@ledgerhq/live-common/lib/currencies";
+import { useNavigation } from "@react-navigation/native";
+import { Alert, ScrollView, Text } from "react-native";
+import { Button, Checkbox, Flex } from "@ledgerhq/native-ui";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { CryptoCurrency } from "@ledgerhq/live-common/lib/types";
+import SettingsRow from "../../../components/SettingsRow";
+import accountModel from "../../../logic/accountModel";
+import { saveAccounts } from "../../../db";
+import { useReboot } from "../../../context/Reboot";
+import { ScreenName } from "../../../const";
+import CurrencyIcon from "../../../components/CurrencyIcon";
+
+async function injectMockAccountsInDB(currencies: CryptoCurrency[]) {
+  await saveAccounts({
+    active: currencies.map(currency =>
+      accountModel.encode(
+        genAccount(String(Math.random()), {
+          currency,
+        }),
+      ),
+    ),
+  });
+}
+
+const currencies = listSupportedCurrencies().sort((a, b) =>
+  a.name.localeCompare(b.name),
+);
+
+export const GenerateMockAccountSelectScreen = () => {
+  const reboot = useReboot();
+  const [checkedCurrencies, setCheckedCurrencies] = useState(
+    {} as Record<string, boolean>,
+  );
+
+  const handleItemPressed = useCallback(
+    ({ id }) => {
+      setCheckedCurrencies({
+        ...checkedCurrencies,
+        [id]: !checkedCurrencies[id],
+      });
+    },
+    [checkedCurrencies, setCheckedCurrencies],
+  );
+
+  const handlePressContinue = useCallback(() => {
+    const selectedCurrencies = currencies.filter(
+      ({ id }) => checkedCurrencies[id],
+    );
+    Alert.alert(
+      "This will erase existing accounts",
+      "Continue?",
+      [
+        {
+          text: "Ok",
+          onPress: () => {
+            injectMockAccountsInDB(selectedCurrencies);
+            reboot();
+          },
+        },
+        { text: "Cancel", onPress: () => {} },
+      ],
+      { cancelable: true },
+    );
+  }, [checkedCurrencies, reboot]);
+
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Flex flex={1} px={2} pb={insets.bottom}>
+      <ScrollView>
+        {currencies.map(currency => {
+          const { id, name } = currency;
+          return (
+            <Flex p={3}>
+              <Checkbox
+                onChange={() => handleItemPressed({ id })}
+                checked={checkedCurrencies[id]}
+                label={
+                  <Flex flexDirection="row" alignItems="center" pt={2}>
+                    <CurrencyIcon circle size={20} currency={currency} />
+                    <Text style={{ marginLeft: 5 }}>{name}</Text>
+                  </Flex>
+                }
+              />
+            </Flex>
+          );
+        })}
+      </ScrollView>
+      <Button
+        disabled={!Object.values(checkedCurrencies).some(a => a)}
+        mx={4}
+        onPress={handlePressContinue}
+        type="main"
+      >
+        Generate accounts
+      </Button>
+    </Flex>
+  );
+};
+
+export default function GenerateMockAccount() {
+  const navigation = useNavigation();
+
+  return (
+    <SettingsRow
+      title="Generate mock accounts"
+      desc="Select for which currencies you want to generate an account"
+      onPress={
+        // @ts-ignore
+        () => navigation.navigate(ScreenName.DebugMockGenerateAccounts)
+      }
+    />
+  );
+}

--- a/src/screens/Settings/Debug/index.tsx
+++ b/src/screens/Settings/Debug/index.tsx
@@ -1,9 +1,7 @@
 import React from "react";
-import { useSelector } from "react-redux";
 import { useNavigation } from "@react-navigation/native";
 import config from "react-native-config";
 import { Box, Text } from "@ledgerhq/native-ui";
-import { accountsSelector } from "../../../reducers/accounts";
 import { TrackScreen } from "../../../analytics";
 import SettingsRow from "../../../components/SettingsRow";
 import SelectDevice from "../../../components/SelectDevice";
@@ -26,10 +24,9 @@ import AddMockAnnouncementButton from "./GenerateAnnouncementMockData";
 import ToggleMockServiceStatusButton from "./ToggleMockStatusIncident";
 import SettingsNavigationScrollView from "../SettingsNavigationScrollView";
 import MockModeRow from "../General/MockModeRow";
+import GenerateMockAccount from "./GenerateMockAccountsSelect";
 
 export function DebugMocks() {
-  const accounts = useSelector(accountsSelector);
-
   return (
     <SettingsNavigationScrollView>
       {config.BRIDGESTREAM_DATA ? (
@@ -39,9 +36,11 @@ export function DebugMocks() {
           dataStr={config.BRIDGESTREAM_DATA}
         />
       ) : null}
-      {accounts.length === 0 ? (
-        <GenerateMockAccounts title="Generate 10 mock Accounts" count={10} />
-      ) : null}
+      <GenerateMockAccounts
+        title="Generate 10 random mock Accounts"
+        count={10}
+      />
+      <GenerateMockAccount />
       <OpenDebugLogs />
       <OpenDebugCrash />
       <OpenDebugStore />


### PR DESCRIPTION
It's quite a pain today to generate mock accounts for one currency in particular so I hope this will help a bit.

PS: I kept the "generate 10 random accounts" feature as it might be useful just to quickly generate a bunch of random accounts. It's also now always there in the menu (even if you already have accounts) but there is a confirmation dialog, as it erases existing accounts.

  

https://user-images.githubusercontent.com/91890529/161307165-62736cd2-bd87-4f03-b884-df13e0c60cce.mp4




### Type

Debug feature

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
