### PR TITLE
LL-1991 - Fix - Select fee strategy checkbox should be tappable

### DIFF
--- a/src/components/SelectFeesStrategy.js
+++ b/src/components/SelectFeesStrategy.js
@@ -108,6 +108,7 @@ export default function SelectFeesStrategy({
       >
         <View style={styles.leftBox}>
           <CheckBox
+            onChange={() => onPressStrategySelect(item)}
             style={styles.checkbox}
             isChecked={feesStrategy === item.label}
           />


### PR DESCRIPTION
Select fee strategy checkbox should be tappable
Actually, only the parent TouchableOpacity is tappable

### Type

Bug fix 

### Context

https://ledgerhq.atlassian.net/browse/LIVE-1991

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->
