### PR TITLE
Tron edit delegation cursor sometimes appeared before the text

### DIFF
--- a/src/families/tron/VoteFlow/02-VoteModal.tsx
+++ b/src/families/tron/VoteFlow/02-VoteModal.tsx
@@ -287,14 +287,13 @@ const styles = StyleSheet.create({
   wrapper: {
     flexDirection: "row",
     alignItems: "center",
+    justifyContent: "center",
     flexGrow: 1,
     flexShrink: 1,
   },
   inputStyle: {
-    flex: 1,
     ...getFontStyle(),
-    textAlign: "center",
-
+    padding: 30,
     fontSize: 32,
   },
   maxLabel: {


### PR DESCRIPTION
"Tron- Android only - Pixel 4 - Manage Votes- When you try to edit votes, in the VOTE FOR … page, some votes have the default cursor in front of number input which is bad UX" => Fixed

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
