### PR TITLE
Fix Learn page Staging URL + Put back dev settings

### DIFF
--- a/src/screens/Learn/index.tsx
+++ b/src/screens/Learn/index.tsx
@@ -11,11 +11,9 @@ import extraStatusBarPadding from "../../logic/extraStatusBarPadding";
 import LoadingView from "./LoadingScreen";
 import NoConnectionErrorScreen from "./NoConnectionErrorScreen";
 import { Track } from "../../analytics";
-import { lightTheme, darkTheme } from "../../colors";
 
 const learnProdURL = "https://www.ledger.com/ledger-live-learn";
-const learnStagingURL =
-  "https://ecommerce-website.aws.stg.ldg-tech.com/ledger-live-learn";
+const learnStagingURL = "https://www-ppr.ledger.com/ledger-live-learn";
 
 const SafeContainer = styled(SafeAreaView)`
   flex: 1;
@@ -41,10 +39,6 @@ function Learn() {
   const params = new URLSearchParams({
     theme: themeType,
     lang: i18n.languages[0],
-    pagePaddingLeft: "16px",
-    pagePaddingRight: "16px",
-    darkBackgroundColor: `${darkTheme.colors.background}`, // TODO: update in v3
-    lightBackgroundColor: `${lightTheme.colors.background}`, // TODO: update in v3
   });
 
   const uri = `${

--- a/src/screens/Settings/index.js
+++ b/src/screens/Settings/index.js
@@ -88,19 +88,21 @@ export default function Settings({ navigation }: Props) {
           icon={<Atom size={16} color={colors.live} />}
           onClick={() => navigation.navigate(ScreenName.ExperimentalSettings)}
         />
-        <SettingsCard
-          title={t("settings.developer.title")}
-          desc={t("settings.developer.desc")}
-          icon={<Wrench size={16} color={colors.live} />}
-          onClick={() => navigation.navigate(ScreenName.DeveloperSettings)}
-        />
         {debugVisible || __DEV__ ? (
-          <SettingsCard
-            title="Debug"
-            desc="Use at your own risk – Developer tools"
-            icon={<Icon name="wind" size={16} color={colors.live} />}
-            onClick={() => navigation.navigate(ScreenName.DebugSettings)}
-          />
+          <>
+            <SettingsCard
+              title={t("settings.developer.title")}
+              desc={t("settings.developer.desc")}
+              icon={<Wrench size={16} color={colors.live} />}
+              onClick={() => navigation.navigate(ScreenName.DeveloperSettings)}
+            />
+            <SettingsCard
+              title="Debug"
+              desc="Use at your own risk – Developer tools"
+              icon={<Icon name="wind" size={16} color={colors.live} />}
+              onClick={() => navigation.navigate(ScreenName.DebugSettings)}
+            />
+          </>
         ) : null}
         <TouchableWithoutFeedback onPress={onDebugHiddenPress}>
           <View>

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -2,14 +2,7 @@ import React, { useRef, useState, useCallback } from "react";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
 import { View, TouchableWithoutFeedback } from "react-native";
-import {
-  MobileMedium,
-  WalletMedium,
-  BracketsMedium,
-  LifeRingMedium,
-  ChartNetworkMedium,
-  ToolsMedium,
-} from "@ledgerhq/native-ui/assets/icons";
+import { Icons } from "@ledgerhq/native-ui";
 import Config from "react-native-config";
 import { ScreenName } from "../../const";
 import { accountsSelector } from "../../reducers/accounts";
@@ -56,7 +49,7 @@ export default function Settings({ navigation }: Props) {
       <SettingsCard
         title={t("settings.display.title")}
         desc={t("settings.display.desc")}
-        Icon={MobileMedium}
+        Icon={Icons.MobileMedium}
         onClick={() => navigation.navigate(ScreenName.GeneralSettings)}
         arrowRight
       />
@@ -64,7 +57,7 @@ export default function Settings({ navigation }: Props) {
         <SettingsCard
           title={t("settings.accounts.title")}
           desc={t("settings.accounts.desc")}
-          Icon={WalletMedium}
+          Icon={Icons.WalletMedium}
           onClick={() => navigation.navigate(ScreenName.AccountsSettings)}
           arrowRight
         />
@@ -72,29 +65,35 @@ export default function Settings({ navigation }: Props) {
       <SettingsCard
         title={t("settings.about.title")}
         desc={t("settings.about.desc")}
-        Icon={BracketsMedium}
+        Icon={Icons.BracketsMedium}
         onClick={() => navigation.navigate(ScreenName.AboutSettings)}
         arrowRight
       />
       <SettingsCard
         title={t("settings.help.title")}
         desc={t("settings.help.desc")}
-        Icon={LifeRingMedium}
+        Icon={Icons.LifeRingMedium}
         onClick={() => navigation.navigate(ScreenName.HelpSettings)}
         arrowRight
       />
       <SettingsCard
         title={t("settings.experimental.title")}
         desc={t("settings.experimental.desc")}
-        Icon={ChartNetworkMedium}
+        Icon={Icons.ChartNetworkMedium}
         onClick={() => navigation.navigate(ScreenName.ExperimentalSettings)}
         arrowRight
+      />
+      <SettingsCard
+        title={t("settings.developer.title")}
+        desc={t("settings.developer.desc")}
+        Icon={Icons.ToolMedium}
+        onClick={() => navigation.navigate(ScreenName.DeveloperSettings)}
       />
       {debugVisible || __DEV__ ? (
         <SettingsCard
           title="Debug"
           desc="Use at your own risk – Developer tools"
-          Icon={ToolsMedium}
+          Icon={Icons.ToolsMedium}
           onClick={() => navigation.navigate(ScreenName.DebugSettings)}
           arrowRight
         />


### PR DESCRIPTION
Fix staging URL used for the Learn page (for a purpose of testing by the e-commerce team)
Also add the Developer settings section because it was missing in the rebranded settings menu.

### Type

URL changing

### Context

### Parts of the app affected / Test plan

Settings main menu
Discover -> Learn
