### PR TITLE
LIVE-1774 LIVE-1927 - Add Spanish (ES) and Chinese (ZH) to fully supported languages

### DIFF
--- a/src/languages.js
+++ b/src/languages.js
@@ -43,7 +43,7 @@ export const supportedLocales = Config.LEDGER_DEBUG_ALL_LANGS
  * or in the case of existing users, they will be prompted once to change their
  * Ledger Live language.
  */
-export const fullySupportedLocales = ["en", "fr", "ru"];
+export const fullySupportedLocales = ["en", "fr", "ru", "es", "zh"];
 
 export const locales = supportedLocales.reduce((obj, key) => {
   obj[key] = allLocales[key]; // eslint-disable-line no-param-reassign


### PR DESCRIPTION
For users that have their system set in either Chinese or Spanish:
- new users will have Ledger Live set in that language by default from the start. (cf. following video, with Spanish)

  https://user-images.githubusercontent.com/91890529/163970073-a77fadd7-42e4-42e7-845b-aad1fd27969a.mp4

- existing users which had Legder Live in English will see a modal prompting them to switch to that language. (cf. following video, with Spanish)

  https://user-images.githubusercontent.com/91890529/163970089-c1185846-c422-4cd9-b3bb-22cf5a4fe785.mp4


### Type

Localization

### Context

[LIVE-1774]
[LIVE-1927]

### Parts of the app affected / Test plan

- Discoverability for new users (fully supported languages):
    1. Uninstall LL
    2. Switch OS language to Spanish or Chinese (fully supported languages)
    3. Install LL, launch it
    4. LL should be in the system's language
- Discoverability for new users (not fully supported languages):
    1. Uninstall LL
    2. Switch OS language to a language not fully supported (German for instance)
    3. Install LL, launch it
    4. LL should still be in the English

- Discoverability for existing users
   1. Uninstall LL
   2. Switch OS language to English
   3. Install LL, launch it, go through onboarding
   4. Quit LL, switch OS language to Spanish or Chinese (resp. a not fully supported language like German)
   5. Launch LL
   6. LL should prompt a dialogue asking the user to switch the language to the OS language (resp. if OS language is not a fully supported language, nothing should happen)


[LIVE-1774]: https://ledgerhq.atlassian.net/browse/LIVE-1774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-1927]: https://ledgerhq.atlassian.net/browse/LIVE-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ