### PR TITLE
LIVE-2289 - Fix discreet mode on portfolio history

### DIFF
--- a/src/screens/Portfolio/PortfolioHistory.tsx
+++ b/src/screens/Portfolio/PortfolioHistory.tsx
@@ -25,12 +25,13 @@ import SectionHeader from "../../components/SectionHeader";
 import LoadingFooter from "../../components/LoadingFooter";
 import Button from "../../components/Button";
 import { ScreenName } from "../../const";
+import { withDiscreetMode } from "../../context/DiscreetModeContext";
 
 type Props = {
   navigation: any,
 };
 
-export function PortfolioHistoryList({
+export const PortfolioHistoryList = withDiscreetMode(({
   onEndReached,
   opCount = 5,
   navigation,
@@ -38,7 +39,7 @@ export function PortfolioHistoryList({
   onEndReached?: () => void,
   opCount?: number,
   navigation: any,
-}) {
+}) => {
   const accounts = useSelector(accountsSelector);
   const allAccounts = useSelector(flattenAccountsSelector);
 
@@ -127,7 +128,7 @@ export function PortfolioHistoryList({
       ListEmptyComponent={ListEmptyComponent}
     />
   );
-}
+})
 
 function PortfolioHistory({ navigation }: Props) {
   const [opCount, setOpCount] = useState(50);


### PR DESCRIPTION
Fix discreet mode not applying to the transaction history on the wallet screen.

#### Before
> https://user-images.githubusercontent.com/91890529/167371318-1d9193d5-789c-4374-9af0-e35c4d38554a.mp4

#### After
> https://user-images.githubusercontent.com/91890529/167371462-2fa39cca-9baa-4546-8d91-0bb4fde05096.mp4



### Type

Bug fix

### Context

v3.1 pre-release
[LIVE-2289] 

### Parts of the app affected / Test plan

Wallet screen > Transaction history (at the bottom)


[LIVE-2289]: https://ledgerhq.atlassian.net/browse/LIVE-2289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ