### PR TITLE
LIVE-2214 - Disable uppercase when displaying an address in DeviceAction

### DIFF
--- a/src/components/DeviceAction/rendering.tsx
+++ b/src/components/DeviceAction/rendering.tsx
@@ -67,9 +67,19 @@ const TitleContainer = styled(Flex).attrs({
   py: 8,
 })``;
 
-const TitleText = ({ children }: { children: React.ReactNode }) => (
+const TitleText = ({
+  children,
+  disableUppercase,
+}: {
+  children: React.ReactNode;
+  disableUppercase?: boolean;
+}) => (
   <TitleContainer>
-    <Log>{children}</Log>
+    <Log
+      extraTextProps={disableUppercase ? { textTransform: "none" } : undefined}
+    >
+      {children}
+    </Log>
   </TitleContainer>
 );
 
@@ -187,7 +197,7 @@ export function renderVerifyAddress({
             onPress={onPress}
           />
         )}
-        {address && <TitleText>{address}</TitleText>}
+        {address && <TitleText disableUppercase>{address}</TitleText>}
       </ActionContainer>
     </Wrapper>
   );


### PR DESCRIPTION
In buy flow (an possibly in other flows), the user has to check that the address displayed on device matches the one displayed in-app. The issue is that in the app it's written with uppercase.

With this fix we remove the "uppercase" text transformation that was applied in the component displaying the address, so the address will be displayed with its original casing.

#### Before

<img src="https://user-images.githubusercontent.com/91890529/166228415-d26a1107-d0be-41f7-951e-52c905d7d1e3.png" height="500px" />

#### After

<img src="https://user-images.githubusercontent.com/91890529/166228389-65ced953-0c97-40dc-8199-c36fb5132651.png" height="500px" />

### Type

Bug fix

### Context

[LIVE-2214]

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LIVE-2214]: https://ledgerhq.atlassian.net/browse/LIVE-2214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ