### PR TITLE
Sentry tweaks

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -100,6 +100,7 @@ project.ext.sentryCli = [
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
+apply from: "../../node_modules/@sentry/react-native/sentry.gradle"
 
 /**
  * Set this to true to create two separate APKs instead of one:

--- a/index.js
+++ b/index.js
@@ -37,8 +37,9 @@ if (Config.SENTRY_DSN && !__DEV__ && !Config.MOCK) {
   Sentry.init({
     dsn: Config.SENTRY_DSN,
     environment: Config.SENTRY_ENVIRONMENT,
-    release: `com.ledger.live@${pkg.version}+${VersionNumber.buildVersion}`,
-    dist: String(VersionNumber.buildVersion),
+    // NB we do not need to explicitly set the release. we let the native side infers it.
+    // release: `com.ledger.live@${pkg.version}+${VersionNumber.buildVersion}`,
+    // dist: String(VersionNumber.buildVersion),
     sampleRate: 0.05,
     tracesSampleRate: 0.001,
     integrations: [

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ if (Config.SENTRY_DSN && !__DEV__ && !Config.MOCK) {
     environment: Config.SENTRY_ENVIRONMENT,
     release: `ledger-live-mobile@${pkg.version}`,
     dist: String(VersionNumber.buildVersion),
+    sampleRate: 0.05,
     tracesSampleRate: 0.001,
     integrations: [
       new Sentry.ReactNativeTracing({

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ if (Config.SENTRY_DSN && !__DEV__ && !Config.MOCK) {
   Sentry.init({
     dsn: Config.SENTRY_DSN,
     environment: Config.SENTRY_ENVIRONMENT,
-    release: `ledger-live-mobile@${pkg.version}`,
+    release: `com.ledger.live@${pkg.version}+${VersionNumber.buildVersion}`,
     dist: String(VersionNumber.buildVersion),
     sampleRate: 0.05,
     tracesSampleRate: 0.001,

--- a/index.js
+++ b/index.js
@@ -22,8 +22,16 @@ import { getEnabled } from "./src/components/HookSentry";
 import logReport from "./src/log-report";
 import pkg from "./package.json";
 
-const blacklistErrorName = ["NetworkDown"];
-const blacklistErrorDescription = [/Device .* was disconnected/];
+const blacklistErrorName = [
+  "NetworkDown",
+  "Network Error",
+  "WebsocketConnectionError",
+  "DisconnectedDeviceDuringOperation",
+  "BleError",
+];
+const blacklistErrorDescription = [
+  "Transaction signing request was rejected by the user",
+];
 
 if (Config.SENTRY_DSN && !__DEV__ && !Config.MOCK) {
   Sentry.init({


### PR DESCRIPTION
- only report 5% of errors to not spam sentry
- blacklist more errors to avoid sending dummy errors (like bluetooth or network down issues)
- Fix Sentry release format
- Fix Android to upload to sentry