### PR TITLE
LL-2041 - Feature: Persist all market page settings in store

### DIFF
--- a/src/actions/settings.js
+++ b/src/actions/settings.js
@@ -6,6 +6,7 @@ import type { Currency } from "@ledgerhq/live-common/lib/types";
 import type { DeviceModelInfo } from "@ledgerhq/live-common/lib/types/manager";
 import type { Device } from "@ledgerhq/live-common/lib/hw/actions/types";
 import type { PortfolioRange } from "@ledgerhq/live-common/lib/portfolio/v2/types";
+import { MarketListRequestParams } from "@ledgerhq/live-common/lib/market/types";
 import { selectedTimeRangeSelector } from "../reducers/settings";
 
 export type CurrencySettings = {
@@ -207,6 +208,23 @@ export const removeStarredMarketCoins = (payload: string) => ({
 export const setLastConnectedDevice = (device: Device) => ({
   type: "SET_LAST_CONNECTED_DEVICE",
   payload: device,
+});
+
+export const setMarketRequestParams = (
+  marketRequestParams: MarketListRequestParams,
+) => ({
+  type: "SET_MARKET_REQUEST_PARAMS",
+  payload: marketRequestParams,
+});
+
+export const setMarketCounterCurrency = (currency: string) => ({
+  type: "SET_MARKET_COUNTER_CURRENCY",
+  payload: currency,
+});
+
+export const setMarketFilterByStarredAccounts = (payload: boolean) => ({
+  type: "SET_MARKET_FILTER_BY_STARRED_ACCOUNTS",
+  payload,
 });
 
 type PortfolioRangeOption = {

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -140,12 +140,13 @@ export const INITIAL_STATE: SettingsState = {
   lastSeenDevice: null,
   starredMarketCoins: [],
   lastConnectedDevice: null,
-  marketParams: {
+  marketRequestParams: {
     range: "24h",
     orderBy: "market_cap",
     order: "desc",
     liveCompatible: false,
     sparkline: false,
+    top100: false,
   },
   marketCounterCurrency: null,
   marketFilterByStarredAccounts: false,

--- a/src/reducers/settings.js
+++ b/src/reducers/settings.js
@@ -20,6 +20,7 @@ import { getAccountCurrency } from "@ledgerhq/live-common/lib/account/helpers";
 import Config from "react-native-config";
 import type { PortfolioRange } from "@ledgerhq/live-common/lib/portfolio/v2/types";
 import type { DeviceModelInfo } from "@ledgerhq/live-common/lib/types/manager";
+import { MarketListRequestParams } from "@ledgerhq/live-common/lib/market/types";
 import { currencySettingsDefaults } from "../helpers/CurrencySettingsDefaults";
 import type { State } from ".";
 import { SLIDES } from "../components/Carousel/shared";
@@ -97,6 +98,9 @@ export type SettingsState = {
   lastSeenDevice: ?DeviceModelInfo,
   starredMarketCoins: string[],
   lastConnectedDevice: ?Device,
+  marketRequestParams: MarketListRequestParams,
+  marketCounterCurrency: ?string,
+  marketFilterByStarredAccounts: boolean,
 };
 
 export const INITIAL_STATE: SettingsState = {
@@ -136,6 +140,15 @@ export const INITIAL_STATE: SettingsState = {
   lastSeenDevice: null,
   starredMarketCoins: [],
   lastConnectedDevice: null,
+  marketParams: {
+    range: "24h",
+    orderBy: "market_cap",
+    order: "desc",
+    liveCompatible: false,
+    sparkline: false,
+  },
+  marketCounterCurrency: null,
+  marketFilterByStarredAccounts: false,
 };
 
 const pairHash = (from, to) => `${from.ticker}_${to.ticker}`;
@@ -378,6 +391,24 @@ const handlers: Object = {
     ...state,
     lastConnectedDevice,
   }),
+  SET_MARKET_REQUEST_PARAMS: (state: SettingsState, { payload }) => ({
+    ...state,
+    marketRequestParams: {
+      ...state.marketRequestParams,
+      ...payload,
+    },
+  }),
+  SET_MARKET_COUNTER_CURRENCY: (state: SettingsState, { payload }) => ({
+    ...state,
+    marketCounterCurrency: payload,
+  }),
+  SET_MARKET_FILTER_BY_STARRED_ACCOUNTS: (
+    state: SettingsState,
+    { payload },
+  ) => ({
+    ...state,
+    marketFilterByStarredAccounts: payload,
+  }),
 };
 
 const storeSelector = (state: *): SettingsState => state.settings;
@@ -554,3 +585,12 @@ export const starredMarketCoinsSelector = (state: State) =>
 
 export const lastConnectedDeviceSelector = (state: State) =>
   state.settings.lastConnectedDevice;
+
+export const marketRequestParamsSelector = (state: State) =>
+  state.settings.marketRequestParams;
+
+export const marketCounterCurrencySelector = (state: State) =>
+  state.settings.marketCounterCurrency;
+
+export const marketFilterByStarredAccountsSelector = (state: State) =>
+  state.settings.marketFilterByStarredAccounts;

--- a/src/screens/Market/MarketCurrencySelect.tsx
+++ b/src/screens/Market/MarketCurrencySelect.tsx
@@ -5,8 +5,13 @@ import React, { useCallback, memo, useState, useRef, useEffect } from "react";
 import { Trans, useTranslation } from "react-i18next";
 import { FlatList, TouchableOpacity, Image } from "react-native";
 import styled, { useTheme } from "styled-components/native";
+import { useDispatch } from "react-redux";
 import Search from "../../components/Search";
 import { supportedCountervalues } from "../../reducers/settings";
+import {
+  setMarketCounterCurrency,
+  setMarketRequestParams,
+} from "../../actions/settings";
 
 const RenderEmptyList = ({
   theme,
@@ -53,6 +58,7 @@ const CheckIconContainer = styled(Flex).attrs({
 
 function MarketCurrencySelect({ navigation }: { navigation: any }) {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
   const { colors } = useTheme();
   const {
     counterCurrency,
@@ -78,6 +84,7 @@ function MarketCurrencySelect({ navigation }: { navigation: any }) {
 
   const onSelectCurrency = useCallback(
     (value: string) => {
+      dispatch(setMarketCounterCurrency(value));
       setCounterCurrency(value);
       navigation.goBack();
     },

--- a/src/screens/Market/MarketDataProviderWrapper.tsx
+++ b/src/screens/Market/MarketDataProviderWrapper.tsx
@@ -44,6 +44,15 @@ export default function MarketDataProviderWrapper({
       countervalue={counterCurrency}
       initState={{
         requestParams: {
+          range: "24h",
+          limit: 100,
+          ids: [],
+          orderBy: "market_cap",
+          order: "desc",
+          search: "",
+          liveCompatible: false,
+          sparkline: false,
+          top100: false,
           ...marketRequestParams,
           starred: filterByStarredAccount ? starredMarketCoins : [],
         },

--- a/src/screens/Market/MarketDataProviderWrapper.tsx
+++ b/src/screens/Market/MarketDataProviderWrapper.tsx
@@ -5,7 +5,13 @@ import apiMock from "@ledgerhq/live-common/lib/market/api/api.mock";
 import Config from "react-native-config";
 import { MarketDataProvider } from "@ledgerhq/live-common/lib/market/MarketDataProvider";
 import { useNetInfo } from "@react-native-community/netinfo";
-import { counterValueCurrencySelector } from "../../reducers/settings";
+import {
+  counterValueCurrencySelector,
+  marketCounterCurrencySelector,
+  marketFilterByStarredAccountsSelector,
+  marketRequestParamsSelector,
+  starredMarketCoinsSelector,
+} from "../../reducers/settings";
 
 type Props = {
   children: React.ReactNode;
@@ -15,30 +21,31 @@ export default function MarketDataProviderWrapper({
   children,
 }: Props): ReactElement {
   const counterValueCurrency: any = useSelector(counterValueCurrencySelector);
+  const marketRequestParams: any = useSelector(marketRequestParamsSelector);
+  const marketCounterCurrency: any = useSelector(marketCounterCurrencySelector);
+  const starredMarketCoins: string[] = useSelector(starredMarketCoinsSelector);
+  const filterByStarredAccount: boolean = useSelector(
+    marketFilterByStarredAccountsSelector,
+  );
   const { isConnected } = useNetInfo();
+
+  const counterCurrency = !isConnected
+    ? undefined // without coutervalues service is not initialized with cg data, this forces it to fetch it at least once the network is on
+    : marketCounterCurrency // If there is a stored market counter currency we use it, otherwise we use the setting countervalue currency
+    ? { ticker: marketCounterCurrency }
+    : counterValueCurrency
+    ? // @TODO move this toLowercase check on live-common
+      { ticker: counterValueCurrency.ticker?.toLowerCase() }
+    : counterValueCurrency;
 
   return (
     <MarketDataProvider
       {...(Config.MOCK ? { fetchApi: apiMock } : {})}
-      countervalue={
-        !isConnected
-          ? undefined // without coutervalues service is not initialized with cg data, this forces it to fetch it at least once the network is on
-          : counterValueCurrency
-          // @TODO move this toLowercase check on live-common
-          ? { ticker: counterValueCurrency.ticker.toLowerCase() }
-          : counterValueCurrency
-      }
+      countervalue={counterCurrency}
       initState={{
         requestParams: {
-          range: "24h",
-          limit: 100,
-          ids: [],
-          starred: [],
-          orderBy: "market_cap",
-          order: "desc",
-          search: "",
-          liveCompatible: false,
-          sparkline: false,
+          ...marketRequestParams,
+          starred: filterByStarredAccount ? starredMarketCoins : [],
         },
       }}
     >

--- a/src/screens/Market/index.tsx
+++ b/src/screens/Market/index.tsx
@@ -79,11 +79,12 @@ const BottomSection = ({ navigation }: { navigation: any }) => {
   const filterByStarredAccount: boolean = useSelector(
     marketFilterByStarredAccountsSelector,
   );
-  const firstMount = useRef(false); // To known if this is the first mount of the page
+  const firstMount = useRef(true); // To known if this is the first mount of the page
 
   useEffect(() => {
-    if (!firstMount.current) {
-      firstMount.current = true;
+    if (firstMount.current) {
+      // We don't want to refresh the market data directly on mount, the data is already refreshed with wanted parameters from MarketDataProviderWrapper
+      firstMount.current = false;
       return;
     }
     if (filterByStarredAccount) {

--- a/src/screens/Market/index.tsx
+++ b/src/screens/Market/index.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable import/named */
 /* eslint-disable import/no-unresolved */
 
-import React, { useMemo, useCallback, useState, useEffect } from "react";
+import React, {
+  useMemo,
+  useCallback,
+  useState,
+  useEffect,
+  useRef,
+} from "react";
 import { useTheme } from "styled-components/native";
 import {
   Flex,
@@ -13,7 +19,7 @@ import {
   InfiniteLoader,
   Icons,
 } from "@ledgerhq/native-ui";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { Trans, useTranslation } from "react-i18next";
 import { useMarketData } from "@ledgerhq/live-common/lib/market/MarketDataProvider";
 import { rangeDataTable } from "@ledgerhq/live-common/lib/market/utils/rangeDataTable";
@@ -21,7 +27,11 @@ import { FlatList, RefreshControl, TouchableOpacity } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { MarketListRequestParams } from "@ledgerhq/live-common/lib/market/types";
 import { useRoute } from "@react-navigation/native";
-import { starredMarketCoinsSelector } from "../../reducers/settings";
+import { useNetInfo } from "@react-native-community/netinfo";
+import {
+  marketFilterByStarredAccountsSelector,
+  starredMarketCoinsSelector,
+} from "../../reducers/settings";
 import MarketRowItem from "./MarketRowItem";
 import { useLocale } from "../../context/Locale";
 import SortBadge, { Badge } from "./SortBadge";
@@ -31,7 +41,10 @@ import { track } from "../../analytics";
 import TrackScreen from "../../analytics/TrackScreen";
 import { useProviders } from "../Swap/SwapEntry";
 import Illustration from "../../images/illustration/Illustration";
-import { useNetInfo } from "@react-native-community/netinfo";
+import {
+  setMarketFilterByStarredAccounts,
+  setMarketRequestParams,
+} from "../../actions/settings";
 
 const noResultIllustration = {
   dark: require("../../images/illustration/Dark/_051.png"),
@@ -59,31 +72,38 @@ function getAnalyticsProperties(
 
 const BottomSection = ({ navigation }: { navigation: any }) => {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
   const { requestParams, counterCurrency, refresh } = useMarketData();
-  const { range, starred = [], orderBy, order, top100 } = requestParams;
+  const { range, orderBy, order, top100 } = requestParams;
   const starredMarketCoins: string[] = useSelector(starredMarketCoinsSelector);
-  const starFilterOn = starred.length > 0;
+  const filterByStarredAccount: boolean = useSelector(
+    marketFilterByStarredAccountsSelector,
+  );
+  const firstMount = useRef(false); // To known if this is the first mount of the page
 
   useEffect(() => {
-    if (starFilterOn) {
-      refresh({ starred: starredMarketCoins });
+    if (!firstMount.current) {
+      firstMount.current = true;
+      return;
     }
-  }, [refresh, starFilterOn, starredMarketCoins]);
+    if (filterByStarredAccount) {
+      refresh({ starred: starredMarketCoins });
+    } else {
+      refresh({ starred: [], search: "" });
+    }
+  }, [refresh, filterByStarredAccount, starredMarketCoins]);
 
   const toggleFilterByStarredAccounts = useCallback(() => {
-    if (starredMarketCoins.length > 0) {
-      const starred = starFilterOn ? [] : starredMarketCoins;
-      if (!starFilterOn) {
-        track(
-          "Page Market Favourites",
-          getAnalyticsProperties(requestParams, {
-            currencies: starredMarketCoins,
-          }),
-        );
-      }
-      refresh({ starred, search: "" });
+    if (!filterByStarredAccount) {
+      track(
+        "Page Market Favourites",
+        getAnalyticsProperties(requestParams, {
+          currencies: starredMarketCoins,
+        }),
+      );
     }
-  }, [refresh, starFilterOn, starredMarketCoins, requestParams]);
+    dispatch(setMarketFilterByStarredAccounts(!filterByStarredAccount));
+  }, [dispatch, filterByStarredAccount]);
 
   const timeRanges = useMemo(
     () =>
@@ -108,9 +128,10 @@ const BottomSection = ({ navigation }: { navigation: any }) => {
         "Page Market",
         getAnalyticsProperties({ ...requestParams, ...value }),
       );
+      dispatch(setMarketRequestParams(value));
       refresh(value);
     },
-    [refresh, requestParams],
+    [dispatch, refresh, requestParams],
   );
 
   const timeRangeValue = timeRanges.find(({ value }) => value === range);
@@ -126,11 +147,11 @@ const BottomSection = ({ navigation }: { navigation: any }) => {
       showsHorizontalScrollIndicator={false}
     >
       <TrackScreen category="Page" name={"Market"} access={true} />
-      {starredMarketCoins.length <= 0 && !starFilterOn ? null : (
+      {starredMarketCoins.length <= 0 && !filterByStarredAccount ? null : (
         <TouchableOpacity onPress={toggleFilterByStarredAccounts}>
           <Badge>
             <Icon
-              name={starFilterOn ? "StarSolid" : "Star"}
+              name={filterByStarredAccount ? "StarSolid" : "Star"}
               color="neutral.c100"
             />
           </Badge>
@@ -173,7 +194,7 @@ const BottomSection = ({ navigation }: { navigation: any }) => {
               order: "asc",
               orderBy: "market_cap",
               top100: false,
-              limit: 20
+              limit: 20,
             },
             value: "market_cap_asc",
           },
@@ -183,7 +204,7 @@ const BottomSection = ({ navigation }: { navigation: any }) => {
               order: "desc",
               orderBy: "market_cap",
               top100: false,
-              limit: 20
+              limit: 20,
             },
             value: "market_cap_desc",
           },
@@ -282,7 +303,7 @@ export default function Market({ navigation }: { navigation: any }) {
   );
 
   useEffect(() => {
-    if (!isConnected) setIsLoading(false); 
+    if (!isConnected) setIsLoading(false);
   }, [isConnected]);
 
   useEffect(() => {
@@ -335,61 +356,63 @@ export default function Market({ navigation }: { navigation: any }) {
 
   const renderEmptyComponent = useCallback(
     () =>
-        search ? ( // shows up in case of no search results
-          <Flex
-            flex={1}
-            flexDirection="column"
-            alignItems="stretch"
-            p="4"
-            mt={70}
-          >
-              <Flex alignItems="center">
-                <Illustration
-                  size={164}
-                  lightSource={noResultIllustration.light}
-                  darkSource={noResultIllustration.dark}
-                />
-              </Flex>
-              <Text textAlign="center" variant="h4" my={3}>
-                {t("market.warnings.noCryptosFound")}
-              </Text>
-              <Text textAlign="center" variant="body" color="neutral.c70">
-                <Trans
-                  i18nKey="market.warnings.noSearchResultsFor"
-                  values={{ search }}
-                >
-                  <Text fontWeight="bold" variant="body" color="neutral.c70">
-                    {""}
-                  </Text>
-                </Trans>
-              </Text>
-              <Button mt={8} onPress={resetSearch} type="main">
-                {t("market.warnings.browseAssets")}
-              </Button>
-            </Flex>
-          ) : !isConnected ? ( // shows up in case of network down
-            <Flex
-              flex={1}
-              flexDirection="column"
-              alignItems="stretch"
-              p="4"
-              mt={70}
-            >
-              <Flex alignItems="center">
-                <Illustration
-                  size={164}
-                  lightSource={noNetworkIllustration.light}
-                  darkSource={noNetworkIllustration.dark}
-                />
-              </Flex>
-              <Text textAlign="center" variant="h4" my={3}>
-                {t("errors.NetworkDown.title")}
-              </Text>
-              <Text textAlign="center" variant="body" color="neutral.c70">
-                  {t("errors.NetworkDown.description")}
-              </Text>
+      search ? ( // shows up in case of no search results
+        <Flex
+          flex={1}
+          flexDirection="column"
+          alignItems="stretch"
+          p="4"
+          mt={70}
+        >
+          <Flex alignItems="center">
+            <Illustration
+              size={164}
+              lightSource={noResultIllustration.light}
+              darkSource={noResultIllustration.dark}
+            />
           </Flex>
-      ): <InfiniteLoader size={30} />, // shows up in case loading is ongoing
+          <Text textAlign="center" variant="h4" my={3}>
+            {t("market.warnings.noCryptosFound")}
+          </Text>
+          <Text textAlign="center" variant="body" color="neutral.c70">
+            <Trans
+              i18nKey="market.warnings.noSearchResultsFor"
+              values={{ search }}
+            >
+              <Text fontWeight="bold" variant="body" color="neutral.c70">
+                {""}
+              </Text>
+            </Trans>
+          </Text>
+          <Button mt={8} onPress={resetSearch} type="main">
+            {t("market.warnings.browseAssets")}
+          </Button>
+        </Flex>
+      ) : !isConnected ? ( // shows up in case of network down
+        <Flex
+          flex={1}
+          flexDirection="column"
+          alignItems="stretch"
+          p="4"
+          mt={70}
+        >
+          <Flex alignItems="center">
+            <Illustration
+              size={164}
+              lightSource={noNetworkIllustration.light}
+              darkSource={noNetworkIllustration.dark}
+            />
+          </Flex>
+          <Text textAlign="center" variant="h4" my={3}>
+            {t("errors.NetworkDown.title")}
+          </Text>
+          <Text textAlign="center" variant="body" color="neutral.c70">
+            {t("errors.NetworkDown.description")}
+          </Text>
+        </Flex>
+      ) : (
+        <InfiniteLoader size={30} />
+      ), // shows up in case loading is ongoing
     [error, isLoading, resetSearch, search, t],
   );
 


### PR DESCRIPTION
https://user-images.githubusercontent.com/89014981/167152126-ce450cfd-394e-4767-8727-22ac4342a36a.mp4


Store all the parameters (sort, time, currency, show favorite) in the store so nothing change when you open again the market page even after restarting the app.

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LIVE-2041

### Parts of the app affected / Test plan

Market page