### PR TITLE
LIVE-2119 Bugfix/graph out of bound issue

### DIFF
--- a/src/components/Graph/index.js
+++ b/src/components/Graph/index.js
@@ -48,8 +48,6 @@ function Graph({
   const minY = mapValue(minBy(data, mapValue));
   const paddedMinY = minY - (maxY - minY) / verticalRangeRatio;
 
-  const yExtractor = d => y(mapValue(d));
-
   const curve = d3shape[shape];
   const x = d3scale
     .scaleTime()
@@ -61,11 +59,15 @@ function Graph({
     .domain([paddedMinY, maxY])
     .range([height - STROKE_WIDTH, STROKE_WIDTH + FOCUS_RADIUS]);
 
+  const yExtractor = d => y(mapValue(d));
+
   const area = d3shape
     .area()
     .x(d => x(d.date))
     .y0(d => yExtractor(d))
-    .y1(d => yExtractor(d) + Math.max((maxY - minY) / verticalRangeRatio, 200))
+    .y1(
+      d => yExtractor(d) + Math.min((maxY - minY) / verticalRangeRatio, height),
+    )
     .curve(curve)(data);
 
   const line = d3shape


### PR DESCRIPTION
<!-- Description of what the PR does go here... screenshot might be good if appropriate -->
Issue in graphs when values could be out of range due to too big of a difference between min and max Y axis values.
d3 lib would then try to create an svg area targeting out of bounds points.
A simple switch in the min value to target for the gradient area clears that
### Type

Bug Fix

### Context

[LIVE-2119]

### Parts of the app affected / Test plan

<!-- Which part of the app is affected? What to do to test it, any special thing to do? -->


[LIVE-2119]: https://ledgerhq.atlassian.net/browse/LIVE-2119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ