### PR TITLE
V3 - Discover page - Remove "tell me more" link in discover page

### DIFF
--- a/src/screens/Discover/index.tsx
+++ b/src/screens/Discover/index.tsx
@@ -1,8 +1,8 @@
-import React, { memo, useCallback, useMemo } from "react";
+import React, { memo, useMemo } from "react";
 import { Linking, Platform, ScrollView } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import styled from "styled-components/native";
-import { Flex, Text, Link as TextLink, Icons } from "@ledgerhq/native-ui";
+import { Flex, Text } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import { useNavigation } from "@react-navigation/native";
 import useFeature from "@ledgerhq/live-common/lib/featureFlags/useFeature";
@@ -19,16 +19,12 @@ const earnImg = require("../../images/illustration/Shared/_Earn.png");
 
 const StyledSafeAreaView = styled(SafeAreaView)`
   flex: 1;
-  backgroundcolor: ${({ theme }) => theme.colors.background.main};
+  background-color: ${({ theme }) => theme.colors.background.main};
 `;
 
 function Discover() {
   const { t } = useTranslation();
   const navigation = useNavigation();
-
-  const onTellMeMore = useCallback(() => {
-    Linking.openURL(urls.discover.tellMeMore);
-  }, []);
 
   const learn = useFeature("learn");
 
@@ -111,16 +107,9 @@ function Discover() {
         <Flex p={8} mt={8} flexDirection="row">
           <Flex flex={1} justyfyContent="flex-start" alignItems="flex-start">
             <Text variant="h1">{t("discover.title")}</Text>
-            <Text variant="body" mb={6} mt={4} color="neutral.c70">
+            <Text variant="body" mb={4} mt={4} color="neutral.c70">
               {t("discover.desc")}
             </Text>
-            <TextLink
-              type="color"
-              onPress={onTellMeMore}
-              Icon={Icons.ArrowRightMedium}
-            >
-              {t("discover.link")}
-            </TextLink>
           </Flex>
           <Flex flex={1} />
         </Flex>


### PR DESCRIPTION
Remove "tell me more" link in discover page

### Type

Bug fix
### Context

https://docs.google.com/spreadsheets/d/16kFSnt7z6p3ro1yAl09FIxsFMm_bkVm00mHgfFfD2fs/edit#gid=356326031

### Parts of the app affected / Test plan

Discover Page
