### PR TITLE
Add to README more info on pre-requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It communicates with the [Ledger Nano X](https://www.ledger.com/pages/ledger-nan
 
 - Node LTS version
 - Yarn 1.10.1 or above
+- [Full React Native environment setup instructions here](https://reactnative.dev/docs/environment-setup)
 
 ### iOS
 
@@ -30,6 +31,10 @@ It communicates with the [Ledger Nano X](https://www.ledger.com/pages/ledger-nan
 ### Android
 
 - Android Studio
+- JDK 11
+- Required SDK tools: (go to Android Studio > Tools > SDK Manager > SDK Tools > check "Show Package Details" at the bottom right)
+  - Android NDK 21.4.7075529 (in case this doc is outdated, check the version specified as `ndkVersion` in `android/build.gradle`)
+  - CMake 3.10.2
 
 ## Scripts
 


### PR DESCRIPTION
Modifications in the `## Pre-requisites` section of the README:
- Adding link to official React Native environment setup instructions.
- `### Android` section:
  - Adding JDK 11 requirement.
  - Adding NDK & CMake with exact versions and how to install them.

<img width="1103" alt="Screenshot 2022-04-29 at 11 53 48" src="https://user-images.githubusercontent.com/91890529/165923195-133f9347-77ab-4b09-b0cc-38df537638b3.png">

### Type

Documentation

### Context

I got a new M1 mac so I'm setting up the environment and some necessary information is missing from the README