### PR TITLE
Genuine check: replace warning icon by loader

### DIFF
--- a/src/screens/PairDevices/PendingGenuineCheck.tsx
+++ b/src/screens/PairDevices/PendingGenuineCheck.tsx
@@ -1,8 +1,6 @@
 import React from "react";
 import { Trans, useTranslation } from "react-i18next";
-
-import { Alert, Flex, IconBox, Text } from "@ledgerhq/native-ui";
-import { WarningMedium } from "@ledgerhq/native-ui/assets/icons";
+import { Alert, Flex, InfiniteLoader, Text } from "@ledgerhq/native-ui";
 import { TrackScreen } from "../../analytics";
 
 const PendingGenuineCheck = () => {
@@ -11,12 +9,7 @@ const PendingGenuineCheck = () => {
   return (
     <Flex flex={1} justifyContent={"center"} alignItems={"center"} mx={6}>
       <TrackScreen category="PairDevices" name="PendingGenuineCheck" />
-      <IconBox
-        Icon={WarningMedium}
-        iconSize={24}
-        boxSize={64}
-        color={"warning.c100"}
-      />
+      <InfiniteLoader size={30} />
       <Text variant={"h2"} textAlign={"center"} mb={5} mt={7}>
         <Trans i18nKey="PairDevices.GenuineCheck.title" />
       </Text>


### PR DESCRIPTION

![genuinecheck](https://user-images.githubusercontent.com/91890529/162221125-755dc707-d30b-40e6-9208-29228eedd6fc.png)


### Type

UI polish

### Context

v3 feedback - L30

### Parts of the app affected / Test plan

Genuine Check screen when pairing a device
