### PR TITLE
Fix date formatting timezone, replace react-native-locale by react-native-localize

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -403,8 +403,6 @@ PODS:
     - react-native-flipper-performance-plugin/FBDefines (= 0.2.0)
   - react-native-flipper-performance-plugin/FBDefines (0.2.0):
     - React-Core
-  - react-native-locale (0.0.19):
-    - React
   - react-native-netinfo (6.2.1):
     - React-Core
   - react-native-performance (2.1.0):
@@ -529,6 +527,8 @@ PODS:
   - RNLibLedgerCore (4.19.1):
     - ledger-core-objc
     - React
+  - RNLocalize (2.2.1):
+    - React-Core
   - RNOS (1.2.6):
     - React
   - RNReanimated (2.4.1):
@@ -658,7 +658,6 @@ DEPENDENCIES:
   - react-native-fast-crypto (from `../node_modules/react-native-fast-crypto`)
   - react-native-fingerprint-scanner (from `../node_modules/react-native-fingerprint-scanner`)
   - react-native-flipper-performance-plugin (from `../node_modules/react-native-flipper-performance-plugin`)
-  - react-native-locale (from `../node_modules/react-native-locale`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-performance (from `../node_modules/react-native-performance/ios`)
   - react-native-randombytes (from `../node_modules/react-native-randombytes`)
@@ -692,6 +691,7 @@ DEPENDENCIES:
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNKeychain (from `../node_modules/react-native-keychain`)
   - "RNLibLedgerCore (from `../node_modules/@ledgerhq/react-native-ledger-core`)"
+  - RNLocalize (from `../node_modules/react-native-localize`)
   - RNOS (from `../node_modules/react-native-os`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
@@ -820,8 +820,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-fingerprint-scanner"
   react-native-flipper-performance-plugin:
     :path: "../node_modules/react-native-flipper-performance-plugin"
-  react-native-locale:
-    :path: "../node_modules/react-native-locale"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-performance:
@@ -888,6 +886,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-keychain"
   RNLibLedgerCore:
     :path: "../node_modules/@ledgerhq/react-native-ledger-core"
+  RNLocalize:
+    :path: "../node_modules/react-native-localize"
   RNOS:
     :path: "../node_modules/react-native-os"
   RNReanimated:
@@ -977,7 +977,6 @@ SPEC CHECKSUMS:
   react-native-fast-crypto: 5943c42466b86ad70be60d3a5f64bd22251e5d9e
   react-native-fingerprint-scanner: ac6656f18c8e45a7459302b84da41a44ad96dbbe
   react-native-flipper-performance-plugin: fccda3ebbcee11cda4e5dee85b335835e9c7e714
-  react-native-locale: bd8edf0e51706d469af3e2fa568a8102213a3139
   react-native-netinfo: 3d3769f0d65de15c83a9bf1346f8be71de5a24bf
   react-native-performance: f4b6604a9d5a8a7407e34a82fab6c641d9a3ec12
   react-native-randombytes: 421f1c7d48c0af8dbcd471b0324393ebf8fe7846
@@ -1011,6 +1010,7 @@ SPEC CHECKSUMS:
   RNGestureHandler: a479ebd5ed4221a810967000735517df0d2db211
   RNKeychain: f75b8c8b2f17d3b2aa1f25b4a0ac5b83d947ff8f
   RNLibLedgerCore: 6d8a54abc2dc2ffa38c33fbb70d5247b97a0091e
+  RNLocalize: cbcb55d0e19c78086ea4eea20e03fe8000bbbced
   RNOS: 6f2f9a70895bbbfbdad7196abd952e7b01d45027
   RNReanimated: 32c91e28f5780937b8efc07ddde1bab8d373fe0b
   RNScreens: 2559f98b0835103cbef3b26ba77fa61d4bb37ae7

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "react-native-gesture-handler": "^1.10.3",
     "react-native-keychain": "^7.0.0",
     "react-native-level-fs": "^3.0.0",
-    "react-native-locale": "0.0.19",
+    "react-native-localize": "^2.2.1",
     "react-native-modal": "^13.0.0",
     "react-native-navigation-bar-color": "^2.0.1",
     "react-native-os": "^1.2.6",

--- a/src/analytics/segment.js
+++ b/src/analytics/segment.js
@@ -8,6 +8,7 @@ import { Platform } from "react-native";
 import analytics from "@segment/analytics-react-native";
 import VersionNumber from "react-native-version-number";
 import Locale from "react-native-locale";
+import RNLocalize from "react-native-localize";
 import { ReplaySubject } from "rxjs";
 import {
   getAndroidArchitecture,
@@ -32,7 +33,7 @@ const { ANALYTICS_LOGS, ANALYTICS_TOKEN } = Config;
 
 const extraProperties = store => {
   const state: State = store.getState();
-  const { localeIdentifier, preferredLanguages } = Locale.constants();
+  const systemLanguage = RNLocalize.getLocales()[0]?.languageTag;
   const language = languageSelector(state);
   const region = localeSelector(state);
   const devices = knownDevicesSelector(state);
@@ -52,8 +53,7 @@ const extraProperties = store => {
     androidVersionCode: getAndroidVersionCode(VersionNumber.buildVersion),
     androidArchitecture: getAndroidArchitecture(VersionNumber.buildVersion),
     environment: ANALYTICS_LOGS ? "development" : "production",
-    localeIdentifier,
-    preferredLanguage: preferredLanguages ? preferredLanguages[0] : null,
+    systemLanguage,
     language,
     region: region?.split("-")[1] || region,
     platformOS: Platform.OS,

--- a/src/context/Locale.js
+++ b/src/context/Locale.js
@@ -9,6 +9,7 @@ import React, {
 import i18next from "i18next";
 import { initReactI18next } from "react-i18next";
 import type { TFunction } from "react-i18next";
+import { getTimeZone } from "react-native-localize";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useSelector } from "react-redux";
 import {
@@ -17,6 +18,12 @@ import {
   locales,
 } from "../languages";
 import { languageSelector } from "../reducers/settings";
+
+if ("__setDefaultTimeZone" in Intl.DateTimeFormat) {
+  /** https://formatjs.io/docs/polyfills/intl-datetimeformat/#default-timezone */
+  // $FlowFixMe
+  Intl.DateTimeFormat.__setDefaultTimeZone(getTimeZone()); // eslint-disable-line no-underscore-dangle
+}
 
 i18next.use(initReactI18next).init({
   fallbackLng: DEFAULT_LANGUAGE_LOCALE,

--- a/src/languages.js
+++ b/src/languages.js
@@ -1,5 +1,5 @@
 // @flow
-import Locale from "react-native-locale";
+import RNLocalize from "react-native-localize";
 import Config from "react-native-config";
 import allLocales from "./locales";
 
@@ -57,17 +57,9 @@ export const DEFAULT_LANGUAGE_LOCALE = "en";
  */
 export const getDefaultLanguageLocale = (
   fallbackLocale: string = DEFAULT_LANGUAGE_LOCALE,
-) => {
-  const { localeIdentifier, preferredLanguages } = Locale.constants();
-  const locale =
-    (preferredLanguages && preferredLanguages[0]) || localeIdentifier;
-  const matches = locale.match(/([a-z]{2,4}[-_]([A-Z]{2,4}|[0-9]{3}))/);
-  const lang = (matches && matches[1].replace("_", "-")) || "en-US";
-  return (
-    fullySupportedLocales.find(locale => lang.startsWith(locale)) ||
-    fallbackLocale
-  );
-};
+) =>
+  RNLocalize.findBestAvailableLanguage(fullySupportedLocales)?.languageTag ||
+  fallbackLocale;
 
 const languageLocaleToDefaultLocaleMap = {
   de: "de-DE",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14242,10 +14242,10 @@ react-native-level-fs@^3.0.0:
     level-filesystem "^1.0.1"
     levelup "^0.18.2"
 
-react-native-locale@0.0.19:
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/react-native-locale/-/react-native-locale-0.0.19.tgz#336842dfb97510a539f98a39331fb7430acdc498"
-  integrity sha512-US+249Sl2PhFcM0k/yU7RFwK8eiU0Qh8vHTZGF4xw5VnhJyDu2oOn3x8Gshb4X+Xyx9AxSTkib280QROnjPFzQ==
+react-native-localize@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-2.2.1.tgz#6fe646833691c6ee8a474df3c8b069402cb1dba8"
+  integrity sha512-BuPaQWvxLZG1NrCDGqgAnecDrNQu3LED9/Pyl4H2LwTMHcEngXpE5PfVntW2GiLumdr6nUOkWmMnh8PynZqrsw==
 
 react-native-modal@^13.0.0:
   version "13.0.0"


### PR DESCRIPTION
### The issue:
All the dates in the app were formatted in UTC timezone.

The issue was that since we were using Hermes as a JS engine, we had to polyfill DateTimeFormat with FormatJS, which came with UTC set a default and left us with **no "javascript native" way to get the current timezone.**

### Changes:
- Replacing `react-native-locale` (old 4y outdated lib) by `react-native-localize` (more modern, **gives us access to the system timezone**).
- Adapting to the change of library:
  - **`src/languages.js`**:
     The default app language can now be obtained directly from `react-native-localize` with `findBestAvailableLanguage(listOfSupportedLanguages)`.
  - **`src/analytics/segment.js`**:
     In the analytics global properties:
    - removing property `localeIdentifier` which was irrelevant on iOS
    - removing property `preferredLanguage` which was working only on iOS
    - adding a property `systemLanguage` which has better naming, works on iOS and Android and gives us the system's main language, fulfilling the role of what the two removed properties were doing before.
- Fixing the DateTimeFormat timezone issue: 
  - **`src/context/Locale.js`**:
    Using `react-native-localize`'s `getTimeZone()` and using it as a default timezone for `DateTimeFormat`.


### Result:
How I tested it: example in timezone Europe/Paris using `<FormatDate date={new Date()} withHoursMinutes />`
> ![Screenshot_1649411357](https://user-images.githubusercontent.com/91890529/162411946-46092d4b-d619-4632-97d8-16c96753922a.png)


### Type

Bug fix

### Context

v3 prerelease

### Parts of the app affected / Test plan

App's default language.
Analytics.
All displayed dates.
