### PR TITLE
[LIVE-2153] Settings currency list containing currencies that have no settings

### DIFF
--- a/src/screens/Settings/CryptoAssets/Currencies/CurrenciesList.tsx
+++ b/src/screens/Settings/CryptoAssets/Currencies/CurrenciesList.tsx
@@ -1,39 +1,49 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useMemo } from "react";
 import { StyleSheet, FlatList } from "react-native";
 import { connect } from "react-redux";
 import { createStructuredSelector } from "reselect";
-import type { CryptoCurrency } from "@ledgerhq/live-common/lib/types";
+import { CryptoCurrency } from "@ledgerhq/live-common/lib/types";
 import { Box, Text } from "@ledgerhq/native-ui";
 import { ScreenName } from "../../../../const";
 import { cryptoCurrenciesSelector } from "../../../../reducers/accounts";
 import SettingsRow from "../../../../components/SettingsRow";
 import CurrencyIcon from "../../../../components/CurrencyIcon";
+import { getCurrencyHasSettings } from "./CurrencySettings";
 
 type Props = {
-  navigation: any,
-  currencies: CryptoCurrency[],
+  navigation: any;
+  currencies: CryptoCurrency[];
 };
 
 const mapStateToProps = createStructuredSelector({
   currencies: cryptoCurrenciesSelector,
 });
 
-
 function CurrenciesList({ navigation, currencies }: Props) {
+  const currenciesWithSetting = useMemo(
+    () => currencies.filter(getCurrencyHasSettings),
+    [currencies],
+  );
+
   const renderItem = useCallback(
     ({ item }: { item: any }) => (
       <SettingsRow
         event="CurrenciesList"
         eventProperties={{ currency: item.id }}
-        title={(
+        title={
           <>
             {item.name}
             {"  "}
-            <Text variant={"body"} fontWeight={"medium"} color={"neutral.c70"} ml={3}>
+            <Text
+              variant={"body"}
+              fontWeight={"medium"}
+              color={"neutral.c70"}
+              ml={3}
+            >
               {item.ticker}
             </Text>
           </>
-        )}
+        }
         iconLeft={<CurrencyIcon size={20} currency={item} />}
         key={item.id}
         onPress={() =>
@@ -46,13 +56,13 @@ function CurrenciesList({ navigation, currencies }: Props) {
     ),
     [navigation],
   );
-  
+
   const keyExtractor = useCallback(item => item.id, []);
 
   return (
-    <Box backgroundColor={'background.main'} height={'100%'}>
+    <Box backgroundColor={"background.main"} height={"100%"}>
       <FlatList
-        data={currencies}
+        data={currenciesWithSetting}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         contentContainerStyle={styles.containerStyle}
@@ -62,7 +72,7 @@ function CurrenciesList({ navigation, currencies }: Props) {
 }
 
 const styles = StyleSheet.create({
-  containerStyle: { paddingTop: 16, paddingBottom: 64, paddingHorizontal: 16, },
+  containerStyle: { paddingTop: 16, paddingBottom: 64, paddingHorizontal: 16 },
 });
 
-export default connect(mapStateToProps)(CurrenciesList)
+export default connect(mapStateToProps)(CurrenciesList);

--- a/src/screens/Settings/CryptoAssets/Currencies/CurrencySettings.tsx
+++ b/src/screens/Settings/CryptoAssets/Currencies/CurrencySettings.tsx
@@ -38,6 +38,9 @@ const mapDispatchToProps = {
   updateCurrencySettings,
 };
 
+export const getCurrencyHasSettings = (currency: CryptoCurrency) =>
+  !!currencySettingsDefaults(currency).confirmationsNb;
+
 function EachCurrencySettings({
   navigation,
   currency,


### PR DESCRIPTION
#### Before:

The list contains currencies that lead to a screen with no settings (in this example Polygon).

> <img src="https://user-images.githubusercontent.com/91890529/167142449-e867a0f7-c0af-4cc7-ad96-b7e5e3a6412e.png" height="500px" />
> <img src="https://user-images.githubusercontent.com/91890529/167142464-d9932f50-7654-4f23-8387-1ede18284bc9.png" height="500px" />

#### After:

The list is filtered to only contain currencies that lead to a screen with some actual settings.

> <img src="https://user-images.githubusercontent.com/91890529/167142568-7a450ca3-3ffd-4fe5-bd6e-796d7d8615d2.png" height="500px" />


### Type

Bug fix

### Context

[LIVE-2153]

### Parts of the app affected / Test plan

Settings > Accounts > Crypto Assets

[LIVE-2153]: https://ledgerhq.atlassian.net/browse/LIVE-2153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ