### PR TITLE
V3 - Account page - Rebrand Parrent currency icon

### DIFF
--- a/src/screens/Account/AccountHeaderTitle.tsx
+++ b/src/screens/Account/AccountHeaderTitle.tsx
@@ -21,7 +21,7 @@ export default function AccountHeaderTitle() {
       <View style={styles.headerContainer}>
         <View style={styles.iconContainer}>
           <ParentCurrencyIcon
-            size={18}
+            size={32}
             currency={getAccountCurrency(account)}
           />
         </View>


### PR DESCRIPTION
Rebrand Parrent currency icon, and Account Page header as a result.
Also fixing bug reported by Anthony where "Token Account Page Header displaying weirdly"

See page header :

![Screenshot_20220407-164705_LL  DEV](https://user-images.githubusercontent.com/89014981/162227611-f94b1b5c-ad82-40bb-9ff6-f85fbb841e96.jpg)

![Screenshot_20220407-164640_LL  DEV](https://user-images.githubusercontent.com/89014981/162227613-cd37e8bc-8e7e-4058-80c4-12dcfc7f5f64.jpg)

![Screenshot_20220407-164744_LL  DEV](https://user-images.githubusercontent.com/89014981/162227605-a503382b-1753-4778-95d5-23e2d8a79862.jpg)

### Type

Feature

### Context

https://docs.google.com/spreadsheets/d/16kFSnt7z6p3ro1yAl09FIxsFMm_bkVm00mHgfFfD2fs/edit#gid=356326031

### Parts of the app affected / Test plan

Account page / Parent currency icon