### PR TITLE
Fixes on the portfolio "wallet" section

### DIFF
--- a/src/components/Delta.tsx
+++ b/src/components/Delta.tsx
@@ -21,6 +21,8 @@ type Props = {
   style?: any;
   /** whether to still render something for a 0% variation */
   show0Delta?: boolean;
+  /** whether to show a placeholder in case the percent value is not valid */
+  fallbackToPercentPlaceholder?: boolean;
 };
 
 function Delta({
@@ -30,8 +32,15 @@ function Delta({
   range,
   style,
   show0Delta,
+  fallbackToPercentPlaceholder,
 }: Props) {
   const { t } = useTranslation();
+
+  const percentPlaceholder = fallbackToPercentPlaceholder ? (
+    <Text variant={"body"} color="neutral.c60" fontWeight={"medium"}>
+      -
+    </Text>
+  ) : null;
 
   if (
     percent &&
@@ -39,6 +48,7 @@ function Delta({
       valueChange.percentage === null ||
       valueChange.percentage === undefined)
   ) {
+    if (fallbackToPercentPlaceholder) return percentPlaceholder;
     return null;
   }
 
@@ -48,6 +58,7 @@ function Delta({
       : valueChange.value;
 
   if (Number.isNaN(delta)) {
+    if (percent && fallbackToPercentPlaceholder) return percentPlaceholder;
     return null;
   }
 

--- a/src/components/Delta.tsx
+++ b/src/components/Delta.tsx
@@ -19,12 +19,26 @@ type Props = {
   unit?: Unit;
   range?: PortfolioRange;
   style?: any;
+  /** whether to still render something for a 0% variation */
+  show0Delta?: boolean;
 };
 
-function Delta({ valueChange, percent, unit, range, style }: Props) {
+function Delta({
+  valueChange,
+  percent,
+  unit,
+  range,
+  style,
+  show0Delta,
+}: Props) {
   const { t } = useTranslation();
 
-  if (percent && (!valueChange.percentage || valueChange.percentage === 0)) {
+  if (
+    percent &&
+    ((valueChange.percentage === 0 && !show0Delta) ||
+      valueChange.percentage === null ||
+      valueChange.percentage === undefined)
+  ) {
     return null;
   }
 

--- a/src/components/Delta.tsx
+++ b/src/components/Delta.tsx
@@ -33,12 +33,19 @@ function Delta({
 }: Props) {
   const { t } = useTranslation();
 
+  if (
+    percent &&
+    ((valueChange.percentage === 0 && !show0Delta) ||
+      valueChange.percentage === null ||
+      valueChange.percentage === undefined)
+  ) {
+    return null;
+  }
+
   const delta =
     percent && valueChange.percentage
       ? valueChange.percentage * 100
       : valueChange.value;
-
-  if (percent && delta === 0 && !show0Delta) return null;
 
   if (Number.isNaN(delta)) {
     return null;

--- a/src/components/Delta.tsx
+++ b/src/components/Delta.tsx
@@ -33,19 +33,12 @@ function Delta({
 }: Props) {
   const { t } = useTranslation();
 
-  if (
-    percent &&
-    ((valueChange.percentage === 0 && !show0Delta) ||
-      valueChange.percentage === null ||
-      valueChange.percentage === undefined)
-  ) {
-    return null;
-  }
-
   const delta =
     percent && valueChange.percentage
       ? valueChange.percentage * 100
       : valueChange.value;
+
+  if (percent && delta === 0 && !show0Delta) return null;
 
   if (Number.isNaN(delta)) {
     return null;

--- a/src/components/DiscreetModeButton.tsx
+++ b/src/components/DiscreetModeButton.tsx
@@ -27,5 +27,7 @@ const styles = StyleSheet.create({
   root: {
     alignItems: "center",
     justifyContent: "center",
+    margin: -10,
+    padding: 10,
   },
 });

--- a/src/components/GraphCard.tsx
+++ b/src/components/GraphCard.tsx
@@ -6,10 +6,10 @@ import { BoxedIcon, Flex, Text } from "@ledgerhq/native-ui";
 import { Trans } from "react-i18next";
 import { PieChartMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useNavigation } from "@react-navigation/native";
+import styled from "styled-components/native";
 import Delta from "./Delta";
 import TransactionsPendingConfirmationWarning from "./TransactionsPendingConfirmationWarning";
 import CurrencyUnitValue from "./CurrencyUnitValue";
-import Placeholder from "./Placeholder";
 import DiscreetModeButton from "./DiscreetModeButton";
 import { NavigatorName } from "../const";
 
@@ -19,6 +19,21 @@ type Props = {
   useCounterValue?: boolean;
   renderTitle?: ({ counterValueUnit: Unit, item: Item }) => ReactNode;
 };
+
+const Placeholder = styled(Flex).attrs({
+  backgroundColor: "neutral.c40",
+  borderRadius: "4px",
+})``;
+const BigPlaceholder = styled(Placeholder).attrs({
+  width: 189,
+  height: 18,
+})``;
+
+const SmallPlaceholder = styled(Placeholder).attrs({
+  width: 109,
+  height: 8,
+  borderRadius: "2px",
+})``;
 
 export default function GraphCard({
   portfolio,
@@ -56,10 +71,9 @@ export default function GraphCard({
             </Text>
             <DiscreetModeButton size={20} />
           </Flex>
-
-          <View>
+          <Flex>
             {!balanceAvailable ? (
-              <Placeholder width={228} containerHeight={27} />
+              <BigPlaceholder mt="8px" />
             ) : renderTitle ? (
               renderTitle({ counterValueUnit: unit, item })
             ) : (
@@ -68,16 +82,11 @@ export default function GraphCard({
               </Text>
             )}
             <TransactionsPendingConfirmationWarning />
-          </View>
+          </Flex>
           <Flex flexDirection={"row"}>
             {!balanceAvailable ? (
               <>
-                <Placeholder
-                  width={50}
-                  containerHeight={19}
-                  style={{ marginRight: 10 }}
-                />
-                <Placeholder width={50} containerHeight={19} />
+                <SmallPlaceholder mt="12px" />
               </>
             ) : (
               <View>

--- a/src/components/GraphCard.tsx
+++ b/src/components/GraphCard.tsx
@@ -96,7 +96,6 @@ export default function GraphCard({
                   <View>
                     <Delta
                       percent
-                      // valueChange={{value: 0, percentage: 0}}
                       show0Delta
                       valueChange={countervalueChange}
                       range={portfolio.range}

--- a/src/components/GraphCard.tsx
+++ b/src/components/GraphCard.tsx
@@ -1,17 +1,12 @@
 import React, { ReactNode, useCallback } from "react";
 import { TouchableOpacity, View } from "react-native";
-import { Currency, Unit } from "@ledgerhq/live-common/lib/types";
-import {
-  Portfolio,
-  PortfolioRange,
-  ValueChange,
-} from "@ledgerhq/live-common/lib/portfolio/v2/types";
+import { Currency } from "@ledgerhq/live-common/lib/types";
+import { Portfolio } from "@ledgerhq/live-common/lib/portfolio/v2/types";
 import { BoxedIcon, Flex, Text } from "@ledgerhq/native-ui";
 import { Trans } from "react-i18next";
 import { PieChartMedium } from "@ledgerhq/native-ui/assets/icons";
 import { useNavigation } from "@react-navigation/native";
 import Delta from "./Delta";
-import { Item } from "./Graph/types";
 import TransactionsPendingConfirmationWarning from "./TransactionsPendingConfirmationWarning";
 import CurrencyUnitValue from "./CurrencyUnitValue";
 import Placeholder from "./Placeholder";
@@ -30,107 +25,83 @@ export default function GraphCard({
   renderTitle,
   counterValueCurrency,
 }: Props) {
-  const { countervalueChange } = portfolio;
+  const { countervalueChange, balanceAvailable, balanceHistory } = portfolio;
 
-  const isAvailable = portfolio.balanceAvailable;
-  const balanceHistory = portfolio.balanceHistory;
-
-  return (
-    <Flex bg={"neutral.c30"} p={6} borderRadius={2}>
-      <GraphCardHeader
-        valueChange={countervalueChange}
-        isLoading={!isAvailable}
-        to={balanceHistory[balanceHistory.length - 1]}
-        unit={counterValueCurrency.units[0]}
-        range={portfolio.range}
-        renderTitle={renderTitle}
-      />
-    </Flex>
-  );
-}
-
-function GraphCardHeader({
-  unit,
-  valueChange,
-  range,
-  renderTitle,
-  isLoading,
-  to,
-}: {
-  isLoading: boolean;
-  valueChange: ValueChange;
-  unit: Unit;
-  to: Item;
-  range?: PortfolioRange;
-  renderTitle?: ({ counterValueUnit: Unit, item: Item }) => ReactNode;
-}) {
-  const item = to;
+  const item = balanceHistory[balanceHistory.length - 1];
   const navigation = useNavigation();
 
   const onPieChartButtonpress = useCallback(() => {
     navigation.navigate(NavigatorName.Analytics);
   }, [navigation]);
 
-  return (
-    <Flex
-      flexDirection={"row"}
-      justifyContent={"space-between"}
-      alignItems={"center"}
-    >
-      <Flex>
-        <Flex flexDirection={"row"} alignItems={"center"} mb={1}>
-          <Text
-            variant={"small"}
-            fontWeight={"semiBold"}
-            color={"neutral.c70"}
-            textTransform={"uppercase"}
-            mr={2}
-          >
-            <Trans i18nKey={"tabs.portfolio"} />
-          </Text>
-          <DiscreetModeButton size={20} />
-        </Flex>
+  const unit = counterValueCurrency.units[0];
 
-        <View>
-          {isLoading ? (
-            <Placeholder width={228} containerHeight={27} />
-          ) : renderTitle ? (
-            renderTitle({ counterValueUnit: unit, item })
-          ) : (
-            <Text variant={"h1"} color={"neutral.c100"}>
-              <CurrencyUnitValue unit={unit} value={item.value} />
+  return (
+    <Flex bg={"neutral.c30"} p={6} borderRadius={2}>
+      <Flex
+        flexDirection={"row"}
+        justifyContent={"space-between"}
+        alignItems={"center"}
+      >
+        <Flex>
+          <Flex flexDirection={"row"} alignItems={"center"} mb={1}>
+            <Text
+              variant={"small"}
+              fontWeight={"semiBold"}
+              color={"neutral.c70"}
+              textTransform={"uppercase"}
+              mr={2}
+            >
+              <Trans i18nKey={"tabs.portfolio"} />
             </Text>
-          )}
-          <TransactionsPendingConfirmationWarning />
-        </View>
-        <Flex flexDirection={"row"}>
-          {isLoading ? (
-            <>
-              <Placeholder
-                width={50}
-                containerHeight={19}
-                style={{ marginRight: 10 }}
-              />
-              <Placeholder width={50} containerHeight={19} />
-            </>
-          ) : (
-            <View>
-              <Delta percent valueChange={valueChange} range={range} />
-            </View>
-          )}
+            <DiscreetModeButton size={20} />
+          </Flex>
+
+          <View>
+            {!balanceAvailable ? (
+              <Placeholder width={228} containerHeight={27} />
+            ) : renderTitle ? (
+              renderTitle({ counterValueUnit: unit, item })
+            ) : (
+              <Text variant={"h1"} color={"neutral.c100"}>
+                <CurrencyUnitValue unit={unit} value={item.value} />
+              </Text>
+            )}
+            <TransactionsPendingConfirmationWarning />
+          </View>
+          <Flex flexDirection={"row"}>
+            {!balanceAvailable ? (
+              <>
+                <Placeholder
+                  width={50}
+                  containerHeight={19}
+                  style={{ marginRight: 10 }}
+                />
+                <Placeholder width={50} containerHeight={19} />
+              </>
+            ) : (
+              <View>
+                <Delta
+                  percent
+                  valueChange={countervalueChange}
+                  range={portfolio.range}
+                />
+              </View>
+            )}
+          </Flex>
         </Flex>
-      </Flex>
-      <Flex>
-        <TouchableOpacity onPress={onPieChartButtonpress}>
-          <BoxedIcon
-            Icon={PieChartMedium}
-            variant={"circle"}
-            iconSize={20}
-            size={48}
-            badgeSize={30}
-            iconColor={"neutral.c100"}
-          />
-        </TouchableOpacity>
+        <Flex>
+          <TouchableOpacity onPress={onPieChartButtonpress}>
+            <BoxedIcon
+              Icon={PieChartMedium}
+              variant={"circle"}
+              iconSize={20}
+              size={48}
+              badgeSize={30}
+              iconColor={"neutral.c100"}
+            />
+          </TouchableOpacity>
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/src/components/GraphCard.tsx
+++ b/src/components/GraphCard.tsx
@@ -97,6 +97,7 @@ export default function GraphCard({
                     <Delta
                       percent
                       show0Delta
+                      fallbackToPercentPlaceholder
                       valueChange={countervalueChange}
                       range={portfolio.range}
                     />

--- a/src/components/GraphCard.tsx
+++ b/src/components/GraphCard.tsx
@@ -96,6 +96,8 @@ export default function GraphCard({
                   <View>
                     <Delta
                       percent
+                      // valueChange={{value: 0, percentage: 0}}
+                      show0Delta
                       valueChange={countervalueChange}
                       range={portfolio.range}
                     />

--- a/src/components/GraphCard.tsx
+++ b/src/components/GraphCard.tsx
@@ -14,10 +14,10 @@ import DiscreetModeButton from "./DiscreetModeButton";
 import { NavigatorName } from "../const";
 
 type Props = {
+  areAccountsEmpty: boolean;
   portfolio: Portfolio;
   counterValueCurrency: Currency;
   useCounterValue?: boolean;
-  renderTitle?: ({ counterValueUnit: Unit, item: Item }) => ReactNode;
 };
 
 const Placeholder = styled(Flex).attrs({
@@ -37,8 +37,8 @@ const SmallPlaceholder = styled(Placeholder).attrs({
 
 export default function GraphCard({
   portfolio,
-  renderTitle,
   counterValueCurrency,
+  areAccountsEmpty,
 }: Props) {
   const { countervalueChange, balanceAvailable, balanceHistory } = portfolio;
 
@@ -69,48 +69,56 @@ export default function GraphCard({
             >
               <Trans i18nKey={"tabs.portfolio"} />
             </Text>
-            <DiscreetModeButton size={20} />
+            {!areAccountsEmpty && <DiscreetModeButton size={20} />}
           </Flex>
+          {areAccountsEmpty ? (
+            <Text variant={"h1"} color={"neutral.c100"}>
+              <CurrencyUnitValue unit={unit} value={0} />
+            </Text>
+          ) : (
+            <>
+              <Flex>
+                {!balanceAvailable ? (
+                  <BigPlaceholder mt="8px" />
+                ) : (
+                  <Text variant={"h1"} color={"neutral.c100"}>
+                    <CurrencyUnitValue unit={unit} value={item.value} />
+                  </Text>
+                )}
+                <TransactionsPendingConfirmationWarning />
+              </Flex>
+              <Flex flexDirection={"row"}>
+                {!balanceAvailable ? (
+                  <>
+                    <SmallPlaceholder mt="12px" />
+                  </>
+                ) : (
+                  <View>
+                    <Delta
+                      percent
+                      valueChange={countervalueChange}
+                      range={portfolio.range}
+                    />
+                  </View>
+                )}
+              </Flex>
+            </>
+          )}
+        </Flex>
+        {!areAccountsEmpty ? (
           <Flex>
-            {!balanceAvailable ? (
-              <BigPlaceholder mt="8px" />
-            ) : renderTitle ? (
-              renderTitle({ counterValueUnit: unit, item })
-            ) : (
-              <Text variant={"h1"} color={"neutral.c100"}>
-                <CurrencyUnitValue unit={unit} value={item.value} />
-              </Text>
-            )}
-            <TransactionsPendingConfirmationWarning />
+            <TouchableOpacity onPress={onPieChartButtonpress}>
+              <BoxedIcon
+                Icon={PieChartMedium}
+                variant={"circle"}
+                iconSize={20}
+                size={48}
+                badgeSize={30}
+                iconColor={"neutral.c100"}
+              />
+            </TouchableOpacity>
           </Flex>
-          <Flex flexDirection={"row"}>
-            {!balanceAvailable ? (
-              <>
-                <SmallPlaceholder mt="12px" />
-              </>
-            ) : (
-              <View>
-                <Delta
-                  percent
-                  valueChange={countervalueChange}
-                  range={portfolio.range}
-                />
-              </View>
-            )}
-          </Flex>
-        </Flex>
-        <Flex>
-          <TouchableOpacity onPress={onPieChartButtonpress}>
-            <BoxedIcon
-              Icon={PieChartMedium}
-              variant={"circle"}
-              iconSize={20}
-              size={48}
-              badgeSize={30}
-              iconColor={"neutral.c100"}
-            />
-          </TouchableOpacity>
-        </Flex>
+        ) : null}
       </Flex>
     </Flex>
   );

--- a/src/components/Placeholder.tsx
+++ b/src/components/Placeholder.tsx
@@ -19,7 +19,7 @@ function Placeholder({ width, containerHeight, style }: Props) {
         height={8}
         borderRadius={4}
         width={width || 100}
-        backgroundColor="colors.fog"
+        backgroundColor="neutral.c70"
         style={[style]}
       />
     </Flex>

--- a/src/screens/Accounts/AccountRow.tsx
+++ b/src/screens/Accounts/AccountRow.tsx
@@ -200,6 +200,7 @@ const AccountRow = ({
               <Delta
                 percent
                 show0Delta={account.balance.toNumber() !== 0}
+                fallbackToPercentPlaceholder
                 valueChange={countervalueChange}
               />
             )}

--- a/src/screens/Accounts/AccountRow.tsx
+++ b/src/screens/Accounts/AccountRow.tsx
@@ -49,7 +49,7 @@ const AccountRow = ({
   navigationParams,
   hideDelta,
   topLink,
-  bottomLink
+  bottomLink,
 }: Props) => {
   // makes it refresh if this changes
   useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
@@ -197,7 +197,11 @@ const AccountRow = ({
               <CurrencyUnitValue showCode unit={unit} value={account.balance} />
             </Text>
             {hideDelta ? null : (
-              <Delta percent valueChange={countervalueChange} />
+              <Delta
+                percent
+                show0Delta={account.balance.toNumber() !== 0}
+                valueChange={countervalueChange}
+              />
             )}
           </Flex>
         </Flex>

--- a/src/screens/Portfolio/GraphCardContainer.tsx
+++ b/src/screens/Portfolio/GraphCardContainer.tsx
@@ -14,10 +14,12 @@ import { withDiscreetMode } from "../../context/DiscreetModeContext";
 const GraphCardContainer = ({
   portfolio,
   showGraphCard,
+  areAccountsEmpty,
   counterValueCurrency,
 }: {
   portfolio: Portfolio;
   showGraphCard: boolean;
+  areAccountsEmpty: boolean;
   counterValueCurrency: Currency;
 }) => {
   const currencies: Array<CryptoCurrency | TokenCurrency> = useSelector(
@@ -30,6 +32,7 @@ const GraphCardContainer = ({
 
       {showGraphCard && (
         <GraphCard
+          areAccountsEmpty={areAccountsEmpty}
           counterValueCurrency={counterValueCurrency}
           portfolio={portfolio}
         />

--- a/src/screens/Portfolio/index.tsx
+++ b/src/screens/Portfolio/index.tsx
@@ -187,7 +187,8 @@ function PortfolioScreen({ navigation }: Props) {
         <GraphCardContainer
           counterValueCurrency={counterValueCurrency}
           portfolio={portfolio}
-          showGraphCard={!areAccountsEmpty}
+          areAccountsEmpty={areAccountsEmpty}
+          showGraphCard={accounts.length > 0}
         />
       </Box>,
       ...(accounts.length > 0


### PR DESCRIPTION
Fixes on the portfolio screen:

- Now if there are accounts but they are empty, we will show the "Wallet" section, but with 0$ basically and no discreet mode button, no stats button:
  <img src="https://user-images.githubusercontent.com/91890529/162999230-21607006-6e61-4be9-a2c8-f5b595b583cb.png" height="300px" />
- Fix no delta % being shown in some cases where the variation is 0 and we actually want to display it
- Fix wallet skeleton being transparent, using [new design](https://www.figma.com/file/kbcqFhPS0O1GQ4zPoXpGJa/?node-id=5691%3A111098)
- Make discreet mode button touch zone bigger
  <img src="https://user-images.githubusercontent.com/91890529/163002661-35e2576d-c476-4a50-987e-4d99585d3443.png" height="300px" />



All the fixes are made following [Figma](https://www.figma.com/file/kbcqFhPS0O1GQ4zPoXpGJa/?node-id=3333%3A67182) obviously.


### Type

Bug fixes

### Context

v3 fixes

### Parts of the app affected / Test plan

Portfolio screen
