### PR TITLE
bugfix/swap-bitcoin-family-custom-row-not-displayed fixed

### DIFF
--- a/src/families/bitcoin/SendRowsFee.js
+++ b/src/families/bitcoin/SendRowsFee.js
@@ -1,6 +1,6 @@
 /* @flow */
 import invariant from "invariant";
-import React, { useCallback, useState } from "react";
+import React, { useCallback, useMemo, useState } from "react";
 import type { Account, AccountLike } from "@ledgerhq/live-common/lib/types";
 import { Trans } from "react-i18next";
 
@@ -31,20 +31,24 @@ export default function BitcoinSendRowsFee({
   ...props
 }: Props) {
   invariant(account.type === "Account", "account not found");
-  let strategies = useFeesStrategy(account, transaction);
+  const defaultStrategies = useFeesStrategy(account, transaction);
   const [satPerByte, setSatPerByte] = useState(null);
 
-  if (satPerByte) {
-    strategies = [
-      ...strategies,
-      {
-        label: "custom",
-        forceValueLabel: null,
-        amount: satPerByte,
-        unit: strategies[0].unit,
-      },
-    ];
-  }
+  const strategies = useMemo(
+    () =>
+      transaction.feesStrategy === "custom"
+        ? [
+            ...defaultStrategies,
+            {
+              label: transaction.feesStrategy,
+              forceValueLabel: null,
+              amount: transaction.feePerByte,
+              unit: defaultStrategies[0].unit,
+            },
+          ]
+        : defaultStrategies,
+    [defaultStrategies, transaction],
+  );
 
   const onFeesSelected = useCallback(
     ({ amount, label }) => {


### PR DESCRIPTION
When swapping from coins from bitcoin family to other coins, when selecting custom fees it wasn't displaying the custom row

Here are screenshots of what was happening (left) and what is now hapenning (right) when swapping from BTC to ETH and setting custom fees to 6 sat per bytes

<img src="https://user-images.githubusercontent.com/17146928/161558257-d98df33e-cbb3-42ac-b44d-f4e19969dfb9.jpg" width="300" height="600" /> --> <img src="https://user-images.githubusercontent.com/17146928/161558249-53a55380-c5af-426f-95c7-7352b8769f91.jpg" width="300" height="600" />

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
