### PR TITLE
fix/LIVE-2116 read only mode issue

### DIFF
--- a/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
+++ b/src/screens/Onboarding/steps/setupDevice/scenes/ConnectNano.tsx
@@ -31,6 +31,7 @@ const ConnectNanoScene = ({
     device => {
       dispatch(setLastConnectedDevice(device));
       setDevice(device);
+      dispatch(setReadOnlyMode(false));
     },
     [dispatch],
   );


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

This fixes an issue where you would connect a device during onboarding but still be locked on read only mode.

The case could be detected when connection a nanoS or nanoSP during onboarding.

### Type

<!-- e.g. Bug Fix, Feature, Code Quality Improvement, UI Polish... -->

[LIVE-2116]

### Context

<!-- e.g. GitHub issue #45 / contextual discussion -->

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LIVE-2116]: https://ledgerhq.atlassian.net/browse/LIVE-2116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ