### PR TITLE
LIVE-2035 - Fix - Subaccount settings rebrand

### DIFF
--- a/src/screens/Account/SubAccountsList.tsx
+++ b/src/screens/Account/SubAccountsList.tsx
@@ -238,11 +238,13 @@ export default function SubAccountsList({
         ListHeaderComponent={renderHeader}
         ListFooterComponent={renderFooter}
       />
-      <TokenContextualModal
-        onClose={() => setAccount()}
-        isOpened={!!account}
-        account={account}
-      />
+      {account && (
+        <TokenContextualModal
+          onClose={() => setAccount(undefined)}
+          isOpened={!!account}
+          account={account}
+        />
+      )}
     </>
   );
 }

--- a/src/screens/Account/TokenContractAddress.tsx
+++ b/src/screens/Account/TokenContractAddress.tsx
@@ -82,7 +82,6 @@ const styles = StyleSheet.create({
     flexDirection: "column",
     alignItems: "center",
     paddingHorizontal: 20,
-    paddingTop: 24,
   },
   iconWrapper: {
     justifyContent: "center",

--- a/src/screens/Settings/Accounts/TokenContextualModal.js
+++ b/src/screens/Settings/Accounts/TokenContextualModal.js
@@ -3,24 +3,24 @@ import React, { useCallback, useState } from "react";
 import { connect } from "react-redux";
 import type { TokenAccount, Account } from "@ledgerhq/live-common/lib/types";
 import { View, StyleSheet } from "react-native";
-import { Trans } from "react-i18next";
-import Icon from "react-native-vector-icons/dist/Feather";
-import { getMainAccount } from "@ledgerhq/live-common/lib/account";
+import { Trans, useTranslation } from "react-i18next";
+import {
+  getAccountCurrency,
+  getMainAccount,
+} from "@ledgerhq/live-common/lib/account";
 import {
   getAccountContractExplorer,
   getDefaultExplorerView,
 } from "@ledgerhq/live-common/lib/explorers";
 import { createStructuredSelector } from "reselect";
-import { useTheme } from "@react-navigation/native";
-import BottomModal from "../../../components/BottomModal";
+import { BottomDrawer } from "@ledgerhq/native-ui";
 import LText from "../../../components/LText";
-import CurrencyIcon from "../../../components/CurrencyIcon";
-import BanIcon from "../../../icons/Ban";
-import Touchable from "../../../components/Touchable";
 import { blacklistToken } from "../../../actions/settings";
 import TokenContractAddress from "../../Account/TokenContractAddress";
 import Button from "../../../components/Button";
 import { parentAccountSelector } from "../../../reducers/accounts";
+import ParentCurrencyIcon from "../../../components/ParentCurrencyIcon";
+import BottomModalChoice from "../../../components/BottomModalChoice";
 
 const mapDispatchToProps = {
   blacklistToken,
@@ -52,7 +52,7 @@ const TokenContextualModal = ({
   parentAccount,
   blacklistToken,
 }: Props) => {
-  const { colors } = useTheme();
+  const { t } = useTranslation();
 
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showContract, setShowContract] = useState(false);
@@ -81,20 +81,22 @@ const TokenContextualModal = ({
     : null;
 
   return (
-    <BottomModal
+    <BottomDrawer
       id="ContractAddress"
-      isOpened={isOpened}
+      isOpen={isOpened}
       preventBackdropClick={false}
+      Icon={
+        showingContextMenu && (
+          <ParentCurrencyIcon
+            size={48}
+            currency={getAccountCurrency(account)}
+          />
+        )
+      }
+      title={showingContextMenu && account.token.name}
       onClose={onCloseModal}
     >
-      {showingContextMenu ? (
-        <View style={[styles.header, { borderColor: colors.fog }]}>
-          <View style={{ marginRight: 12 }}>
-            <CurrencyIcon currency={account.token} size={24} />
-          </View>
-          <LText>{account.token.name}</LText>
-        </View>
-      ) : showConfirmation ? (
+      {!showingContextMenu && showConfirmation ? (
         <LText secondary semiBold style={styles.confirmationHeader}>
           <Trans i18nKey="settings.accounts.blacklistedTokensModal.title" />
         </LText>
@@ -140,37 +142,21 @@ const TokenContextualModal = ({
         </View>
       ) : (
         <>
-          <Touchable
-            hitSlop={hitSlop}
+          <BottomModalChoice
+            title={t("settings.accounts.hideTokenCTA")}
             onPress={() => setShowConfirmation(true)}
-            style={styles.item}
-            event="blacklistToken"
-          >
-            <View style={{ marginRight: 8 }}>
-              <BanIcon size={18} color={colors.smoke} />
-            </View>
-            <LText semiBold>
-              <Trans i18nKey="settings.accounts.hideTokenCTA" />
-            </LText>
-          </Touchable>
+            iconName="EyeNone"
+          />
           {url && (
-            <Touchable
-              hitSlop={hitSlop}
+            <BottomModalChoice
+              title={t("settings.accounts.showContractCTA")}
               onPress={() => setShowContract(true)}
-              style={styles.item}
-              event="blacklistToken"
-            >
-              <View style={{ marginRight: 8 }}>
-                <Icon name="file-text" size={18} color={colors.smoke} />
-              </View>
-              <LText semiBold>
-                <Trans i18nKey="settings.accounts.showContractCTA" />
-              </LText>
-            </Touchable>
+              iconName="News"
+            />
           )}
         </>
       )}
-    </BottomModal>
+    </BottomDrawer>
   );
 };
 
@@ -230,6 +216,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
   },
   body: {
-    padding: 16,
+    paddingHorizontal: 16,
   },
 });

--- a/src/screens/Settings/Accounts/TokenContextualModal.js
+++ b/src/screens/Settings/Accounts/TokenContextualModal.js
@@ -26,13 +26,6 @@ const mapDispatchToProps = {
   blacklistToken,
 };
 
-const hitSlop = {
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-};
-
 type OwnProps = {
   isOpened: boolean,
   onClose: () => void,


### PR DESCRIPTION
Token contextual modal (subaccount settings) rebranding

![Screenshot_20220429-192218_LL  DEV](https://user-images.githubusercontent.com/89014981/165993398-67016ffc-e0e7-4270-8430-748a99760b17.jpg)


### Type

UI Polish

### Context

https://ledgerhq.atlassian.net/browse/LIVE-2035

### Parts of the app affected / Test plan

Account / Token account page