### PR TITLE
feat(swap): Add Changelly's Terms of Use in the confirmation screen [LIVE-1196]

### DIFF
--- a/src/components/DeviceAction/index.js
+++ b/src/components/DeviceAction/index.js
@@ -171,7 +171,15 @@ export default function DeviceAction<R, H, P>({
   }
 
   if (initSwapRequested && !initSwapResult && !initSwapError) {
-    return renderConfirmSwap({ t, device: selectedDevice, colors, theme });
+    return renderConfirmSwap({
+      t,
+      device: selectedDevice,
+      colors,
+      theme,
+      provider:
+        (request && request.exchangeRate && request.exchangeRate.provider) ||
+        undefined,
+    });
   }
 
   if (initSellRequested && !initSellResult && !initSellError) {

--- a/src/components/DeviceAction/rendering.tsx
+++ b/src/components/DeviceAction/rendering.tsx
@@ -26,6 +26,7 @@ import Circle from "../Circle";
 import { MANAGER_TABS } from "../../screens/Manager/Manager";
 import ExternalLink from "../ExternalLink";
 import { track } from "../../analytics";
+import TermsFooter, { TermsProviders } from "../TermsFooter";
 
 const Wrapper = styled(Flex).attrs({
   flex: 1,
@@ -207,8 +208,10 @@ export function renderConfirmSwap({
   t,
   device,
   theme,
+  provider,
 }: RawProps & {
   device: Device;
+  provider?: TermsProviders;
 }) {
   return (
     <Wrapper width="100%">
@@ -224,6 +227,7 @@ export function renderConfirmSwap({
         />
       </AnimationContainer>
       <TitleText>{t("DeviceAction.confirmSwap.title")}</TitleText>
+      <TermsFooter provider={provider} />
     </Wrapper>
   );
 }

--- a/src/components/TermsFooter.tsx
+++ b/src/components/TermsFooter.tsx
@@ -1,0 +1,48 @@
+import { Text } from "@ledgerhq/native-ui";
+import React, { useCallback } from "react";
+import { Trans } from "react-i18next";
+import { Linking } from "react-native";
+import styled from "styled-components/native";
+import { urls } from "../config/urls";
+
+const CenteredText = styled(Text).attrs({
+  fontWeight: "medium",
+  textAlign: "center",
+})``;
+
+const UnderlinedText = styled(Text)`
+  text-decoration-line: underline;
+`;
+
+export type TermsProviders = keyof typeof urls.swap.providers;
+
+const TermsFooter: React.FC<{
+  provider?: TermsProviders;
+}> = ({ provider }) => {
+  const url = provider && urls.swap.providers[provider]?.tos;
+  const onLinkClick = useCallback(() => {
+    if (url) {
+      Linking.openURL(url);
+    }
+  }, [url]);
+
+  if (!url) {
+    return null;
+  }
+
+  return (
+    <CenteredText>
+      <Trans
+        i18nKey="DeviceAction.confirmSwap.acceptTerms"
+        values={{ provider }}
+        components={[
+          <UnderlinedText onPress={onLinkClick}>
+            <Text textTransform="capitalize">{provider}</Text>
+          </UnderlinedText>,
+        ]}
+      />
+    </CenteredText>
+  );
+};
+
+export default TermsFooter;

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -2783,7 +2783,8 @@
     },
     "confirmSwap": {
       "title": "Confirm swap operation on device",
-      "alert": "Verify the Swap details on your device before sending it. The addresses are exchanged securely so you don’t have to verify them."
+      "alert": "Verify the Swap details on your device before sending it. The addresses are exchanged securely so you don’t have to verify them.",
+      "acceptTerms": "By validating this transaction, I accept\n<0><0>{{provider}}</0>'s terms of use</0>"
     },
     "confirmSell": {
       "title": "Confirm sell operation on device",


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
Added terms of use for any provider in the swap config.

<img width="392" alt="screen.png" src="https://user-images.githubusercontent.com/3009753/166895973-da78dbec-af15-4b54-b9c6-93d67787fd26.png">


### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->
Feature

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->
[LIVE-1196]

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
- Swap flow

[LIVE-1196]: https://ledgerhq.atlassian.net/browse/LIVE-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ