### PR TITLE
LIVE-2003 - Feature - Pass urls through regex to replace template by locale

### DIFF
--- a/src/config/urls.tsx
+++ b/src/config/urls.tsx
@@ -1,3 +1,4 @@
+// Place {locale} inside url to replace it by current locale. Ex: ledger.com/{locale}/ become ledger.com/fr/
 export const urls = {
   faq:
     "https://support.ledgerwallet.com/hc/en-us?utm_source=ledger_live_mobile&utm_medium=self_referral&utm_content=faq",
@@ -164,3 +165,41 @@ export const urls = {
       "https://www.ledger.com/supported-services?utm_source=ledger_live&utm_medium=self_referral&utm_content=discover",
   },
 };
+
+const regex = /{locale}/g;
+
+class UrlsConfig {
+  public locale = "en";
+
+  changeLocale(locale: string) {
+    this.locale = locale;
+  }
+}
+
+export const urlsConfig = new UrlsConfig();
+
+// Iterate through url strings and substitute them by getter function with regex replacing template {locale} by current locale
+const iterateUrls = (obj: typeof urls) => {
+  Object.keys(obj).forEach(key => {
+    // @ts-ignore
+    if (typeof obj[key] === "object" && obj[key] !== null) {
+      // @ts-ignore
+      iterateUrls(obj[key]);
+    }
+
+    // @ts-ignore
+    if (typeof obj[key] === "string") {
+      // @ts-ignore
+      // eslint-disable-next-line no-param-reassign
+      obj["_" + key] = obj[key];
+      Object.defineProperty(obj, key, {
+        get() {
+          // @ts-ignore
+          return obj["_" + key].replace(regex, urlsConfig.locale);
+        },
+      });
+    }
+  });
+};
+
+iterateUrls(urls);

--- a/src/context/Locale.js
+++ b/src/context/Locale.js
@@ -18,6 +18,7 @@ import {
   locales,
 } from "../languages";
 import { languageSelector } from "../reducers/settings";
+import { urlsConfig } from "../config/urls";
 
 if ("__setDefaultTimeZone" in Intl.DateTimeFormat) {
   /** https://formatjs.io/docs/polyfills/intl-datetimeformat/#default-timezone */
@@ -65,6 +66,7 @@ export default function LocaleProvider({ children }: Props) {
   const language = useSelector(languageSelector);
   useEffect(() => {
     i18next.changeLanguage(language);
+    urlsConfig.changeLocale(language);
   }, [language]);
 
   const value: LocaleState = useMemo(


### PR DESCRIPTION
Substitute url strings by getter function with regex replacing template {locale} by current locale

Ex: ledger.com/{locale}/ become ledger.com/fr/

### Type

Feature

### Context

https://ledgerhq.atlassian.net/jira/software/c/projects/LIVE/boards/463?modal=detail&selectedIssue=LIVE-2003&sprint=994&assignee=6102d4f20b454a0068cad0d6

### Parts of the app affected / Test plan

Config urls