### PR TITLE
Fix layout of portfolio recommended section on some screens

### DIFF
--- a/src/components/Carousel/Slide.tsx
+++ b/src/components/Carousel/Slide.tsx
@@ -2,8 +2,13 @@ import React, { useCallback } from "react";
 import { Linking, Image } from "react-native";
 import { Flex, Text, Link as TextLink, Icons } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
+import styled from "styled-components/native";
 import Touchable from "../Touchable";
 import { track } from "../../analytics";
+
+const StyledTouchable = styled(Touchable)`
+  flex: 1;
+`;
 
 type SlideProps = {
   url: string;
@@ -36,10 +41,10 @@ const Slide = ({
     Linking.openURL(url);
   }, [url]);
   return (
-    <Touchable event={`${name} Carousel`} onPress={onClick}>
+    <StyledTouchable event={`${name} Carousel`} onPress={onClick}>
       <Flex
         width={width}
-        height={"125px"}
+        flex={1}
         borderRadius={2}
         borderWidth={"1px"}
         borderColor={"neutral.c40"}
@@ -77,7 +82,7 @@ const Slide = ({
           ) : null}
         </Flex>
       </Flex>
-    </Touchable>
+    </StyledTouchable>
   );
 };
 

--- a/src/components/Carousel/Slide.tsx
+++ b/src/components/Carousel/Slide.tsx
@@ -52,7 +52,7 @@ const Slide = ({
         flexDirection={"row"}
         p={6}
       >
-        <Flex width={"200px"} alignItems="flex-start">
+        <Flex alignItems="flex-start" flex={1}>
           <Text variant={"subtitle"} fontSize={11} color={"neutral.c60"}>
             {t(title)}
           </Text>
@@ -78,7 +78,7 @@ const Slide = ({
               source={image}
             />
           ) : icon ? (
-            <Flex width={"110px"}>{icon}</Flex>
+            <Flex>{icon}</Flex>
           ) : null}
         </Flex>
       </Flex>

--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -1,7 +1,7 @@
 import React, { memo, useCallback, useMemo, useRef, useState } from "react";
 import { TouchableOpacity, ScrollView } from "react-native";
 import { useDispatch } from "react-redux";
-import { Box } from "@ledgerhq/native-ui";
+import { Flex } from "@ledgerhq/native-ui";
 import { CloseMedium } from "@ledgerhq/native-ui/assets/icons";
 import styled from "styled-components/native";
 import { setCarouselVisibility } from "../../actions/settings";
@@ -35,12 +35,12 @@ type CarouselCardProps = {
 };
 
 const CarouselCard = ({ id, children, onHide, index }: CarouselCardProps) => (
-  <Box key={`container_${id}`} mr={6} ml={index === 0 ? 6 : 0}>
+  <Flex key={`container_${id}`} mr={6} ml={index === 0 ? 6 : 0}>
     {children}
     <DismissCarousel hitSlop={hitSlop} onPress={() => onHide(id)}>
       <CloseMedium size={16} color="neutral.c70" />
     </DismissCarousel>
-  </Box>
+  </Flex>
 );
 
 // TODO : make it generic in the ui


### PR DESCRIPTION
On some devices depending on the screen size or the layout settings, the images & text are overflowing from the "recommended" cards on the Portfolio screen.

With this fix:
  1. all the cards have the height of the biggest card
  2. the image now fits properly because the width of its container isn't hardcoded.

#### Before:

> https://user-images.githubusercontent.com/91890529/163396748-39aaefae-d44d-4e3d-a2a9-820b103647a9.mp4

#### After:

> https://user-images.githubusercontent.com/91890529/163396826-ca6baefd-5b6a-4d76-9acd-b44b87ec0cdf.mp4



### Type

Bug fix / UI

### Context

v3 pre-release

### Parts of the app affected / Test plan

Portfolio -> "Recommended" section
