### PR TITLE
LIVE-2028 - Fix - Use hide empty sub account setting on accounts list

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -1877,7 +1877,7 @@
         "bullet2": "Ledger Live version, OS region, language and region"
       },
       "hideEmptyTokenAccounts": "Hide empty token accounts",
-      "hideEmptyTokenAccountsDesc": "Hide empty token accounts on the Accounts page."
+      "hideEmptyTokenAccountsDesc": "All empty token accounts in the Assets page will be hidden."
     },
     "currencies": {
       "header": "Currencies",

--- a/src/screens/Accounts/index.tsx
+++ b/src/screens/Accounts/index.tsx
@@ -58,7 +58,9 @@ function Accounts({ navigation, route }: Props) {
 
   const [account, setAccount] = useState(undefined);
 
-  const flattenedAccounts = flattenAccounts(accounts);
+  const flattenedAccounts = flattenAccounts(accounts, {
+    enforceHideEmptySubAccounts: true,
+  });
 
   // Deep linking params redirect
   useEffect(() => {


### PR DESCRIPTION
Use hide empty sub account setting on accounts list

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LIVE-2028

### Parts of the app affected / Test plan

Accounts