### PR TITLE
Workaround fix for LIVE-2121

### DIFF
--- a/scripts/post.sh
+++ b/scripts/post.sh
@@ -17,6 +17,7 @@ rn-nodeify --hack
 # manually shim
 sed -i -- 's/require("crypto")/require("react-native-crypto")/g' node_modules/@walletconnect/randombytes/dist/cjs/node/index.js
 
+patch -N node_modules/react-native-video/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java ./scripts/react-native-video.2575.patch || false
 
 # Create the dev .env file with APP_NAME if it doesn't exist
 if ! [ -f .env ]; then

--- a/scripts/react-native-video.2575.patch
+++ b/scripts/react-native-video.2575.patch
@@ -1,0 +1,5 @@
+950c950,951
+<                 if (decoderInitializationException.codecInfo.name == null) {
+---
+>                 if (decoderInitializationException.codecInfo == null
+>                         || decoderInitializationException.codecInfo.name == null) {


### PR DESCRIPTION
this PR patches a react-native-video bug "on the fly" in a postinstall as a workaround for the real future fix to do for LIVE-2121

- [ ] the fix need to be tested. As we should no longer have a crash at boot, it is now not clear what is then the behavior of Ledger Live (does it crash, does it render a white page instead of the video,...)