### PR TITLE
LIVE-2142 - Add "stake" button to account page actions

### DIFF
--- a/src/families/cosmos/accountActions.tsx
+++ b/src/families/cosmos/accountActions.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import type { Account } from "@ledgerhq/live-common/lib/types";
+import { canDelegate } from "@ledgerhq/live-common/lib/families/cosmos/logic";
+
+import { Icons } from "@ledgerhq/native-ui";
+import { Trans } from "react-i18next";
+import { NavigatorName, ScreenName } from "../../const";
+
+const getActions = ({ account }: { account: Account }) => {
+  const delegationDisabled = !canDelegate(account);
+
+  return [
+    {
+      disabled: delegationDisabled,
+      navigationParams: [
+        NavigatorName.CosmosDelegationFlow,
+        {
+          screen: ScreenName.CosmosDelegationStarted,
+
+        },
+      ],
+      label: <Trans i18nKey="account.stake" />,
+      Icon: Icons.ClaimRewardsMedium,
+    },
+  ];
+};
+
+export default {
+  getActions,
+};

--- a/src/families/polkadot/accountActions.js
+++ b/src/families/polkadot/accountActions.js
@@ -10,9 +10,11 @@ import {
   hasExternalController,
   hasExternalStash,
   hasPendingOperationType,
+  isStash,
 } from "@ledgerhq/live-common/lib/families/polkadot/logic";
 import { getCurrentPolkadotPreloadData } from "@ledgerhq/live-common/lib/families/polkadot/preload";
 
+import { Icons } from "@ledgerhq/native-ui";
 import BondIcon from "../../icons/LinkIcon";
 import UnbondIcon from "../../icons/Undelegate";
 import WithdrawUnbondedIcon from "../../icons/Coins";
@@ -51,11 +53,34 @@ const getActions = ({ account }: { account: Account }) => {
   const withdrawEnabled =
     !electionOpen && hasUnlockedBalance && !hasPendingWithdrawUnbondedOperation;
 
+  const earnRewardsEnabled =
+    !electionOpen && !hasBondedBalance && !hasPendingBondOperation;
+
   if (hasExternalController(account) || hasExternalStash(account)) {
     return null;
   }
 
   return [
+    {
+      disabled: !(earnRewardsEnabled || nominationEnabled),
+      navigationParams: isStash(account)
+        ? [
+            NavigatorName.PolkadotNominateFlow,
+            {
+              screen: ScreenName.PolkadotNominateSelectValidators,
+              params: { accountId },
+            },
+          ]
+        : [
+            NavigatorName.PolkadotBondFlow,
+            {
+              screen: ScreenName.PolkadotBondStarted,
+              params: { accountId },
+            },
+          ],
+      label: <Trans i18nKey="account.stake" />,
+      Icon: Icons.ClaimRewardsMedium,
+    },
     {
       disabled: !bondingEnabled,
       navigationParams: [

--- a/src/families/tezos/DelegationFlow/Started.tsx
+++ b/src/families/tezos/DelegationFlow/Started.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { Linking } from "react-native";
+import { Linking, ScrollView } from "react-native";
 import { Trans } from "react-i18next";
 import { Flex, Text, Icons, List, Link, Log } from "@ledgerhq/native-ui";
 import { ScreenName } from "../../../const";
@@ -29,50 +29,52 @@ export default function DelegationStarted({ navigation, route }: Props) {
   }, []);
 
   return (
-    <Flex flex={1} justifyContent="space-between" bg="background.main">
-      <Flex m={6}>
-        <TrackScreen category="DelegationFlow" name="Started" />
-        <Flex alignItems="center">
-          <Illustration
-            lightSource={EarnLight}
-            darkSource={EarnDark}
-            size={150}
+    <ScrollView>
+      <Flex flex={1} justifyContent="space-between" bg="background.main">
+        <Flex m={6}>
+          <TrackScreen category="DelegationFlow" name="Started" />
+          <Flex alignItems="center">
+            <Illustration
+              lightSource={EarnLight}
+              darkSource={EarnDark}
+              size={150}
+            />
+          </Flex>
+          <Flex py={8} alignItems="center">
+            <Log>
+              <Trans i18nKey="delegation.started.title" />
+            </Log>
+          </Flex>
+          <Text variant="body" fontWeight="medium" textAlign="center" mb={6}>
+            <Trans i18nKey="delegation.started.description" />
+          </Text>
+          <List
+            items={[
+              <Trans i18nKey="delegation.started.steps.0" />,
+              <Trans i18nKey="delegation.started.steps.1" />,
+              <Trans i18nKey="delegation.started.steps.2" />,
+            ].map(wording => ({ title: wording, bullet: Check }))}
+            itemContainerProps={{
+              alignItems: "center",
+            }}
+            my={8}
           />
+          <Link
+            type="color"
+            size="medium"
+            iconPosition="right"
+            Icon={Icons.ExternalLinkMedium}
+            onPress={howDelegationWorks}
+          >
+            <Trans i18nKey="delegation.howDelegationWorks" />
+          </Link>
         </Flex>
-        <Flex py={8} alignItems="center">
-          <Log>
-            <Trans i18nKey="delegation.started.title" />
-          </Log>
+        <Flex p={6}>
+          <Button event="DelegationStartedBtn" onPress={onNext} type="main">
+            <Trans i18nKey="delegation.started.cta" />
+          </Button>
         </Flex>
-        <Text variant="body" fontWeight="medium" textAlign="center" mb={6}>
-          <Trans i18nKey="delegation.started.description" />
-        </Text>
-        <List
-          items={[
-            <Trans i18nKey="delegation.started.steps.0" />,
-            <Trans i18nKey="delegation.started.steps.1" />,
-            <Trans i18nKey="delegation.started.steps.2" />,
-          ].map(wording => ({ title: wording, bullet: Check }))}
-          itemContainerProps={{
-            alignItems: "center",
-          }}
-          my={8}
-        />
-        <Link
-          type="color"
-          size="medium"
-          iconPosition="right"
-          Icon={Icons.ExternalLinkMedium}
-          onPress={howDelegationWorks}
-        >
-          <Trans i18nKey="delegation.howDelegationWorks" />
-        </Link>
       </Flex>
-      <Flex p={6}>
-        <Button event="DelegationStartedBtn" onPress={onNext} type="main">
-          <Trans i18nKey="delegation.started.cta" />
-        </Button>
-      </Flex>
-    </Flex>
+    </ScrollView>
   );
 }

--- a/src/families/tezos/accountActions.tsx
+++ b/src/families/tezos/accountActions.tsx
@@ -1,8 +1,10 @@
-// @flow
 import React from "react";
 import { Trans } from "react-i18next";
 import type { AccountLike } from "@ledgerhq/live-common/lib/types";
-import { getAccountDelegationSync } from "@ledgerhq/live-common/lib/families/tezos/bakers";
+import { getAccountDelegationSync, isAccountDelegating } from "@ledgerhq/live-common/lib/families/tezos/bakers";
+import { Account } from "@ledgerhq/live-common/lib/types";
+import { Icons } from "@ledgerhq/native-ui";
+import { NavigatorName, ScreenName } from "../../const";
 
 const getExtraSendActionParams = ({ account }: { account: AccountLike }) => {
   const delegation = getAccountDelegationSync(account);
@@ -36,7 +38,30 @@ const getExtraReceiveActionParams = ({ account }: { account: AccountLike }) => {
     : {};
 };
 
+const getActions = ({ account, parentAccount }: { account: Account,  parentAccount: Account }) => {
+  const delegationDisabled = (isAccountDelegating(account) || account.type !== "Account");
+
+  return [
+    {
+      disabled: delegationDisabled,
+      navigationParams: [
+        NavigatorName.TezosDelegationFlow,
+        {
+          screen: ScreenName.DelegationStarted,
+          params: {
+            accountId: account.id,
+            parentId: parentAccount ? parentAccount.id : undefined,
+          },
+        },
+      ],
+      label: <Trans i18nKey="account.stake" />,
+      Icon: Icons.ClaimRewardsMedium,
+    },
+  ];
+};
+
 export default {
   getExtraSendActionParams,
   getExtraReceiveActionParams,
+  getActions
 };

--- a/src/families/tron/accountActions.js
+++ b/src/families/tron/accountActions.js
@@ -26,7 +26,7 @@ const getActions = ({
   colors,
 }: {
   account: Account,
-  parentId: Account,
+  parentAccount: Account,
   colors: *,
 }) => {
   if (!account.tronResources) return null;

--- a/src/families/tron/accountActions.js
+++ b/src/families/tron/accountActions.js
@@ -11,6 +11,7 @@ import {
   getLastVotedDate,
 } from "@ledgerhq/live-common/lib/families/tron/react";
 
+import { Icons } from "@ledgerhq/native-ui";
 import FreezeIcon from "../../icons/Freeze";
 import UnfreezeIcon from "../../icons/Unfreeze";
 import VoteIcon from "../../icons/Vote";
@@ -19,7 +20,15 @@ import LText from "../../components/LText";
 import DateFromNow from "../../components/DateFromNow";
 import { NavigatorName, ScreenName } from "../../const";
 
-const getActions = ({ account, colors }: { account: Account, colors: * }) => {
+const getActions = ({
+  account,
+  parentAccount,
+  colors,
+}: {
+  account: Account,
+  parentId: Account,
+  colors: *,
+}) => {
   if (!account.tronResources) return null;
 
   const {
@@ -59,6 +68,20 @@ const getActions = ({ account, colors }: { account: Account, colors: * }) => {
   const lastVotedDate = getLastVotedDate(account);
 
   return [
+    {
+      disabled: !canVote && !canFreeze,
+      navigationParams: [
+        canVote ? NavigatorName.TronVoteFlow : NavigatorName.Freeze,
+        {
+          screen: canVote ? ScreenName.VoteStarted : ScreenName.FreezeInfo,
+          params: {
+            params: { accountId, parentId: parentAccount?.id },
+          },
+        },
+      ],
+      label: <Trans i18nKey="account.stake" />,
+      Icon: Icons.ClaimRewardsMedium,
+    },
     {
       disabled: !canFreeze,
       navigationParams: [


### PR DESCRIPTION
Add "stake" button to account page actions for TRON, TEZOS, COSMOS and DOT

Partly based on https://github.com/LedgerHQ/ledger-live-desktop/pull/4921

**TRON** : 
If there is already frozen TRON, stake button navigate to Vote flow. If not, it go to freeze flow

https://user-images.githubusercontent.com/89014981/165813966-21153152-f4b3-42c5-b97f-9b035c72e25c.mp4



**TEZOS** :

https://user-images.githubusercontent.com/89014981/165814000-9d471bb1-b911-4b98-be06-28f9b730b828.mp4



**COSMOS** :

https://user-images.githubusercontent.com/89014981/165814009-12819cb8-036d-43f6-816f-0b148dbbeb0f.mp4



**DOT** :
If there is already bonded DOT, stake button navigate to Nominate flow. If not, it goes to bond flow

https://user-images.githubusercontent.com/89014981/165814015-8fa334f3-19a2-4104-840a-9df2d5bfac53.mp4


<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LIVE-2142

### Parts of the app affected / Test plan

Account page -> Tezos, cosmos, dot, tron
