### PR TITLE
LL-2228 - Qr code scan screen - UI Fix

### DIFF
--- a/src/components/CameraScreen/QRCodeBottomLayer.tsx
+++ b/src/components/CameraScreen/QRCodeBottomLayer.tsx
@@ -2,7 +2,7 @@ import React, { memo } from "react";
 import { StyleSheet } from "react-native";
 import { Trans } from "react-i18next";
 
-import { Flex, Text, ProgressBar, Alert } from "@ledgerhq/native-ui";
+import { Flex, Text, ProgressBar } from "@ledgerhq/native-ui";
 import { rgba } from "../../colors";
 
 import { softMenuBarHeight } from "../../logic/getWindowDimensions";
@@ -52,18 +52,6 @@ function QrCodeBottomLayer({ progress, liveQrCode, instruction }: Props) {
           </Flex>
         )}
         <Flex flex={1} />
-        {liveQrCode ? (
-          <Alert type="info">
-            <Flex>
-              <Text fontWeight="semiBold" variant="body">
-                <Trans i18nKey="account.import.scan.descTop.line1" />
-              </Text>
-              <Text fontWeight="bold" variant="body">
-                <Trans i18nKey="account.import.scan.descTop.line2" />
-              </Text>
-            </Flex>
-          </Alert>
-        ) : null}
       </Flex>
     </Flex>
   );

--- a/src/components/CameraScreen/QRCodeTopLayer.tsx
+++ b/src/components/CameraScreen/QRCodeTopLayer.tsx
@@ -1,3 +1,26 @@
-const QRCodeTopLayer = () => null;
+import { Alert, Flex, Text } from "@ledgerhq/native-ui";
+import { Trans } from "react-i18next";
+import React from "react";
+
+type Props = {
+  liveQrCode?: boolean;
+};
+
+const QRCodeTopLayer = ({ liveQrCode }: Props) => (
+  <Flex flex={1} alignItems="center" py={8} px={6}>
+    {liveQrCode ? (
+      <Alert type="info">
+        <Flex>
+          <Text fontWeight="semiBold" variant="body">
+            <Trans i18nKey="account.import.scan.descTop.line1" />
+          </Text>
+          <Text fontWeight="bold" variant="body">
+            <Trans i18nKey="account.import.scan.descTop.line2" />
+          </Text>
+        </Flex>
+      </Alert>
+    ) : null}
+  </Flex>
+);
 
 export default QRCodeTopLayer;

--- a/src/components/CameraScreen/index.js
+++ b/src/components/CameraScreen/index.js
@@ -39,7 +39,7 @@ export default function CameraScreen({
           styles.topCell,
         ]}
       >
-        {typeof progress === "number" ? <QRCodeTopLayer /> : null}
+        <QRCodeTopLayer liveQrCode={liveQrCode} />
       </View>
       <QRCodeRectangleViewport viewFinderSize={viewFinderSize} />
       <QRCodeBottomLayer


### PR DESCRIPTION
Qr code scan screen - Move alert to top layer so the ui doesn't overflow anymore

Before : 

![image](https://user-images.githubusercontent.com/89014981/166508968-0c9f7d2c-14a4-4925-a05e-d68b8870a9cc.png)

After :

![Screenshot_20220503-193401_LL  DEV](https://user-images.githubusercontent.com/89014981/166509002-3050ca38-459a-4397-b575-00f20ee330cc.jpg)


<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix

### Context

https://ledgerhq.atlassian.net/browse/LIVE-2228

### Parts of the app affected / Test plan

Import account -> QR Code scan