### PR TITLE
Remove styled-components warning in onboarding

### DIFF
--- a/src/screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx
+++ b/src/screens/Onboarding/steps/setupDevice/scenes/BaseStepperView.tsx
@@ -78,7 +78,7 @@ const ImageHeader = ({
           onChange={() => {}}
         />
       )}
-      <Flex width="48">
+      <Flex width={48}>
         <InfoButton target={stepData.drawer} />
       </Flex>
     </Flex>


### PR DESCRIPTION
The issue was with the styling of the top-right ⓘ button.

#### see annoying warning at the bottom
> <img src="https://user-images.githubusercontent.com/91890529/165941210-4531f94a-1c81-45bc-8220-2a0ee5490375.png" height="500px" />

### Type

Warning fix

### Context

I was annoyed by this

### Parts of the app affected / Test plan

Onboarding > "pair device" step