### PR TITLE
LIVE-1987 - Fix wrong icon in operation details

### DIFF
--- a/src/components/OperationIcon.js
+++ b/src/components/OperationIcon.js
@@ -9,6 +9,7 @@ import type {
   AccountLike,
 } from "@ledgerhq/live-common/lib/types";
 import { getMainAccount } from "@ledgerhq/live-common/lib/account";
+import { isConfirmedOperation } from "@ledgerhq/live-common/lib/operation";
 import OperationStatusIcon from "../icons/OperationStatusIcon";
 import { currencySettingsForAccountSelector } from "../reducers/settings";
 
@@ -73,18 +74,20 @@ class OperationIcon extends PureComponent<Props> {
 }
 
 const m: React$ComponentType<OwnProps> = connect((state, props) => {
-  const {
-    account,
-    parentAccount,
-    operation: { blockHeight, type },
-  } = props;
+  const { account, parentAccount, operation } = props;
+  const { type } = operation;
   const mainAccount = getMainAccount(account, parentAccount);
-  const confirmations = blockHeight ? mainAccount.blockHeight - blockHeight : 0;
+  const currencySettings = currencySettingsForAccountSelector(state, props);
+
+  const isConfirmed = isConfirmedOperation(
+    operation,
+    mainAccount,
+    currencySettings.confirmationsNb,
+  );
+
   return {
     type,
-    confirmed:
-      confirmations >=
-      currencySettingsForAccountSelector(state, props).confirmationsNb,
+    confirmed: isConfirmed,
   };
 })(OperationIcon);
 


### PR DESCRIPTION
The icon in OperationIcon was wrong for some coins (XRP, Cosmos) when the transaction is unconfirmed.
It would appear like the operation was confirmed, while the text below was showing "Not confirmed".
It was because the "confirmed" state was calculated differently in OperationIcon than the rest of OperationDetails.

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LIVE-1987

### Parts of the app affected / Test plan

Operation Details