### PR TITLE
Add polygon and BSC to supported chains for WalletConnect

### DIFF
--- a/src/screens/Account/hooks/useActions.tsx
+++ b/src/screens/Account/hooks/useActions.tsx
@@ -14,9 +14,7 @@ import { NavigatorName, ScreenName } from "../../../const";
 import { readOnlyModeEnabledSelector } from "../../../reducers/settings";
 import perFamilyAccountActions from "../../../generated/accountActions";
 import { isCurrencySupported } from "../../Exchange/coinifyConfig";
-import Lending from "../../../icons/Lending";
 import WalletConnect from "../../../icons/WalletConnect";
-import useCompoundAccountEnabled from "../../Lending/shared/useCompoundAccountEnabled";
 
 type Props = {
   account: AccountLike;
@@ -39,9 +37,6 @@ export default function useActions({ account, parentAccount, colors }: Props) {
   );
 
   const accountId = account.id;
-
-  // @ts-expect-error issue in typing
-  const availableOnCompound = useCompoundAccountEnabled(account, parentAccount);
 
   const canBeSold = isCurrencySupported(currency, "sell");
 

--- a/src/screens/Account/hooks/useActions.tsx
+++ b/src/screens/Account/hooks/useActions.tsx
@@ -34,6 +34,9 @@ export default function useActions({ account, parentAccount, colors }: Props) {
   const decorators = perFamilyAccountActions[mainAccount?.currency?.family];
 
   const isEthereum = currency.id === "ethereum";
+  const isWalletConnectSupported = ["ethereum", "bsc", "polygon"].includes(
+    currency.id,
+  );
 
   const accountId = account.id;
 
@@ -123,7 +126,7 @@ export default function useActions({ account, parentAccount, colors }: Props) {
           },
         ]
       : []),
-    ...(isEthereum
+    ...(isWalletConnectSupported
       ? [
           {
             navigationParams: [

--- a/src/screens/WalletConnect/DeeplinkingSelectAccount.js
+++ b/src/screens/WalletConnect/DeeplinkingSelectAccount.js
@@ -123,7 +123,9 @@ class SendFundsSelectAccount extends Component<Props, State> {
               list={allAccounts.filter(
                 account =>
                   account.type === "Account" &&
-                  getAccountCurrency(account).id === "ethereum",
+                  ["ethereum", "bsc", "polygon"].includes(
+                    getAccountCurrency(account).id,
+                  ),
               )}
               inputWrapperStyle={styles.padding}
               renderList={this.renderList}


### PR DESCRIPTION
reopening this PR https://github.com/LedgerHQ/ledger-live-mobile/pull/2443 from a correctly named branch 
___

Add polygon and BSC to supported chains for WalletConnect instead of just Ethereum

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LIVE-2004

### Parts of the app affected / Test plan

Can be tested with this [URL](https://dappradar.com/hub/token/bsc/CAKE?from=0x0e09fabb73bd3ade0a17ecc321fd13a19e81ce82)

Account page -> walletconnect
Deeplink -> walletconnect