### PR TITLE
LL-2227 - Fix - Operation details - Fix navigation with account page

### DIFF
--- a/src/screens/OperationDetails/Content.js
+++ b/src/screens/OperationDetails/Content.js
@@ -84,9 +84,6 @@ export default function Content({
   const onPress = useCallback(() => {
     navigation.navigate(NavigatorName.Accounts, {
       screen: ScreenName.Account,
-      initial: false,
-      // Set to false so it still adds `Accounts` as the previous route in the stack history
-      // even if you're targeting another navigation stack from your current one
       params: {
         accountId: account.id,
         parentId: parentAccount?.id,


### PR DESCRIPTION
After navigating to the operation's account page, when clicking "back" button you should go back to operation and not go to Accounts page

<!-- Description of what the PR does go here... screenshot might be good if appropriate -->

### Type

Bug fix 

### Context

https://ledgerhq.atlassian.net/browse/LIVE-2227

### Parts of the app affected / Test plan

Operation details