### PR TITLE
Portfolio fixes & pixel polish

### DIFF
--- a/src/screens/Accounts/AccountRow.tsx
+++ b/src/screens/Accounts/AccountRow.tsx
@@ -133,7 +133,7 @@ const AccountRow = ({
         />
       )}
       <Flex flexDirection="row" pt={topLink ? 0 : 6} pb={bottomLink ? 0 : 6}>
-        <Flex mr={6}>
+        <Flex pr={4}>
           <ProgressLoader
             strokeWidth={2}
             mainColor={color}
@@ -157,8 +157,8 @@ const AccountRow = ({
             </Flex>
           </ProgressLoader>
         </Flex>
-        <Flex flex={1}>
-          <Flex flexDirection="row" justifyContent="space-between">
+        <Flex flex={1} justifyContent="center">
+          <Flex mb={1} flexDirection="row" justifyContent="space-between">
             <Flex
               flexGrow={1}
               flexShrink={1}

--- a/src/screens/Accounts/index.tsx
+++ b/src/screens/Accounts/index.tsx
@@ -143,7 +143,10 @@ function Accounts({ navigation, route }: Props) {
   );
 
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <SafeAreaView
+      style={{ flex: 1 }}
+      edges={["top", "left", "right"]} // see https://github.com/th3rdwave/react-native-safe-area-context#edges
+    >
       <TrackScreen category="Accounts" accountsLength={accounts.length} />
       <Flex flex={1} bg={"background.main"}>
         <Flex p={6} flexDirection="row" alignItems="center">

--- a/src/screens/Discover/index.tsx
+++ b/src/screens/Discover/index.tsx
@@ -19,7 +19,9 @@ const appsImg = require("../../images/illustration/Shared/_Apps.png");
 
 const earnImg = require("../../images/illustration/Shared/_Earn.png");
 
-const StyledSafeAreaView = styled(SafeAreaView)`
+const StyledSafeAreaView = styled(SafeAreaView).attrs({
+  edges: ["top", "left", "right"], // see https://github.com/th3rdwave/react-native-safe-area-context#edges
+})`
   flex: 1;
   background-color: ${({ theme }) => theme.colors.background.main};
 `;

--- a/src/screens/Market/index.tsx
+++ b/src/screens/Market/index.tsx
@@ -403,6 +403,7 @@ export default function Market({ navigation }: { navigation: any }) {
 
   return (
     <SafeAreaView
+      edges={["top", "left", "right"]} // see https://github.com/th3rdwave/react-native-safe-area-context#edges
       style={{
         flex: 1,
         backgroundColor: colors.background.main,

--- a/src/screens/Nft/NftCollection/index.js
+++ b/src/screens/Nft/NftCollection/index.js
@@ -192,6 +192,7 @@ const NftCollection = ({ route }: Props) => {
 
   return (
     <SafeAreaView
+      edges={["top", "left", "right"]} // see https://github.com/th3rdwave/react-native-safe-area-context#edges
       style={[
         styles.root,
         {

--- a/src/screens/Nft/NftGallery/index.js
+++ b/src/screens/Nft/NftGallery/index.js
@@ -87,6 +87,7 @@ const NftGallery = () => {
 
   return (
     <SafeAreaView
+      edges={["top", "left", "right"]} // see https://github.com/th3rdwave/react-native-safe-area-context#edges
       style={[
         styles.root,
         {

--- a/src/screens/Portfolio/Header.tsx
+++ b/src/screens/Portfolio/Header.tsx
@@ -27,8 +27,9 @@ import { scrollToTop } from "../../navigation/utils";
 import LiveLogo from "../../icons/LiveLogo";
 import CurrencyUnitValue from "../../components/CurrencyUnitValue";
 import Placeholder from "../../components/Placeholder";
+import { withDiscreetMode } from "../../context/DiscreetModeContext";
 
-export default function PortfolioHeader({
+function PortfolioHeader({
   currentPositionY,
   graphCardEndPosition,
   portfolio,
@@ -194,3 +195,5 @@ export default function PortfolioHeader({
     </Animated.View>
   );
 }
+
+export default withDiscreetMode(PortfolioHeader);

--- a/src/screens/Portfolio/index.tsx
+++ b/src/screens/Portfolio/index.tsx
@@ -15,6 +15,7 @@ import { Box, Flex, Link as TextLink, Text } from "@ledgerhq/native-ui";
 
 import styled, { useTheme } from "styled-components/native";
 import { FlexBoxProps } from "@ledgerhq/native-ui/components/Layout/Flex";
+import proxyStyled from "@ledgerhq/native-ui/components/styled";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { PlusMedium } from "@ledgerhq/native-ui/assets/icons";
 import { Currency } from "@ledgerhq/live-common/lib/types";
@@ -67,6 +68,11 @@ const StyledTouchableOpacity = styled.TouchableOpacity`
 const ContentContainer = styled(SafeAreaView)`
   flex: 1;
 `;
+
+const SectionContainer = styled(Flex).attrs((p: { px?: string | number }) => ({
+  mt: 9,
+  px: p.px ?? 6,
+}))``;
 
 const SectionTitle = ({
   title,
@@ -188,11 +194,12 @@ function PortfolioScreen({ navigation }: Props) {
         : []),
       ...(showAssets
         ? [
-            <Flex mx={6} mt={8}>
+            <SectionContainer>
               <SectionTitle
                 title={t("distribution.title")}
                 navigation={navigation}
                 navigatorName={NavigatorName.PortfolioAccounts}
+                containerProps={{ mb: "9px" }}
               />
               <Assets
                 balanceHistory={portfolio.balanceHistory}
@@ -222,20 +229,21 @@ function PortfolioScreen({ navigation }: Props) {
                   />
                 </>
               )}
-            </Flex>,
+            </SectionContainer>,
           ]
         : []),
       ...(showCarousel
         ? [
-            <Flex mt={8}>
-              <Flex mx={6}>
-                <SectionTitle title={t("portfolio.recommended.title")} />
-              </Flex>
+            <SectionContainer px={0}>
+              <SectionTitle
+                title={t("portfolio.recommended.title")}
+                containerProps={{ mb: 7, mx: 6 }}
+              />
               <Carousel cardsVisibility={carouselVisibility} />
-            </Flex>,
+            </SectionContainer>,
           ]
         : []),
-      <Flex mx={6} my={8}>
+      <SectionContainer mb={9}>
         <SectionTitle
           title={t("portfolio.topGainers.title")}
           navigation={navigation}
@@ -243,10 +251,10 @@ function PortfolioScreen({ navigation }: Props) {
           screenName={ScreenName.MarketList}
           params={{ top100: true }}
           seeMoreText={t("portfolio.topGainers.seeMarket")}
-          containerProps={{ mb: 5 }}
+          containerProps={{ mb: "17px" }}
         />
         <MarketSection />
-      </Flex>,
+      </SectionContainer>,
     ],
     [
       showAssets,

--- a/src/screens/Portfolio/index.tsx
+++ b/src/screens/Portfolio/index.tsx
@@ -67,7 +67,10 @@ const StyledTouchableOpacity = proxyStyled.TouchableOpacity.attrs({
   my: -5,
 })``;
 
-const ContentContainer = styled(SafeAreaView)`
+const ContentContainer = styled(SafeAreaView).attrs({
+  /** This view doesn't touch the bottom of the screen https://github.com/th3rdwave/react-native-safe-area-context#edges */
+  edges: ["top", "left", "right"],
+})`
   flex: 1;
 `;
 

--- a/src/screens/Portfolio/index.tsx
+++ b/src/screens/Portfolio/index.tsx
@@ -58,12 +58,14 @@ type Props = {
   navigation: any;
 };
 
-const StyledTouchableOpacity = styled.TouchableOpacity`
-  justify-content: center;
-  align-items: flex-end;
-  padding-left: 24px;
-  padding-vertical: 16px;
-`;
+const StyledTouchableOpacity = proxyStyled.TouchableOpacity.attrs({
+  justifyContent: "center",
+  alignItems: "flex-end",
+  px: 7,
+  mx: -7,
+  py: 5,
+  my: -5,
+})``;
 
 const ContentContainer = styled(SafeAreaView)`
   flex: 1;


### PR DESCRIPTION
Some fixes & pixel polish on the porfolio screen:

- Fix an issue where the "see all" button was very hard to press because only a zone around it was triggering an `onPress`.
- Fix an issue with `SafeAreaView` -> the bottom part of the main screens would be clipped above the navigation bar. There might be some other screens affected but I fixed the main ones that appear right when switching to another tab. _see before/after screenshots below_
- Fix spacing between section, following [Figma design](https://www.figma.com/file/kbcqFhPS0O1GQ4zPoXpGJa/LLM-%2F-Portfolio?node-id=4035%3A86997), _see before/after screenshots below_.
- Fix layout of `AccountRow` on the portfolio screen, _see before/after screenshots below_:
  - Vertically centering + appropriate spacing between the 2 rows of text (following Figma exactly)
  - Padding between currency icon and content, exactly as on Figma
- Fix an issue where discreet mode isn't applied to the portfolio header that appears upon scrolling.
  > This video is after the fix. Before, the value appearing at the top would always be in clear
  >
  > https://user-images.githubusercontent.com/91890529/162732670-0e336942-a3fe-4ff1-b781-1b7b4f245a3d.mp4

### Before / After of portfolio screen

![Simulator Screen Shot - iPhone 12 - 2022-04-11 at 13 48](https://user-images.githubusercontent.com/91890529/162735066-35adb581-511a-42b7-b1ed-79dda510f8d3.png)



### Type

Bug fixes & pixel polish

### Context

v3 pre release

### Parts of the app affected / Test plan

Portfolio screen, assets screen, account screen, nft collection screen, nft gallery screen, market screen, discover screen
