### PR TITLE
V3 - Fix swap screen with big account name

### DIFF
--- a/src/screens/Swap/FormSelection/AccountAmountRow.js
+++ b/src/screens/Swap/FormSelection/AccountAmountRow.js
@@ -184,7 +184,8 @@ const styles = StyleSheet.create({
     marginBottom: 16,
   },
   wrapper: {
-    flex: 1,
+    flexShrink: 0,
+    minWidth: 100,
     alignItems: "flex-end",
     justifyContent: "center",
     height: 32,

--- a/src/screens/Swap/FormSelection/AccountSelect.js
+++ b/src/screens/Swap/FormSelection/AccountSelect.js
@@ -66,7 +66,7 @@ export default function AccountSelect({
             </View>
             <View style={styles.accountColumn}>
               <View style={styles.labelContainer}>
-                <LText semiBold style={styles.label}>
+                <LText semiBold style={styles.label} numberOfLines={1}>
                   {name}
                 </LText>
                 {currency.type === "TokenCurrency" &&
@@ -113,6 +113,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "center",
     alignItems: "center",
+    flex: 1,
   },
   label: {
     fontSize: 16,
@@ -126,15 +127,14 @@ const styles = StyleSheet.create({
   },
   accountColumn: {
     flexDirection: "column",
+    flex: 1,
   },
   accountTicker: {
     fontSize: 13,
     lineHeight: 16,
   },
   labelContainer: {
-    flexDirection: "row",
-    justifyContent: "center",
-    alignItems: "center",
+    flex: 0,
   },
   currencyLabel: {
     flexGrow: 0,


### PR DESCRIPTION
Unhide the amount input when the account name is really big

Before:
![Screenshot_20220401-191433_LL  DEV](https://user-images.githubusercontent.com/89014981/161311092-b05a82e2-8960-40b2-a8a3-b23bb05b1098.jpg)
![Screenshot_20220401-191456_LL  DEV](https://user-images.githubusercontent.com/89014981/161311098-a9053266-b880-4fb7-a981-2218aa9c2f55.jpg)


After:

![Screenshot_20220401-191523_LL  DEV](https://user-images.githubusercontent.com/89014981/161311119-9c3e3039-bc64-430c-bf7a-5bad94cecdbc.jpg)
![Screenshot_20220401-191513_LL  DEV](https://user-images.githubusercontent.com/89014981/161311127-23b61bd8-c7fa-4706-8233-39d6fb4fe04c.jpg)


### Type

Bug fix

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

Swap screen