### PR TITLE
LIVE-1132 - Layer 2 (Polygon / BSC) - send step 2 (Amount) - Customis…

### DIFF
--- a/src/families/ethereum/EditFeeUnitEthereum.js
+++ b/src/families/ethereum/EditFeeUnitEthereum.js
@@ -83,7 +83,7 @@ export default function EditFeeUnitEthereum({
           >
             <LText style={[styles.currencyUnitText, { color: colors.live }]}>
               <CurrencyUnitValue
-                unit={feeCustomUnit || mainAccount.unit}
+                unit={mainAccount.unit || feeCustomUnit}
                 value={gasPrice}
               />
             </LText>


### PR DESCRIPTION
…e fees: Wrong unit for gasPrice

Display the right unit fee on mobile, the wrong one was Gwei and the right one is MATIC for Polygon 

### Type

Bug Fix

### Context

Live issue 1132 :  Layer 2 (Polygon / BSC) - send step 2 (Amount) - Customise fees: Wrong unit for gasPrice

### Parts of the app affected / Test plan

ledger-live-mobile/src/families/ethereum/EditFeeUnitEthereum.js
![live-1132](https://user-images.githubusercontent.com/103273462/165099973-16cb9fbc-648c-470c-8358-521634d27ecd.jpeg)

