### PR TITLE
Bugfix/live 1316: edit device name only for Nano X

### DIFF
--- a/src/screens/Manager/Device/DeviceName.tsx
+++ b/src/screens/Manager/Device/DeviceName.tsx
@@ -45,7 +45,7 @@ export default function DeviceNameRow({
       >
         {savedName || initialDeviceName || productName}
       </Text>
-      {id !== "nanoS" && (
+      {id === "nanoX" && (
         <Flex
           ml={3}
           backgroundColor={"palette.primary.c30"}


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Context

Bug Fix: [LIVE-1316](https://ledgerhq.atlassian.net/browse/LIVE-1316?atlOrigin=eyJpIjoiZjQzZTg2Mjk4ZjU4NGQyYmE4ZjI1OGFiNGY5M2FiZjEiLCJwIjoiaiJ9l) -> but actually only allowing Nano X to update its device name
 
### Draft

The branch `release/v3.0.x` needs to be merged first to `develop`

### Screenshots

<details>
  <summary>Nano S - no edit name feature</summary>

![Screenshot from 2022-04-07 16-49-18](https://user-images.githubusercontent.com/15096913/162236841-4316555e-57bc-4010-b75e-a1deca807041.png)

</details>

<details>
  <summary>Nano X - available edit name feature</summary>

![Screenshot from 2022-04-07 16-55-12](https://user-images.githubusercontent.com/15096913/162236785-c6f59e58-16f9-4fc4-9d89-71ac2786be3a.png)

![Screenshot from 2022-04-07 16-55-36](https://user-images.githubusercontent.com/15096913/162236805-771c6e5c-ec82-4e1b-b330-1cd91f9f845a.png)
</details>

### Parts of the app affected / Test plan

On `My Ledger` (formerly the `Manager` tab) you should only be able to change the name of your nano if it is a Nano X