### PR TITLE
LIVE-2111: Fix wallet recommended section carousel v2 to v3 migration

### DIFF
--- a/src/components/Carousel/index.tsx
+++ b/src/components/Carousel/index.tsx
@@ -25,8 +25,6 @@ const hitSlop = {
   bottom: 16,
 };
 
-export const CAROUSEL_NONCE: number = 4;
-
 type CarouselCardProps = {
   id: string;
   children: React.ReactNode;

--- a/src/components/Carousel/shared.tsx
+++ b/src/components/Carousel/shared.tsx
@@ -198,5 +198,3 @@ export const getDefaultSlides = () =>
     id: slide.name,
     Component: () => <Slide width={WIDTH} {...slide} />,
   }));
-
-export const CAROUSEL_NONCE: number = 6;

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -83,7 +83,7 @@ export type SettingsState = {
   hasAvailableUpdate: boolean,
   theme: Theme,
   osTheme: ?string,
-  carouselVisibility: any,
+  carouselVisibility: number | { [slideName: string]: boolean }, // number is the legacy type from LLM V2
   discreetMode: boolean,
   language: string,
   languageIsSetByUser: boolean,
@@ -511,8 +511,18 @@ export const dismissedBannersSelector = (state: State) =>
 export const hasAvailableUpdateSelector = (state: State) =>
   state.settings.hasAvailableUpdate;
 
-export const carouselVisibilitySelector = (state: State) =>
-  state.settings.carouselVisibility;
+export const carouselVisibilitySelector = (state: State) => {
+  const settingValue = state.settings.carouselVisibility;
+  if (typeof settingValue === "number") {
+    /**
+     * Ensure correct behavior when using the legacy setting value from LLM v2:
+     * We show all the slides as they are different from the ones in V2.
+     * Users will then be able to hide them one by one if they want.
+     */
+    return Object.fromEntries(SLIDES.map(slide => [slide.name, true]));
+  }
+  return settingValue;
+};
 
 export const discreetModeSelector = (state: State): boolean =>
   state.settings.discreetMode === true;

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -120,6 +120,7 @@ export const INITIAL_STATE: SettingsState = {
   hasAvailableUpdate: false,
   theme: "system",
   osTheme: undefined,
+  // $FlowFixMe
   carouselVisibility: Object.fromEntries(
     SLIDES.map(slide => [slide.name, true]),
   ),
@@ -519,6 +520,7 @@ export const carouselVisibilitySelector = (state: State) => {
      * We show all the slides as they are different from the ones in V2.
      * Users will then be able to hide them one by one if they want.
      */
+    // $FlowFixMe
     return Object.fromEntries(SLIDES.map(slide => [slide.name, true]));
   }
   return settingValue;


### PR DESCRIPTION
#### Before:

The recommended section is missing from the Wallet page when updating the app from v2 to v3.

> https://user-images.githubusercontent.com/91890529/166658304-5fc5a713-a2fa-45ae-b7b2-189293984bd3.mp4

#### After:

The recommended section is displayed when updating the app from v2 to v3.

> https://user-images.githubusercontent.com/91890529/166658269-e1928840-4e10-4855-b89e-3693e342709a.mp4

### Type

Bug fix

### Context

[LIVE-2111]

### Parts of the app affected / Test plan

"Wallet" screen -> "Recommended" section (carousel with cards)

Install v2, go through the onboarding, then install v3 and check that the "Recommended" section is here.




[LIVE-2111]: https://ledgerhq.atlassian.net/browse/LIVE-2111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ