### PR TITLE
bugfix: temp solution to fix cro ow failing on hermes

### DIFF
--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -18,7 +18,7 @@ rn-nodeify --hack
 # issue: https://github.com/WalletConnect/walletconnect-monorepo/issues/595
 # manually shim
 sed -i -- 's/require("crypto")/require("react-native-crypto")/g' node_modules/@walletconnect/randombytes/dist/cjs/node/index.js
-
+sed -i -- 's/(\?:\\+\|-)\?//g' node_modules/ow/dist/source/index.js
 
 # Create the dev .env file with APP_NAME if it doesn't exist
 if ! [ -f .env ]; then


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bugfix

### Context

When using CRO in dev we got an error of :
```
ERROR  Error: Requiring module "node_modules/@crypto-com/chain-jslib/lib/dist/index.js", which threw an exception: SyntaxError: 307339:13:Invalid regular expression: Quantifier has nothing to repeat, js engine: hermes
 LOG  [TypeError: Cannot read property 'CroSDK' of undefined]
```

I wasn't able to make it work with babel

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
