### PR TITLE
bugfix/misaligned-add-account-button fixed

### DIFF
--- a/src/screens/ReceiveFunds/03-Confirmation.js
+++ b/src/screens/ReceiveFunds/03-Confirmation.js
@@ -431,7 +431,7 @@ const styles = StyleSheet.create({
   },
   buttonsContainer: {
     flexDirection: "row",
-    paddingHorizontal: 8,
+    marginVertical: 8,
     alignItems: "flex-end",
     flexGrow: 1,
   },
@@ -441,7 +441,6 @@ const styles = StyleSheet.create({
   },
   bigButton: {
     flexGrow: 2,
-    marginHorizontal: 8,
   },
   footer: {
     flexDirection: "row",

--- a/src/screens/Swap/FormSelection/SelectAccountScreen.js
+++ b/src/screens/Swap/FormSelection/SelectAccountScreen.js
@@ -185,7 +185,7 @@ export default function SelectAccount({ navigation, route }: Props) {
         <View style={styles.searchContainer}>
           <FilteredSearchBar
             keys={SEARCH_KEYS}
-            inputWrapperStyle={styles.card}
+            inputWrapperStyle={[ styles.card, styles.searchBarContainer ]}
             list={elligibleAccountsForSelectedCurrency}
             renderList={renderList}
             renderEmptySearch={() => (
@@ -225,6 +225,9 @@ const styles = StyleSheet.create({
     paddingTop: 18,
     flex: 1,
   },
+  searchBarContainer: {
+    paddingBottom: 8,
+  },
   list: {
     paddingTop: 8,
   },
@@ -255,5 +258,6 @@ const styles = StyleSheet.create({
     paddingRight: 16,
     marginBottom: 24,
     flexDirection: "row",
+    alignItems: "center",
   },
 });

--- a/src/screens/Swap/FormSelection/SelectCurrencyScreen.js
+++ b/src/screens/Swap/FormSelection/SelectCurrencyScreen.js
@@ -111,6 +111,7 @@ const styles = StyleSheet.create({
   },
   filteredSearchInputWrapperStyle: {
     marginHorizontal: 16,
+    marginBottom: 8,
   },
   emptySearch: {
     paddingHorizontal: 16,


### PR DESCRIPTION
Add Account text now centered in swap account selection and a bottom margin added to searchbar in swap account and currency selection

PS : not really in the scope of this PR but I also added a margin to ReceiveFunds confirmation error modal

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
