### PR TITLE
Feat/live 1625 hide nft collection v3 rebased

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@ledgerhq/errors": "6.10.0",
     "@ledgerhq/hw-transport": "6.27.1",
     "@ledgerhq/hw-transport-http": "6.27.1",
-    "@ledgerhq/live-common": "22.0.3",
+    "@ledgerhq/live-common": "https://github.com/LedgerHQ/ledger-live-common.git#0ce72dd7976ddb47844e3b2e162dd514a46196dc",
     "@ledgerhq/logs": "6.10.0",
     "@ledgerhq/native-ui": "^0.7.16",
     "@ledgerhq/react-native-hid": "^6.28.2",

--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -128,6 +128,16 @@ export const showToken = (tokenId: string) => ({
   payload: tokenId,
 });
 
+export const hideNftCollection = (collectionId: string) => ({
+  type: "HIDE_NFT_COLLECTION",
+  payload: collectionId,
+});
+
+export const unhideNftCollection = (collectionId: string) => ({
+  type: "UNHIDE_NFT_COLLECTION",
+  payload: collectionId,
+});
+
 export const dismissBanner = (bannerId: string) => ({
   type: "SETTINGS_DISMISS_BANNER",
   payload: bannerId,

--- a/src/components/Nft/NftCollectionOptionsMenu.tsx
+++ b/src/components/Nft/NftCollectionOptionsMenu.tsx
@@ -1,0 +1,58 @@
+import React, { useCallback } from "react";
+
+import { useDispatch } from "react-redux";
+import {
+  BottomDrawer,
+  Text,
+  Icons,
+  BoxedIcon,
+  Button,
+  Flex,
+} from "@ledgerhq/native-ui";
+import { Account, ProtoNFT } from "@ledgerhq/live-common/lib/types";
+import { useTranslation } from "react-i18next";
+import { hideNftCollection } from "../../actions/settings";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  collection: ProtoNFT[];
+  account: Account;
+};
+
+const NftCollectionOptionsMenu = ({
+  isOpen,
+  onClose,
+  collection,
+  account,
+}: Props) => {
+  const { t } = useTranslation();
+  const dispatch = useDispatch();
+
+  const onConfirm = useCallback(() => {
+    dispatch(hideNftCollection(`${account.id}|${collection?.[0]?.contract}`));
+    onClose();
+  }, [dispatch, account.id, collection, onClose]);
+
+  return (
+    <BottomDrawer isOpen={isOpen} onClose={onClose}>
+      <Flex alignItems="center">
+        <BoxedIcon Icon={Icons.EyeNoneMedium} size={48} />
+        <Text variant="h1" mt={20}>
+          {t("settings.accounts.hideNFTCollectionModal.title")}
+        </Text>
+        <Text variant="body" textAlign="center" mt={20}>
+          {t("settings.accounts.hideNFTCollectionModal.desc")}
+        </Text>
+        <Button type="main" alignSelf="stretch" mt={20} onPress={onConfirm}>
+          {t("common.confirm")}
+        </Button>
+        <Button type="default" alignSelf="stretch" mt={20} onPress={onClose}>
+          {t("common.cancel")}
+        </Button>
+      </Flex>
+    </BottomDrawer>
+  );
+};
+
+export default React.memo(NftCollectionOptionsMenu);

--- a/src/components/Nft/NftCollectionRow.tsx
+++ b/src/components/Nft/NftCollectionRow.tsx
@@ -1,6 +1,5 @@
 import React, { memo } from "react";
 import { StyleSheet } from "react-native";
-import { TouchableOpacity } from "react-native-gesture-handler";
 import {
   useNftCollectionMetadata,
   useNftMetadata,
@@ -9,6 +8,7 @@ import { ProtoNFT } from "@ledgerhq/live-common/lib/types";
 import { Flex, Text } from "@ledgerhq/native-ui";
 import Skeleton from "../Skeleton";
 import NftImage from "./NftImage";
+import Touchable from "../Touchable";
 
 type Props = {
   collection: ProtoNFT[];
@@ -35,7 +35,11 @@ function NftCollectionRow({
   const loading = nftStatus === "loading" || collectionStatus === "loading";
 
   return (
-    <TouchableOpacity onLongPress={onLongPress} onPress={onCollectionPress}>
+    <Touchable
+      event="ShowNftCollectionMenu"
+      onPress={onCollectionPress}
+      onLongPress={onLongPress}
+    >
       <Flex accessible flexDirection={"row"} alignItems={"center"} py={6}>
         <NftImage
           style={styles.collectionImage}
@@ -63,7 +67,7 @@ function NftCollectionRow({
           {collection?.length}
         </Text>
       </Flex>
-    </TouchableOpacity>
+    </Touchable>
   );
 }
 

--- a/src/components/Nft/NftCollectionRow.tsx
+++ b/src/components/Nft/NftCollectionRow.tsx
@@ -1,23 +1,26 @@
 import React, { memo } from "react";
 import { StyleSheet } from "react-native";
-import { RectButton } from "react-native-gesture-handler";
+import { TouchableOpacity } from "react-native-gesture-handler";
 import {
   useNftCollectionMetadata,
   useNftMetadata,
 } from "@ledgerhq/live-common/lib/nft";
 import { ProtoNFT } from "@ledgerhq/live-common/lib/types";
 import { Flex, Text } from "@ledgerhq/native-ui";
-import { useTheme } from "styled-components/native";
 import Skeleton from "../Skeleton";
 import NftImage from "./NftImage";
 
 type Props = {
   collection: ProtoNFT[];
   onCollectionPress: () => void;
+  onLongPress: () => void;
 };
 
-function NftCollectionRow({ collection, onCollectionPress }: Props) {
-  const { colors } = useTheme();
+function NftCollectionRow({
+  collection,
+  onCollectionPress,
+  onLongPress,
+}: Props) {
   const nft = collection[0];
   const { status: nftStatus, metadata: nftMetadata } = useNftMetadata(
     nft?.contract,
@@ -32,11 +35,7 @@ function NftCollectionRow({ collection, onCollectionPress }: Props) {
   const loading = nftStatus === "loading" || collectionStatus === "loading";
 
   return (
-    <RectButton
-      style={styles.container}
-      underlayColor={colors.neutral.c50}
-      onPress={onCollectionPress}
-    >
+    <TouchableOpacity onLongPress={onLongPress} onPress={onCollectionPress}>
       <Flex accessible flexDirection={"row"} alignItems={"center"} py={6}>
         <NftImage
           style={styles.collectionImage}
@@ -64,16 +63,13 @@ function NftCollectionRow({ collection, onCollectionPress }: Props) {
           {collection?.length}
         </Text>
       </Flex>
-    </RectButton>
+    </TouchableOpacity>
   );
 }
 
 export default memo(NftCollectionRow);
 
 const styles = StyleSheet.create({
-  container: {
-    borderRadius: 4,
-  },
   collectionNameSkeleton: {
     height: 8,
     width: 113,

--- a/src/components/RootNavigator/SettingsNavigator.tsx
+++ b/src/components/RootNavigator/SettingsNavigator.tsx
@@ -43,6 +43,7 @@ import Button from "../Button";
 import HelpButton from "../../screens/Settings/HelpButton";
 import OnboardingStepLanguage from "../../screens/Onboarding/steps/language";
 import { GenerateMockAccountSelectScreen } from "../../screens/Settings/Debug/GenerateMockAccountsSelect";
+import HiddenNftCollections from "../../screens/Settings/Accounts/HiddenNftCollections";
 
 export default function SettingsNavigator() {
   const { t } = useTranslation();
@@ -111,6 +112,11 @@ export default function SettingsNavigator() {
         name={ScreenName.CryptoAssetsSettings}
         component={CurrenciesList}
         options={{ title: t("settings.accounts.cryptoAssets.header") }}
+      />
+      <Stack.Screen
+        name={ScreenName.HiddenNftCollections}
+        component={HiddenNftCollections}
+        options={{ title: t("settings.accounts.hiddenNFTCollections") }}
       />
       <Stack.Screen
         name={ScreenName.CurrencySettings}

--- a/src/components/Touchable.js
+++ b/src/components/Touchable.js
@@ -63,23 +63,16 @@ export default class Touchable extends Component<
   };
 
   onLongPress = async () => {
-    const { onLongPress, event, eventProperties } = this.props;
-    if (!onLongPress) return;
-    try {
+      const { onLongPress, event, eventProperties } = this.props;
+      if (!onLongPress) return;
       if (event) {
         track(event, eventProperties);
       }
+      
       const res = onLongPress();
-      if (res && res.then) {
-        // it's a promise, we will use pending/spinnerOn state
-        this.setState({ pending: true });
-        await res;
-      }
-    } finally {
-      if (!this.unmounted) {
-        this.setState(({ pending }) => (pending ? { pending: false } : null));
-      }
-    }
+      this.setState({ pending: true });
+      await res;
+      this.setState({ pending: false });
   };
 
   render() {

--- a/src/components/Touchable.js
+++ b/src/components/Touchable.js
@@ -18,6 +18,7 @@ type Props = {
   // will wait the promise to complete before enabling the button again
   // it also displays a spinner if it takes more than WAIT_TIME_BEFORE_SPINNER
   onPress: ?() => ?Promise<any> | void,
+  onLongPress: ?() => ?Promise<any> | void,
   children: *,
   event?: string,
   eventProperties?: { [key: string]: any },
@@ -49,6 +50,26 @@ export default class Touchable extends Component<
         track(event, eventProperties);
       }
       const res = onPress();
+      if (res && res.then) {
+        // it's a promise, we will use pending/spinnerOn state
+        this.setState({ pending: true });
+        await res;
+      }
+    } finally {
+      if (!this.unmounted) {
+        this.setState(({ pending }) => (pending ? { pending: false } : null));
+      }
+    }
+  };
+
+  onLongPress = async () => {
+    const { onLongPress, event, eventProperties } = this.props;
+    if (!onLongPress) return;
+    try {
+      if (event) {
+        track(event, eventProperties);
+      }
+      const res = onLongPress();
       if (res && res.then) {
         // it's a promise, we will use pending/spinnerOn state
         this.setState({ pending: true });

--- a/src/components/Touchable.js
+++ b/src/components/Touchable.js
@@ -18,7 +18,7 @@ type Props = {
   // will wait the promise to complete before enabling the button again
   // it also displays a spinner if it takes more than WAIT_TIME_BEFORE_SPINNER
   onPress: ?() => ?Promise<any> | void,
-  onLongPress: ?() => ?Promise<any> | void,
+  onLongPress?: ?() => ?Promise<any> | void,
   children: *,
   event?: string,
   eventProperties?: { [key: string]: any },

--- a/src/const/navigation.js
+++ b/src/const/navigation.js
@@ -26,6 +26,7 @@ export const ScreenName = {
   ConfirmPassword: "ConfirmPassword",
   CountervalueSettings: "CountervalueSettings",
   CryptoAssetsSettings: "CryptoAssetsSettings",
+  HiddenNftCollections: "HiddenNftCollections",
   CurrenciesList: "CurrenciesList",
   CurrencySettings: "CurrencySettings",
   DebugBLE: "DebugBLE",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1909,7 +1909,7 @@
       "hiddenNFTCollectionsDesc": "You can hide tokens by going to the account then long-pressing on a collection and selecting \"Hide Collection\".",
       "hideNFTCollectionModal": {
         "title": "Hide Collection?",
-        "desc": "You can unhide this collection from the \"Account Section\" in the app settings"
+        "desc": "You can unhide this collection in the setting options."
       },
       "cryptoAssets": {
         "header": "Crypto assets",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1904,6 +1904,13 @@
         "desc": "This action will hide all <1><0>{tokenName}</0></1> accounts, you can show them again using <3>Settings > Accounts</3>.",
         "confirm": "Hide token"
       },
+      "hideNFTCollectionCTA": "Hide collection",
+      "hiddenNFTCollections": "Hidden NFT collections",
+      "hiddenNFTCollectionsDesc": "You can hide tokens by going to the account then long-pressing on a collection and selecting \"Hide Collection\".",
+      "hideNFTCollectionModal": {
+        "title": "Hide Collection?",
+        "desc": "You can unhide this collection from the \"Account Section\" in the app settings"
+      },
       "cryptoAssets": {
         "header": "Crypto assets",
         "title": "Crypto assets",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1753,7 +1753,8 @@
       "sectionLabel": "Undelegation(s)"
     },
     "nft": {
-      "receiveNft": "Receive NFT"
+      "receiveNft": "Receive NFT",
+      "howTo": "To add NFTs, you need to <0>receive them</0> using your <1>{{currency}} address</1>."
     }
   },
   "accounts": {

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -80,6 +80,7 @@ export type SettingsState = {
   graphCountervalueFirst: boolean,
   hideEmptyTokenAccounts: boolean,
   blacklistedTokenIds: string[],
+  hiddenNftCollections: string[],
   dismissedBanners: string[],
   hasAvailableUpdate: boolean,
   theme: Theme,
@@ -118,6 +119,7 @@ export const INITIAL_STATE: SettingsState = {
   graphCountervalueFirst: true,
   hideEmptyTokenAccounts: false,
   blacklistedTokenIds: [],
+  hiddenNftCollections: [],
   dismissedBanners: [],
   hasAvailableUpdate: false,
   theme: "system",
@@ -284,6 +286,20 @@ const handlers: Object = {
     return {
       ...state,
       blacklistedTokenIds: [...ids, tokenId],
+    };
+  },
+  HIDE_NFT_COLLECTION: (state: SettingsState, { payload: collectionId }) => {
+    const ids = state.hiddenNftCollections;
+    return {
+      ...state,
+      hiddenNftCollections: [...ids, collectionId],
+    };
+  },
+  UNHIDE_NFT_COLLECTION: (state: SettingsState, { payload: collectionId }) => {
+    const ids = state.hiddenNftCollections;
+    return {
+      ...state,
+      hiddenNftCollections: ids.filter(id => id !== collectionId),
     };
   },
   SETTINGS_DISMISS_BANNER: (state, { payload }) => ({
@@ -485,6 +501,9 @@ export const readOnlyModeEnabledSelector = (state: State) =>
 
 export const blacklistedTokenIdsSelector = (state: State) =>
   state.settings.blacklistedTokenIds;
+
+export const hiddenNftCollectionsSelector = (state: State) =>
+  state.settings.hiddenNftCollections;
 
 // $FlowFixMe
 export const exportSettingsSelector = createSelector(

--- a/src/screens/Account/ListHeaderComponent.tsx
+++ b/src/screens/Account/ListHeaderComponent.tsx
@@ -13,6 +13,8 @@ import { ValueChange } from "@ledgerhq/live-common/lib/portfolio/v2/types";
 import { CompoundAccountSummary } from "@ledgerhq/live-common/lib/compound/types";
 
 import { Box } from "@ledgerhq/native-ui";
+import { isNFTActive } from "@ledgerhq/live-common/lib/nft";
+
 import Header from "./Header";
 import AccountGraphCard from "../../components/AccountGraphCard";
 import SubAccountsList from "./SubAccountsList";
@@ -168,7 +170,7 @@ export function getListHeaderComponents({
             </Box>,
           ]
         : []),
-      ...(!empty && account.type === "Account" && account.nfts?.length
+      ...(!empty && account.type === "Account" && isNFTActive(account.currency)
         ? [<NftCollectionsList account={account} />]
         : []),
       ...(compoundSummary &&

--- a/src/screens/Account/NftCollectionsList.tsx
+++ b/src/screens/Account/NftCollectionsList.tsx
@@ -1,23 +1,25 @@
 import React, { useCallback, useMemo, useState } from "react";
 
 import { useSelector } from "react-redux";
-import { Trans, useTranslation } from "react-i18next";
-import useEnv from "@ledgerhq/live-common/lib/hooks/useEnv";
-import { nftsByCollections } from "@ledgerhq/live-common/lib/nft";
-import { useNavigation } from "@react-navigation/native";
-import { StyleSheet, View, FlatList } from "react-native";
-import { Account, ProtoNFT } from "@ledgerhq/live-common/lib/types";
 import { Box, Text } from "@ledgerhq/native-ui";
+import { Trans, useTranslation } from "react-i18next";
+import { StyleSheet, View, FlatList } from "react-native";
+import useEnv from "@ledgerhq/live-common/lib/hooks/useEnv";
+import Icon from "react-native-vector-icons/dist/FontAwesome";
+import { nftsByCollections } from "@ledgerhq/live-common/lib/nft";
+import { useNavigation, useTheme } from "@react-navigation/native";
+import { Account, ProtoNFT } from "@ledgerhq/live-common/lib/types";
 import {
   ArrowBottomMedium,
   DroprightMedium,
 } from "@ledgerhq/native-ui/assets/icons";
+import NftCollectionOptionsMenu from "../../components/Nft/NftCollectionOptionsMenu";
+import { hiddenNftCollectionsSelector } from "../../reducers/settings";
 import NftCollectionRow from "../../components/Nft/NftCollectionRow";
 import { NavigatorName, ScreenName } from "../../const";
 import Button from "../../components/wrappedUi/Button";
+import Touchable from "../../components/Touchable";
 import Link from "../../components/wrappedUi/Link";
-import NftCollectionOptionsMenu from "../../components/Nft/NftCollectionOptionsMenu";
-import { hiddenNftCollectionsSelector } from "../../reducers/settings";
 
 const MAX_COLLECTIONS_TO_SHOW = 3;
 
@@ -28,6 +30,7 @@ type Props = {
 export default function NftCollectionsList({ account }: Props) {
   useEnv("HIDE_EMPTY_TOKEN_ACCOUNTS");
 
+  const { colors } = useTheme();
   const { t } = useTranslation();
   const navigation = useNavigation();
   const { nfts } = account;
@@ -88,38 +91,88 @@ export default function NftCollectionsList({ account }: Props) {
     });
   }, [account.id, navigation, t]);
 
+  const navigateToReceiveConnectDevice = useCallback(() => {
+    navigation.navigate(NavigatorName.ReceiveFunds, {
+      screen: ScreenName.ReceiveConnectDevice,
+      params: {
+        accountId: account.id,
+      },
+    });
+  }, [account.id, navigation]);
+
   const renderHeader = useCallback(
     () => (
       <View style={styles.header}>
         <Text variant={"h3"}>NFT</Text>
-        <Link
-          type="color"
-          event="AccountReceiveToken"
-          Icon={ArrowBottomMedium}
-          iconPosition={"left"}
-          onPress={navigateToReceive}
-        >
-          <Trans i18nKey="account.nft.receiveNft" />
-        </Link>
+        {data.length ? (
+          <Link
+            type="color"
+            event="AccountReceiveToken"
+            Icon={ArrowBottomMedium}
+            iconPosition={"left"}
+            onPress={navigateToReceive}
+          >
+            <Trans i18nKey="account.nft.receiveNft" />
+          </Link>
+        ) : null}
       </View>
     ),
-    [navigateToReceive],
+    [data.length, navigateToReceive],
   );
 
   const renderFooter = useCallback(
-    () => (
-      <Button
-        type={"shade"}
-        size={"small"}
-        outline
-        onPress={navigateToGallery}
-        Icon={DroprightMedium}
-        mt={3}
-      >
-        <Trans i18nKey="nft.account.seeAllNfts" />
-      </Button>
-    ),
-    [navigateToGallery],
+    () =>
+      data.length ? (
+        <Button
+          type={"shade"}
+          size={"small"}
+          outline
+          onPress={navigateToGallery}
+          Icon={DroprightMedium}
+          mt={3}
+        >
+          <Trans i18nKey="nft.account.seeAllNfts" />
+        </Button>
+      ) : (
+        <Touchable
+          event="AccountReceiveSubAccount"
+          onPress={navigateToReceiveConnectDevice}
+        >
+          <View
+            style={[
+              styles.footer,
+              {
+                borderColor: colors.fog,
+              },
+            ]}
+          >
+            <Icon color={colors.live} size={26} name="plus" />
+            <View style={styles.footerText}>
+              <Text variant={"large"}>
+                <Trans
+                  i18nKey={`account.nft.howTo`}
+                  values={{ currency: account.currency.family }}
+                >
+                  <Text variant={"large"} fontWeight={"semiBold"}>
+                    text
+                  </Text>
+                  <Text variant={"large"} fontWeight={"semiBold"}>
+                    text
+                  </Text>
+                </Trans>
+              </Text>
+            </View>
+          </View>
+        </Touchable>
+      ),
+    [
+      account.currency.family,
+      colors.fog,
+      colors.live,
+      data.length,
+      navigateToGallery,
+      navigateToReceiveConnectDevice,
+    ],
   );
 
   const renderItem = useCallback(
@@ -166,6 +219,29 @@ const styles = StyleSheet.create({
     alignItems: "center",
   },
   collectionList: {
+    paddingLeft: 16,
+    paddingRight: 16,
+    paddingBottom: 24,
+  },
+  footer: {
+    borderRadius: 4,
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderStyle: "dashed",
+    borderWidth: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    overflow: "hidden",
+  },
+  footerText: {
+    flex: 1,
+    flexShrink: 1,
+    flexWrap: "wrap",
+    paddingLeft: 12,
+    flexDirection: "row",
+  },
+  subAccountList: {
+    paddingTop: 32,
     paddingLeft: 16,
     paddingRight: 16,
     paddingBottom: 24,

--- a/src/screens/Nft/NftGallery/NftCollectionWithName.tsx
+++ b/src/screens/Nft/NftGallery/NftCollectionWithName.tsx
@@ -1,11 +1,18 @@
-import React, { memo } from "react";
+import React, { useCallback, useState, memo } from "react";
 import { useNftCollectionMetadata } from "@ledgerhq/live-common/lib/nft";
 import { FlatList, View, SafeAreaView, StyleSheet } from "react-native";
-import { ProtoNFT, NFTMetadata } from "@ledgerhq/live-common/lib/types";
+import {
+  ProtoNFT,
+  NFTMetadata,
+  Account,
+} from "@ledgerhq/live-common/lib/types";
+import { OthersMedium } from "@ledgerhq/native-ui/assets/icons";
 import { NFTResource } from "@ledgerhq/live-common/lib/nft/NftMetadataProvider/types";
 import NftCard from "../../../components/Nft/NftCard";
+import Touchable from "../../../components/Touchable";
 import Skeleton from "../../../components/Skeleton";
 import LText from "../../../components/LText";
+import NftCollectionOptionsMenu from "../../../components/Nft/NftCollectionOptionsMenu";
 
 const renderItem = ({ item, index }: { item: ProtoNFT; index: number }) => (
   <NftCard
@@ -17,16 +24,28 @@ const renderItem = ({ item, index }: { item: ProtoNFT; index: number }) => (
 
 const NftCollectionWithNameList = ({
   collection,
+  account,
   contentContainerStyle,
   status,
   metadata,
 }: {
+  account: Account;
   collection: ProtoNFT[];
   contentContainerStyle?: Object;
   status: NFTResource["status"];
   metadata?: NFTMetadata;
 }) => {
   const nft = collection?.[0] || {};
+  const [isCollectionMenuOpen, setIsCollectionMenuOpen] = useState(false);
+
+  const onOpenCollectionMenu = useCallback(
+    () => setIsCollectionMenuOpen(true),
+    [],
+  );
+  const onCloseCollectionMenu = useCallback(
+    () => setIsCollectionMenuOpen(false),
+    [],
+  );
 
   return (
     <SafeAreaView style={contentContainerStyle}>
@@ -44,6 +63,9 @@ const NftCollectionWithNameList = ({
             {metadata?.tokenName || nft?.contract}
           </LText>
         </Skeleton>
+        <Touchable event="ShowNftCollectionMenu" onPress={onOpenCollectionMenu}>
+          <OthersMedium size={24} color="neutral.c100" />
+        </Touchable>
       </View>
       <FlatList
         data={collection}
@@ -51,6 +73,13 @@ const NftCollectionWithNameList = ({
         scrollEnabled={false}
         numColumns={2}
         renderItem={renderItem}
+      />
+
+      <NftCollectionOptionsMenu
+        isOpen={isCollectionMenuOpen}
+        collection={collection}
+        onClose={onCloseCollectionMenu}
+        account={account}
       />
     </SafeAreaView>
   );
@@ -62,11 +91,13 @@ const NftCollectionWithNameMemo = memo(NftCollectionWithNameList);
 type Props = {
   collection: ProtoNFT[];
   contentContainerStyle?: Object;
+  account: Account;
 };
 
 const NftCollectionWithName = ({
   collection,
   contentContainerStyle,
+  account,
 }: Props) => {
   const nft: ProtoNFT | null = collection[0];
   const { status, metadata } = useNftCollectionMetadata(
@@ -78,6 +109,7 @@ const NftCollectionWithName = ({
     <NftCollectionWithNameMemo
       collection={collection}
       contentContainerStyle={contentContainerStyle}
+      account={account}
       status={status}
       metadata={metadata}
     />
@@ -89,6 +121,9 @@ const nftKeyExtractor = (nft: ProtoNFT) => nft?.id;
 const styles = StyleSheet.create({
   title: {
     paddingBottom: 16,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
   tokenNameSkeleton: {
     height: 12,

--- a/src/screens/Nft/NftGallery/index.tsx
+++ b/src/screens/Nft/NftGallery/index.tsx
@@ -7,7 +7,7 @@ import {
   SafeAreaView,
   StyleSheet,
   Platform,
-  ListRenderItemInfo,
+  ListRenderItem,
 } from "react-native";
 import { useSelector } from "react-redux";
 import { useTranslation } from "react-i18next";
@@ -28,15 +28,6 @@ const MAX_COLLECTIONS_FIRST_RENDER = 12;
 const COLLECTIONS_TO_ADD_ON_LIST_END_REACHED = 6;
 
 const CollectionsList = Animated.createAnimatedComponent(FlatList);
-
-const renderItem = ({ item: collection }: ListRenderItemInfo<ProtoNFT[]>) => (
-  <View style={styles.collectionContainer}>
-    <NftCollectionWithName
-      key={collection?.[0]?.contract}
-      collection={collection}
-    />
-  </View>
-);
 
 const NftGallery = () => {
   const navigation = useNavigation();
@@ -79,6 +70,16 @@ const NftGallery = () => {
         .slice(0, collectionsCount)
         .map(([, collection]) => collection),
     [collections, collectionsCount],
+  );
+
+  const renderItem: ListRenderItem<ProtoNFT[]> = ({ item: collection }) => (
+    <View style={styles.collectionContainer}>
+      <NftCollectionWithName
+        key={collection?.[0]?.contract}
+        collection={collection}
+        account={account}
+      />
+    </View>
   );
 
   const onEndReached = useCallback(() => {

--- a/src/screens/Nft/NftGallery/index.tsx
+++ b/src/screens/Nft/NftGallery/index.tsx
@@ -22,6 +22,7 @@ import NftCollectionWithName from "./NftCollectionWithName";
 import { NavigatorName, ScreenName } from "../../../const";
 import Button from "../../../components/Button";
 import SendIcon from "../../../icons/Send";
+import { hiddenNftCollectionsSelector } from "../../../reducers/settings";
 
 const MAX_COLLECTIONS_FIRST_RENDER = 12;
 const COLLECTIONS_TO_ADD_ON_LIST_END_REACHED = 6;
@@ -46,6 +47,8 @@ const NftGallery = () => {
     accountSelector(state, { accountId: params.accountId }),
   );
 
+  const hiddenNftCollections = useSelector(hiddenNftCollectionsSelector);
+
   const scrollY = useRef(new Value(0)).current;
   const onScroll = event(
     [
@@ -61,11 +64,20 @@ const NftGallery = () => {
   const [collectionsCount, setCollectionsCount] = useState(
     MAX_COLLECTIONS_FIRST_RENDER,
   );
-  const collections = useMemo(() => nftsByCollections(account.nfts), [
-    account.nfts,
-  ]);
+  const collections = useMemo(
+    () =>
+      Object.entries(nftsByCollections(account.nfts)).filter(
+        ([contract]) =>
+          !hiddenNftCollections.includes(`${account.id}|${contract}`),
+      ),
+    [account.id, account.nfts, hiddenNftCollections],
+  ) as [string, ProtoNFT[]][];
+
   const collectionsSlice: Array<ProtoNFT[]> = useMemo(
-    () => Object.values(collections).slice(0, collectionsCount),
+    () =>
+      collections
+        .slice(0, collectionsCount)
+        .map(([, collection]) => collection),
     [collections, collectionsCount],
   );
 

--- a/src/screens/SendFunds/01b-SelectCollection.tsx
+++ b/src/screens/SendFunds/01b-SelectCollection.tsx
@@ -189,4 +189,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default memo(SendFundsSelectCollection);
+export default memo<Props>(SendFundsSelectCollection);

--- a/src/screens/SendFunds/01b-SelectCollection.tsx
+++ b/src/screens/SendFunds/01b-SelectCollection.tsx
@@ -14,8 +14,10 @@ import {
   useNftCollectionMetadata,
   useNftMetadata,
 } from "@ledgerhq/live-common/lib/nft";
+import { useSelector } from "react-redux";
 import { useNavigation, useTheme } from "@react-navigation/native";
 import { Account, ProtoNFT } from "@ledgerhq/live-common/lib/types";
+import { hiddenNftCollectionsSelector } from "../../reducers/settings";
 import LoadingFooter from "../../components/LoadingFooter";
 import NftImage from "../../components/Nft/NftImage";
 import Skeleton from "../../components/Skeleton";
@@ -88,22 +90,33 @@ const SendFundsSelectCollection = ({ route }: Props) => {
   const { account } = params;
   const { colors } = useTheme();
 
-  const [collectionCount, setCollectionCount] = useState(
+  const hiddenNftCollections = useSelector(hiddenNftCollectionsSelector);
+
+  const [collectionsCount, setCollectionsCount] = useState(
     MAX_COLLECTIONS_FIRST_RENDER,
   );
-  const collections = useMemo(() => nftsByCollections(account.nfts), [
-    account.nfts,
-  ]);
-  const collectionsSlice = useMemo(
-    () => Object.values(collections).slice(0, collectionCount),
-    [collections, collectionCount],
+  const collections = useMemo(
+    () =>
+      Object.entries(nftsByCollections(account.nfts)).filter(
+        ([contract]) =>
+          !hiddenNftCollections.includes(`${account.id}|${contract}`),
+      ),
+    [account.id, account.nfts, hiddenNftCollections],
+  ) as [string, ProtoNFT[]][];
+
+  const collectionsSlice: Array<ProtoNFT[]> = useMemo(
+    () =>
+      collections
+        .slice(0, collectionsCount)
+        .map(([, collection]) => collection),
+    [collections, collectionsCount],
   );
   const onEndReached = useCallback(
     () =>
-      setCollectionCount(
-        collectionCount + COLLECTIONS_TO_ADD_ON_LIST_END_REACHED,
+      setCollectionsCount(
+        collectionsCount + COLLECTIONS_TO_ADD_ON_LIST_END_REACHED,
       ),
-    [collectionCount, setCollectionCount],
+    [collectionsCount, setCollectionsCount],
   );
 
   const renderItem = useCallback(
@@ -125,7 +138,7 @@ const SendFundsSelectCollection = ({ route }: Props) => {
         keyExtractor={keyExtractor}
         onEndReached={onEndReached}
         ListFooterComponent={
-          collectionCount < collections.length ? <LoadingFooter /> : null
+          collectionsCount < collections.length ? <LoadingFooter /> : null
         }
       />
     </SafeAreaView>

--- a/src/screens/SendFunds/01c-SelectNft.tsx
+++ b/src/screens/SendFunds/01c-SelectNft.tsx
@@ -210,4 +210,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default memo(SendFundsSelectNft);
+export default memo<Props>(SendFundsSelectNft);

--- a/src/screens/Settings/Accounts/HiddenNftCollections.tsx
+++ b/src/screens/Settings/Accounts/HiddenNftCollections.tsx
@@ -1,0 +1,127 @@
+import React, { useCallback, useMemo } from "react";
+import { FlatList } from "react-native";
+import { Box, Flex, Text, Icons } from "@ledgerhq/native-ui";
+import { useDispatch, useSelector } from "react-redux";
+import { Account } from "@ledgerhq/live-common/lib/types";
+import {
+  useNftCollectionMetadata,
+  useNftMetadata,
+} from "@ledgerhq/live-common/lib/nft/NftMetadataProvider";
+import { TouchableOpacity } from "react-native-gesture-handler";
+import styled from "styled-components";
+import { hiddenNftCollectionsSelector } from "../../../reducers/settings";
+import { accountSelector } from "../../../reducers/accounts";
+import NftImage from "../../../components/Nft/NftImage";
+import Skeleton from "../../../components/Skeleton";
+import { unhideNftCollection } from "../../../actions/settings";
+
+const CollectionFlatList = styled(FlatList)`
+  min-height: 100%;
+`;
+
+const CollectionImage = styled(NftImage)`
+  border-radius: 4px;
+  width: 36px;
+  aspect-ratio: 1;
+  overflow: hidden;
+`;
+
+const CollectionNameSkeleton = styled(Skeleton)`
+  height: 8px;
+  width: 113px;
+  border-radius: 4px;
+  margin-left: 10px;
+`;
+
+const HiddenNftCollectionRow = ({
+  contractAddress,
+  accountId,
+  onUnhide,
+}: {
+  contractAddress: string;
+  accountId: string;
+  onUnhide: () => void;
+}) => {
+  const account: Account = useSelector(state =>
+    accountSelector(state, { accountId }),
+  );
+  const nfts = account?.nfts || [];
+  const nft = nfts.find(nft => nft?.contract === contractAddress);
+
+  const {
+    status: collectionStatus,
+    metadata: collectionMetadata,
+  } = useNftCollectionMetadata(contractAddress, nft?.currencyId);
+  const { status: nftStatus, metadata: nftMetadata } = useNftMetadata(
+    contractAddress,
+    nft?.tokenId,
+    nft?.currencyId,
+  );
+  const loading = useMemo(
+    () => nftStatus === "loading" || collectionStatus === "loading",
+    [collectionStatus, nftStatus],
+  );
+
+  return (
+    <Flex p={6} flexDirection="row" alignItems="center">
+      <CollectionImage status={nftStatus} src={nftMetadata?.media} />
+      <Flex
+        flexDirection="row"
+        alignItems="center"
+        flexShrink={1}
+        justifyContent="space-between"
+      >
+        <Flex mx={6} flexGrow={1} flexShrink={1} flexDirection="column">
+          <CollectionNameSkeleton loading={loading}>
+            <Text
+              fontWeight={"semiBold"}
+              variant={"large"}
+              ellipsizeMode="tail"
+              numberOfLines={2}
+            >
+              {collectionMetadata?.tokenName || contractAddress}
+            </Text>
+          </CollectionNameSkeleton>
+        </Flex>
+        <TouchableOpacity onPress={onUnhide}>
+          <Icons.CloseMedium color="neutral.c100" size={24} />
+        </TouchableOpacity>
+      </Flex>
+    </Flex>
+  );
+};
+
+const HiddenNftCollections = () => {
+  const hiddenCollections = useSelector(hiddenNftCollectionsSelector);
+  const dispatch = useDispatch();
+
+  const renderItem = useCallback(
+    ({ item }: { item: any }) => {
+      const [accountId, contractAddress] = item.split("|");
+      return (
+        <HiddenNftCollectionRow
+          accountId={accountId}
+          contractAddress={contractAddress}
+          onUnhide={() => dispatch(unhideNftCollection(item))}
+        />
+      );
+    },
+    [dispatch],
+  );
+
+  const keyExtractor = useCallback(item => item, []);
+
+  return (
+    <Box backgroundColor={"background.main"} height={"100%"}>
+      <Flex p={2}>
+        <CollectionFlatList
+          data={hiddenCollections}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+        />
+      </Flex>
+    </Box>
+  );
+};
+
+export default HiddenNftCollections;

--- a/src/screens/Settings/Accounts/index.tsx
+++ b/src/screens/Settings/Accounts/index.tsx
@@ -78,7 +78,7 @@ export default function AccountsSettings({ navigation }: { navigation: any }) {
             onPress={() => navigation.navigate(ScreenName.CryptoAssetsSettings)}
           />
         )}
-        {hiddenNftCollections.length > 0 && (
+        {hiddenNftCollections.length && (
           <SettingsRow
             event="HiddenNftCollectionsSettings"
             title={t("settings.accounts.hiddenNFTCollections")}

--- a/src/screens/Settings/Accounts/index.tsx
+++ b/src/screens/Settings/Accounts/index.tsx
@@ -4,7 +4,6 @@ import { useSelector, useDispatch } from "react-redux";
 import { TouchableOpacity, View, StyleSheet, SectionList } from "react-native";
 import { findTokenById } from "@ledgerhq/live-common/lib/currencies";
 import { CryptoCurrency, TokenCurrency } from "@ledgerhq/live-common/lib/types";
-import { Box } from "@ledgerhq/native-ui";
 import { useTheme } from "styled-components/native";
 import SettingsRow from "../../../components/SettingsRow";
 import { showToken } from "../../../actions/settings";
@@ -81,6 +80,7 @@ export default function AccountsSettings({ navigation }: { navigation: any }) {
         )}
         {hiddenNftCollections.length > 0 && (
           <SettingsRow
+            event="HiddenNftCollectionsSettings"
             title={t("settings.accounts.hiddenNFTCollections")}
             desc={t("settings.accounts.hiddenNFTCollectionsDesc")}
             arrowRight

--- a/src/screens/Settings/Accounts/index.tsx
+++ b/src/screens/Settings/Accounts/index.tsx
@@ -8,7 +8,10 @@ import { Box } from "@ledgerhq/native-ui";
 import { useTheme } from "styled-components/native";
 import SettingsRow from "../../../components/SettingsRow";
 import { showToken } from "../../../actions/settings";
-import { blacklistedTokenIdsSelector } from "../../../reducers/settings";
+import {
+  blacklistedTokenIdsSelector,
+  hiddenNftCollectionsSelector,
+} from "../../../reducers/settings";
 import { cryptoCurrenciesSelector } from "../../../reducers/accounts";
 import LText from "../../../components/LText";
 import CurrencyIcon from "../../../components/CurrencyIcon";
@@ -22,6 +25,7 @@ export default function AccountsSettings({ navigation }: { navigation: any }) {
   const { t } = useTranslation();
   const blacklistedTokenIds = useSelector(blacklistedTokenIdsSelector);
   const currencies = useSelector(cryptoCurrenciesSelector);
+  const hiddenNftCollections = useSelector(hiddenNftCollectionsSelector);
   const dispatch = useDispatch();
 
   const renderSectionHeader = useCallback(
@@ -73,6 +77,14 @@ export default function AccountsSettings({ navigation }: { navigation: any }) {
             desc={t("settings.accounts.cryptoAssets.desc")}
             arrowRight
             onPress={() => navigation.navigate(ScreenName.CryptoAssetsSettings)}
+          />
+        )}
+        {hiddenNftCollections.length > 0 && (
+          <SettingsRow
+            title={t("settings.accounts.hiddenNFTCollections")}
+            desc={t("settings.accounts.hiddenNFTCollectionsDesc")}
+            arrowRight
+            onPress={() => navigation.navigate(ScreenName.HiddenNftCollections)}
           />
         )}
         <HideEmptyTokenAccountsRow />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2777,10 +2777,9 @@
     bignumber.js "^9.0.2"
     json-rpc-2.0 "^1.0.0"
 
-"@ledgerhq/live-common@22.0.3":
+"@ledgerhq/live-common@https://github.com/LedgerHQ/ledger-live-common.git#0ce72dd7976ddb47844e3b2e162dd514a46196dc":
   version "22.0.3"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-22.0.3.tgz#d25ed7de09212fb4be4c139f037070ace78de81b"
-  integrity sha512-ypP6nLopyD/uDh8JqvPTdUkCzsfq/cFDxW8RklULrYch0dm9Fnw2L7qRKrlg63GBbUFOl3w6i7nIctz+n4QStA==
+  resolved "https://github.com/LedgerHQ/ledger-live-common.git#0ce72dd7976ddb47844e3b2e162dd514a46196dc"
   dependencies:
     "@celo/contractkit" "^1.5.2"
     "@celo/wallet-base" "^1.5.2"


### PR DESCRIPTION
### Copy of #2333 

This PR adds the possibility of hiding NFT collections from both the account page and the NFT Gallery page.
The hidden collections are visible in the account settings page and can be unhidden there.



https://user-images.githubusercontent.com/6013294/159961708-04afeea7-3f4a-45e4-8543-f53a42153125.mp4





### Type
Feature

### Context
[LIVE-1625]

### Parts of the app affected / Test plan
Account page, NFT Gallery and Setting page.
On an account page, long-press an NFT collection to show the hide menu.
On the NFT Gallery, click the 3 dots beside the collection title to show the hide menu.
Go to settings -> accounts -> hidden NFT collections to unhide the collections.
Hidden collections should not be visible in the account page nor the NFT gallery.


[LIVE-1625]: https://ledgerhq.atlassian.net/browse/LIVE-1625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ