### PR TITLE
Upgrade @ledgerhq/native-ui to 0.7.16, addressing LIVE-1981

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@ledgerhq/hw-transport-http": "6.27.0",
     "@ledgerhq/live-common": "22.0.2",
     "@ledgerhq/logs": "6.10.0",
-    "@ledgerhq/native-ui": "^0.7.14",
+    "@ledgerhq/native-ui": "^0.7.16",
     "@ledgerhq/react-native-hid": "6.24.1",
     "@ledgerhq/react-native-hw-transport-ble": "6.25.1",
     "@ledgerhq/react-native-passcode-auth": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,10 +2708,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.50.0.tgz#29c6419e8379d496ab6d0426eadf3c4d100cd186"
   integrity sha512-swKHYCOZUGyVt4ge0u8a7AwNcA//h4nx5wIi0sruGye1IJ5Cva0GyK9L2/WdX+kWVTKp92ZiEo1df31lrWGPgA==
 
-"@ledgerhq/native-ui@^0.7.14":
-  version "0.7.14"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/native-ui/-/native-ui-0.7.14.tgz#5c86f460612d75c655d522164ec34b2f0bc04e0d"
-  integrity sha512-c13cg+0Yr3mDiD7HtzpQjTEFWqtq4GWnA5LC2732PMJwRxPiK+1sqiI4e1bnkVz9yBbrmOIT3T7v/17WEWMDZQ==
+"@ledgerhq/native-ui@^0.7.16":
+  version "0.7.16"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/native-ui/-/native-ui-0.7.16.tgz#ed3a5240a5a94c8db5fea533cd58f9351cb99ca3"
+  integrity sha512-4MIo1h5w14fq49uAWocTtJfWZ7dkhNvupcatmjyfkYGfJMn0MSDoZBQS+HZpJGJVG68QEZSsjcUD2e8pK3/K9Q==
   dependencies:
     "@ledgerhq/icons-ui" "^0.2.4"
     "@ledgerhq/ui-shared" "^0.1.6"


### PR DESCRIPTION
No breaking changes in that upgrade.

Adding external link icon next to notification link
![Screenshot_20220503-125859_LL  DEV](https://user-images.githubusercontent.com/89014981/166441803-d46f4dc4-af23-45a8-a31c-b934949226f1.jpg)


### Type

Dependency upgrade

### Context

[LIVE-1981]

### Parts of the app affected / Test plan

Notifications screen


[LIVE-1981]: https://ledgerhq.atlassian.net/browse/LIVE-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ