### PR TITLE
[LIVE-2036] - Fix - Settings - Full width touchable setting row

### DIFF
--- a/src/components/SettingsCard.tsx
+++ b/src/components/SettingsCard.tsx
@@ -37,7 +37,7 @@ function Card({
 
 const StyledCard = styled(Card)`
   background-color: ${p => p.theme.colors.palette.background.main};
-  padding: ${p => p.theme.space[7]}px 0;
+  padding: ${p => p.theme.space[7]}px ${p => p.theme.space[6]}px;
   flex-direction: row;
   align-items: center;
 `;

--- a/src/components/SettingsRow.tsx
+++ b/src/components/SettingsRow.tsx
@@ -10,7 +10,7 @@ import Touchable from "./Touchable";
 
 const StyledTouchableRow = styled(Touchable)<{ compact?: boolean }>`
   background-color: ${p => p.theme.colors.palette.background.main};
-  padding: ${p => p.theme.space[p.compact ? 6 : 7]}px 0;
+  padding: ${p => p.theme.space[p.compact ? 6 : 7]}px ${p => p.theme.space[6]}px;
   flex-direction: row;
   align-items: center;
   border-bottom-color: ${p => p.theme.colors.palette.neutral.c40};

--- a/src/screens/Settings/SettingsNavigationScrollView.tsx
+++ b/src/screens/Settings/SettingsNavigationScrollView.tsx
@@ -8,8 +8,6 @@ const styles = StyleSheet.create({
 
 export const SettingsNavigationScrollView = styled(NavigationScrollView).attrs({
   contentContainerStyle: styles.root,
-})`
-  padding: 0 ${p => p.theme.space[6]}px;
-`;
+})``;
 
 export default SettingsNavigationScrollView;


### PR DESCRIPTION
The setting row is now clickable in full screen width

https://user-images.githubusercontent.com/89014981/164754657-09d8b247-61d4-4d8c-976e-28a6bd758b0d.mp4

### Type

Bug fix / UI

### Context

https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/463?modal=detail&selectedIssue=LIVE-2036&sprint=994

### Parts of the app affected / Test plan

Settings