### PR TITLE
LIVE-2083 LIVE-2084 - Reenable navigation to Lido platform app on iOS

### DIFF
--- a/src/components/Carousel/Slide.tsx
+++ b/src/components/Carousel/Slide.tsx
@@ -3,27 +3,31 @@ import { Linking, Image } from "react-native";
 import { Flex, Text, Link as TextLink, Icons } from "@ledgerhq/native-ui";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components/native";
+import { useNavigation } from "@react-navigation/native";
 import Touchable from "../Touchable";
 import { track } from "../../analytics";
+import { SlideProps } from "./shared";
 
 const StyledTouchable = styled(Touchable)`
   flex: 1;
 `;
 
-type SlideProps = {
+export type SlideProps = {
   url: string;
+  onPress?: (navigate: (...args: any) => void) => void;
   name: string;
   title: string;
   description: any;
   cta: any;
-  image: any;
-  icon: any;
-  position: any;
-  width: number;
+  image?: any;
+  width?: number;
+  icon?: any;
+  position?: any;
 };
 
 const Slide = ({
   url,
+  onPress,
   name,
   title,
   description,
@@ -34,12 +38,17 @@ const Slide = ({
   width,
 }: SlideProps) => {
   const { t } = useTranslation();
+  const { navigate } = useNavigation();
   const onClick = useCallback(() => {
     track("Portfolio Recommended OpenUrl", {
       url,
     });
-    Linking.openURL(url);
-  }, [url]);
+    if (onPress) {
+      onPress(navigate);
+    } else {
+      Linking.openURL(url);
+    }
+  }, [onPress, navigate, url]);
   return (
     <StyledTouchable event={`${name} Carousel`} onPress={onClick}>
       <Flex

--- a/src/components/Carousel/shared.tsx
+++ b/src/components/Carousel/shared.tsx
@@ -96,6 +96,7 @@ const LidoSlide: SlideProps = {
   onPress: navigate => {
     navigate(ScreenName.PlatformApp, {
       platform: "lido",
+      name: "Lido",
     });
   },
   name: "Lido",

--- a/src/components/Carousel/shared.tsx
+++ b/src/components/Carousel/shared.tsx
@@ -1,9 +1,9 @@
 import React from "react";
-import { Platform } from "react-native";
 import { urls } from "../../config/urls";
-import Slide from "./Slide";
+import Slide, { SlideProps } from "./Slide";
 import Illustration from "../../images/illustration/Illustration";
 import { width } from "../../helpers/normalizeSize";
+import { ScreenName } from "../../const";
 
 const illustrations = {
   dark: {
@@ -27,7 +27,7 @@ const illustrations = {
 };
 
 /*
-const AcademySlide = {
+const AcademySlide: SlideProps = {
   url: urls.banners.ledgerAcademy,
   name: "takeTour",
   title: "carousel.banners.tour.title",
@@ -49,7 +49,7 @@ const AcademySlide = {
 };
 */
 
-const BuySlide = {
+const BuySlide: SlideProps = {
   url: "ledgerlive://buy",
   name: "buyCrypto",
   title: "carousel.banners.buyCrypto.title",
@@ -70,7 +70,7 @@ const BuySlide = {
   },
 };
 
-const SwapSlide = {
+const SwapSlide: SlideProps = {
   url: "ledgerlive://swap",
   name: "Swap",
   title: "carousel.banners.swap.title",
@@ -91,8 +91,13 @@ const SwapSlide = {
   },
 };
 
-const LidoSlide = {
+const LidoSlide: SlideProps = {
   url: "ledgerlive://discover/lido",
+  onPress: navigate => {
+    navigate(ScreenName.PlatformApp, {
+      platform: "lido",
+    });
+  },
   name: "Lido",
   title: "carousel.banners.lido.title",
   description: "carousel.banners.lido.description",
@@ -112,7 +117,7 @@ const LidoSlide = {
   },
 };
 
-const MarketSlide = {
+const MarketSlide: SlideProps = {
   url: "ledgerlive://market",
   name: "Market",
   title: "carousel.banners.market.title",
@@ -134,7 +139,7 @@ const MarketSlide = {
 };
 
 /** 
-const FamilyPackSlide = {
+const FamilyPackSlide: SlideProps = {
   url: urls.banners.familyPack,
   name: "FamilyPack",
   title: "carousel.banners.familyPack.title",
@@ -156,7 +161,7 @@ const FamilyPackSlide = {
 };
 */
 
-const FamilyPackXSlide = {
+const FamilyPackXSlide: SlideProps = {
   url: urls.banners.familyPackX,
   name: "FamilyPack",
   title: "carousel.banners.familyPackX.title",
@@ -177,29 +182,20 @@ const FamilyPackXSlide = {
   },
 };
 
-export const SLIDES =
-  Platform.OS === "ios"
-    ? [SwapSlide, BuySlide, MarketSlide, FamilyPackXSlide]
-    : [SwapSlide, LidoSlide, BuySlide, MarketSlide, FamilyPackXSlide];
+export const SLIDES: SlideProps[] = [
+  SwapSlide,
+  LidoSlide,
+  BuySlide,
+  MarketSlide,
+  FamilyPackXSlide,
+];
 
 export const WIDTH = width * 0.8;
 
 export const getDefaultSlides = () =>
-  SLIDES.map((slide: any) => ({
+  SLIDES.map(slide => ({
     id: slide.name,
-    Component: () => (
-      <Slide
-        url={slide.url}
-        name={slide.name}
-        title={slide.title}
-        description={slide.description}
-        cta={slide.cta}
-        image={slide.image}
-        icon={slide.icon}
-        position={slide.position}
-        width={WIDTH}
-      />
-    ),
+    Component: () => <Slide width={WIDTH} {...slide} />,
   }));
 
 export const CAROUSEL_NONCE: number = 6;

--- a/src/screens/Account/hooks/useActions.tsx
+++ b/src/screens/Account/hooks/useActions.tsx
@@ -112,10 +112,19 @@ export default function useActions({ account, parentAccount, colors }: Props) {
     ...(!readOnlyModeEnabled ? [SendAction] : []),
     ReceiveAction,
     ...baseActions,
-    ...(isEthereum && Platform.OS !== "ios"
+    ...(isEthereum
       ? [
           {
-            linkUrl: "ledgerlive://discover/lido",
+            navigationParams: [
+              NavigatorName.Base,
+              {
+                screen: ScreenName.PlatformApp,
+                params: {
+                  platform: "lido",
+                  name: "Lido",
+                },
+              },
+            ],
             label: <Trans i18nKey="account.stake" />,
             Icon: Icons.ClaimRewardsMedium,
             event: "Stake Ethereum Account Button",

--- a/src/screens/Platform/App.js
+++ b/src/screens/Platform/App.js
@@ -1,17 +1,21 @@
 // @flow
 
-import React from "react";
+import React, { useEffect } from "react";
 import { usePlatformApp } from "@ledgerhq/live-common/lib/platform/PlatformAppProvider";
 import type { StackScreenProps } from "@react-navigation/stack";
-import { useTheme } from "@react-navigation/native";
+import { useNavigation, useTheme } from "@react-navigation/native";
 import TrackScreen from "../../analytics/TrackScreen";
 import WebPlatformPlayer from "../../components/WebPlatformPlayer";
 
 const PlatformApp = ({ route }: StackScreenProps) => {
   const { dark } = useTheme();
   const { platform: appId, ...params } = route.params;
+  const { setParams } = useNavigation();
   const { manifests } = usePlatformApp();
   const manifest = manifests.get(appId);
+  useEffect(() => {
+    manifest.name && setParams({ name: manifest.name });
+  }, [manifest, setParams]);
   const themeType = dark ? "dark" : "light";
 
   return manifest ? (


### PR DESCRIPTION
On the Portfolio (in the Carousel) and on the account screen for Ethereum accounts, we have CTAs that lead to the Lido discover apps.

The logic for these CTAs was using deeplinking (opening this URI: `ledgerlive://discover/lido`) and the deeplinks handling and redirection logic for discover apps is in part handled by the `PlatformCatalog` screen: react-navigation navigates to the `PlatformCatalog` screen with the correct params, then that screen has a useEffect to check the validity of the params (it checks that the app manifest exists and is not filtered) and then navigate to the `PlatformApp` screen.

The issue with that is that on iOS we have removed the `PlatformCatalog` completely from the navigation logic so this deeplinking logic cannot work. That is why these CTAs have been disabled on iOS.

The simple solution then to reenable these is to implement a direct navigation instead of a deeplink logic.

#### Wallet > "Recommended" section > Lido card

> https://user-images.githubusercontent.com/91890529/165715963-7d046a67-c447-4721-9744-1a7149ed8e04.mp4

#### Ethereum account page > "Stake" CTA

> https://user-images.githubusercontent.com/91890529/165715977-dd179e78-c6a3-43ff-99dc-5b248aaecffe.mp4



### Type

Reenabling existing feature

### Context

[LIVE-2083]
[LIVE-2084]

### Parts of the app affected / Test plan
- Wallet > "Recommended" section > Lido card
- Ethereum account page > "Stake" CTA


[LIVE-2083]: https://ledgerhq.atlassian.net/browse/LIVE-2083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIVE-2084]: https://ledgerhq.atlassian.net/browse/LIVE-2084