### PR TITLE
Snakecase feature ids when searching in Firebase

### DIFF
--- a/src/components/FirebaseRemoteConfig.tsx
+++ b/src/components/FirebaseRemoteConfig.tsx
@@ -1,10 +1,10 @@
 import React, { ReactNode, useEffect, useState } from "react";
 import remoteConfig from "@react-native-firebase/remote-config";
 import { defaultFeatures } from "@ledgerhq/live-common/lib/featureFlags";
-import { reduce } from "lodash";
+import { reduce, snakeCase } from "lodash";
 import { FeatureId, DefaultFeatures } from "@ledgerhq/live-common/lib/types";
 
-export const formatFeatureId = (id: FeatureId) => `feature_${id}`;
+export const formatFeatureId = (id: FeatureId) => `feature_${snakeCase(id)}`;
 
 // Firebase SDK treat JSON values as strings
 const formatDefaultFeatures = (config: DefaultFeatures) =>


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

Naming convention in Firebase is `snake_case` but naming convention in the code-base is `camelCase`. This makes the conversion seemless for the team. Needed for proper feature flagging.